### PR TITLE
ray_server: hardcode Arctic Inference / FCA tunables (Mert, draft)

### DIFF
--- a/arctic_platform/rl/ray_server.py
+++ b/arctic_platform/rl/ray_server.py
@@ -378,6 +378,12 @@ class ArcticRLRayServerState(ArcticRLServerState):
             vllm_cfg = dict(job_config.vllm_config or {})
             if colocate:
                 vllm_cfg["enable_sleep_mode"] = True
+            if job_config.use_arctic_inference:
+                # Hardcoded Arctic Inference / FCA tunables. Moved server-side
+                # from arctic-verl `arctic_rl_client.py` (Mert, draft) so that
+                # backends without a verl client get the same defaults.
+                vllm_cfg["compilation_config"] = {"cudagraph_mode": "PIECEWISE"}
+                vllm_cfg["forest_cascade_attn_configs"] = "{}"
             model_cfg = _build_model_config(job_config.model_name, vllm_cfg)
             tp = model_cfg.tensor_parallel_size
             num_replicas = gpus // tp
@@ -447,6 +453,12 @@ class ArcticRLRayServerState(ArcticRLServerState):
                 lp_vllm_cfg = dict(job_config.vllm_config or {})
                 if colocate:
                     lp_vllm_cfg["enable_sleep_mode"] = True
+                if job_config.use_arctic_inference:
+                    # Hardcoded Arctic Inference / FCA tunables. Moved server-side
+                    # from arctic-verl `arctic_rl_client.py` (Mert, draft) so that
+                    # backends without a verl client get the same defaults.
+                    lp_vllm_cfg["compilation_config"] = {"cudagraph_mode": "PIECEWISE"}
+                    lp_vllm_cfg["forest_cascade_attn_configs"] = "{}"
                 model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg)
                 lp_tp = model_cfg.tensor_parallel_size
                 num_replicas = gpus // lp_tp


### PR DESCRIPTION
Draft PR per Mert's Slack note: move the Arctic Inference / FCA tunables that today live in [`arctic-verl/verl/trainer/ppo/arctic_rl_client.py#L194-L209`](https://github.com/snowflake-eng/arctic-verl/blob/tunji/arl_client/verl/trainer/ppo/arctic_rl_client.py#L194-L209) into `arctic_platform/rl/ray_server.py` so the defaults travel with the Arctic-side server, not the verl client.

## What this PR does

Inside both Ray pools that build a vLLM `ModelConfig` (sampling and the vLLM-based log-prob path), inject — when `job_config.use_arctic_inference=True`:

```python
vllm_cfg["compilation_config"] = {"cudagraph_mode": "PIECEWISE"}
vllm_cfg["forest_cascade_attn_configs"] = "{}"
```

Tunables are hardcoded as Mert noted in Slack ("I will include the tuning parameters hardcoded for now"). They can be promoted to `JobConfig` fields in a follow-up if needed.

## What this PR explicitly does NOT do

- The matching deletion in [`arctic-verl/verl/trainer/ppo/arctic_rl_client.py`](https://github.com/snowflake-eng/arctic-verl/blob/tunji/arl_client/verl/trainer/ppo/arctic_rl_client.py#L194-L209) is a separate cross-repo PR. The verl side keeps the existing config-driven `use_fca` / `spec_model` shape until this lands and we coordinate the cutover.
- `spec_model` (the speculative-decoding sibling of `use_fca`) still threads through `job_config.vllm_config["speculative_config"]` from the client and is unchanged here. We can fold it server-side in the same follow-up if it makes sense.

## Test plan

- [x] Lint clean.
- [ ] Functional smoke on Arctic Inference path (FCA enabled): verify `compilation_config={"cudagraph_mode":"PIECEWISE"}` shows up in the vLLM startup log.
- [ ] Negative test (`use_arctic_inference=False`): ensure no FCA keys leak into vLLM config.

cc @MertHidayetoglu @sfc-gh-truwase

Made with [Cursor](https://cursor.com)