### PR TITLE
Fix rollout-compile grad-norm explosion in colocate by offloading wei…

### DIFF
--- a/arctic_platform/rl/http_server.py
+++ b/arctic_platform/rl/http_server.py
@@ -511,10 +511,15 @@ async def sleep_inference(job_id: int, level: int):
     colocate = app.state.colocate
     results = {}
     pool: ReplicaPool = app.state.sampling_pool
-    results["sampling"] = await pool.sleep(level=level, offload_weights=colocate)
+    # Let vLLM's CuMemAllocator free the weights (offload_weights=False) instead
+    # of the legacy manual offload, which reallocated param.data on each wake and
+    # changed weight addresses -> stale rollout CUDA graphs (compile on) ->
+    # grad-norm explosion. cumem keeps addresses stable.
+    offload_weights = False
+    results["sampling"] = await pool.sleep(level=level, offload_weights=offload_weights)
     lp_pool: ReplicaPool | None = app.state.log_prob_pool
     if lp_pool is not None and lp_pool._config is not None and not lp_pool.sleeping:
-        results["log_prob"] = await lp_pool.sleep(level=level, offload_weights=colocate)
+        results["log_prob"] = await lp_pool.sleep(level=level, offload_weights=offload_weights)
     if colocate:
         await pool.close_weight_sync()
         if lp_pool is not None and lp_pool._config is not None:

--- a/arctic_platform/rl/ray_server.py
+++ b/arctic_platform/rl/ray_server.py
@@ -253,7 +253,11 @@ class ArcticRLRayServerState(ArcticRLServerState):
         colocate = self.colocate
         results = {}
         pool: ReplicaPool = self.sampling_pool
-        offload_weights = colocate
+        # Let vLLM's CuMemAllocator free the weights (offload_weights=False)
+        # instead of the legacy manual offload, which reallocated param.data on
+        # each wake and changed weight addresses -> stale rollout CUDA graphs
+        # (compile on) -> grad-norm explosion. cumem keeps addresses stable.
+        offload_weights = False
         results["sampling"] = await pool.sleep(level=level, offload_weights=offload_weights)
         lp_pool: ReplicaPool | None = self.log_prob_pool
         if lp_pool is not None and lp_pool._config is not None and not lp_pool.sleeping:


### PR DESCRIPTION
# Fix rollout-compile issue that causes grad-norm explosion 

## Summary

In colocate mode the per-step weight offload/backload reallocated `param.data` on every wake, **changing each weight's GPU virtual address**. With rollout compile enabled (`enforce_eager=False`), vLLM's captured CUDA graph keeps reading the *old* addresses, so generation samples from stale/garbage memory. 

Fix: stop the legacy manual offload (`offload_weights=False`) and let vLLM's `CuMemAllocator` free the weights. cumem returns only the physical pages and keeps the virtual address pinned.