### PR TITLE
Integrate Zorro Inference (FCA) and Arctic Speculative Decoding into Arctic Platform

### DIFF
--- a/arctic_platform/rl/config.py
+++ b/arctic_platform/rl/config.py
@@ -54,9 +54,11 @@ class ArcticRLClientConfig(BaseModel):
     ds_worker_config: Optional[dict] = Field(
         default=None, description="Deepspeed worker config dict (optimizer, dtype, etc.)."
     )
-    use_arctic_inference: bool = Field(
-        default=False,
-        description="If True, set ARCTIC_INFERENCE_ENABLED=1 and override VLLM_DISABLE_COMPILE_CACHE=0.",
+    arctic_inference_config: Optional[dict] = Field(
+        default=None,
+        description="Arctic inference signals (e.g. use_fca, spec_model). A non-empty value enables "
+        "Arctic inference (ARCTIC_INFERENCE_ENABLED=1) and is expanded into vLLM engine kwargs "
+        "server-side by ModelConfig.to_engine_kwargs(); None/empty means Arctic inference is off.",
     )
     full_determinism: bool = Field(
         default=False,

--- a/arctic_platform/rl/http_client.py
+++ b/arctic_platform/rl/http_client.py
@@ -255,7 +255,6 @@ class ArcticRLHTTPClient:
         payload: dict[str, Any] = {
             "model_name": self.config.model_name,
             "job_type": job_type,
-            "use_arctic_inference": self.config.use_arctic_inference,
             "full_determinism": self.config.full_determinism,
             "seed": self.config.seed,
         }
@@ -283,6 +282,8 @@ class ArcticRLHTTPClient:
             if job_type == "training":
                 payload["checkpoint_path"] = self.config.checkpoint_path
         else:
+            if self.config.arctic_inference_config:
+                payload["arctic_inference_config"] = self.config.arctic_inference_config
             if self.config.vllm_config:
                 payload["vllm_config"] = self.config.vllm_config
 

--- a/arctic_platform/rl/http_server.py
+++ b/arctic_platform/rl/http_server.py
@@ -102,7 +102,7 @@ class JobConfig(BaseModel):
     ds_worker_config: Optional[dict] = None
     vllm_config: Optional[dict] = None
     checkpoint_path: Optional[str] = None
-    use_arctic_inference: bool = False
+    arctic_inference_config: Optional[dict] = None
     full_determinism: bool = False
     seed: int = 42
 
@@ -118,10 +118,21 @@ class LogProbsRequest(BaseModel):
     top_k: int = 1
 
 
-def _build_model_config(model_name: str, vllm_config: dict | None) -> ModelConfig:
-    """Construct a :class:`ModelConfig` from user-supplied vllm_config dict."""
+def _build_model_config(
+    model_name: str,
+    vllm_config: dict | None,
+    arctic_inference_config: dict | None = None,
+) -> ModelConfig:
+    """Construct a :class:`ModelConfig` from user-supplied vllm_config dict.
+
+    `arctic_inference_config` carries Arctic-platform signals (e.g. use_fca,
+    spec_model) that are not vLLM engine args: they are recorded on the
+    ModelConfig, which expands them into real engine kwargs in
+    `ModelConfig.to_engine_kwargs()`.
+    """
     cfg = dict(vllm_config or {})
     cfg["model"] = model_name
+    cfg.update(arctic_inference_config or {})
     known_fields = set(ModelConfig.model_fields.keys())
     extra = {k: v for k, v in cfg.items() if k not in known_fields}
     base = {k: v for k, v in cfg.items() if k in known_fields}
@@ -226,7 +237,7 @@ async def initialize(job_config: JobConfig = Body(...)):
         vllm_cfg = dict(job_config.vllm_config or {})
         if colocate:
             vllm_cfg["enable_sleep_mode"] = True
-        model_cfg = _build_model_config(job_config.model_name, vllm_cfg)
+        model_cfg = _build_model_config(job_config.model_name, vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
         tp = model_cfg.tensor_parallel_size
         num_replicas = gpus // tp
         if colocate and placement:
@@ -235,8 +246,8 @@ async def initialize(job_config: JobConfig = Body(...)):
             if tp > 1:
                 extra_env["VLLM_RAY_PER_WORKER_GPUS"] = str(_COLOCATE_GPU_FRACTIONS["sampling"])
                 vllm_cfg["distributed_executor_backend"] = "ray"
-                model_cfg = _build_model_config(job_config.model_name, vllm_cfg)
-            if job_config.use_arctic_inference:
+                model_cfg = _build_model_config(job_config.model_name, vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
+            if job_config.arctic_inference_config:
                 extra_env["ARCTIC_INFERENCE_ENABLED"] = "1"
                 # vllm-project/vllm#31199 was fixed in 0.18.0 (vllm-project/vllm#35420);
                 # override the global VLLM_DISABLE_COMPILE_CACHE=1 set in the verl runtime_env.
@@ -293,7 +304,7 @@ async def initialize(job_config: JobConfig = Body(...)):
             lp_vllm_cfg = dict(job_config.vllm_config or {})
             if colocate:
                 lp_vllm_cfg["enable_sleep_mode"] = True
-            model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg)
+            model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
             lp_tp = model_cfg.tensor_parallel_size
             num_replicas = gpus // lp_tp
             if colocate and placement:
@@ -310,8 +321,8 @@ async def initialize(job_config: JobConfig = Body(...)):
                     # need to be set here.
                     lp_extra_env.pop("CUDA_VISIBLE_DEVICES", None)
                     lp_vllm_cfg["distributed_executor_backend"] = "ray"
-                    model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg)
-                if job_config.use_arctic_inference:
+                    model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
+                if job_config.arctic_inference_config:
                     lp_extra_env["ARCTIC_INFERENCE_ENABLED"] = "1"
                     # vllm-project/vllm#31199 was fixed in 0.18.0 (vllm-project/vllm#35420);
                     # override the global VLLM_DISABLE_COMPILE_CACHE=1 set in the verl runtime_env.

--- a/arctic_platform/rl/ray_client.py
+++ b/arctic_platform/rl/ray_client.py
@@ -143,7 +143,6 @@ class ArcticRLRayClient:
         job_config: dict[str, Any] = {
             "model_name": self.config.model_name,
             "job_type": job_type,
-            "use_arctic_inference": self.config.use_arctic_inference,
             "full_determinism": self.config.full_determinism,
             "seed": self.config.seed,
         }
@@ -171,6 +170,8 @@ class ArcticRLRayClient:
             if job_type == "training":
                 job_config["checkpoint_path"] = self.config.checkpoint_path
         else:
+            if self.config.arctic_inference_config:
+                job_config["arctic_inference_config"] = self.config.arctic_inference_config
             if self.config.vllm_config:
                 job_config["vllm_config"] = self.config.vllm_config
 

--- a/arctic_platform/rl/ray_server.py
+++ b/arctic_platform/rl/ray_server.py
@@ -94,7 +94,7 @@ class JobConfig(BaseModel):
     ds_worker_config: Optional[dict] = None
     vllm_config: Optional[dict] = None
     checkpoint_path: Optional[str] = None
-    use_arctic_inference: bool = False
+    arctic_inference_config: Optional[dict] = None
     full_determinism: bool = False
     seed: int = 42
 
@@ -118,10 +118,23 @@ class SyncWeightsRequest(BaseModel):
     low_memory: bool = False
 
 
-def _build_model_config(model_name: str, vllm_config: dict | None) -> ModelConfig:
-    """Construct a :class:`ModelConfig` from user-supplied vllm_config dict."""
+def _build_model_config(
+    model_name: str,
+    vllm_config: dict | None,
+    arctic_inference_config: dict | None = None,
+) -> ModelConfig:
+    """Construct a :class:`ModelConfig` from user-supplied vllm_config dict.
+
+    `arctic_inference_config` carries Arctic-platform signals (e.g. use_fca,
+    spec_model) that are not vLLM engine args: they are recorded on the
+    ModelConfig, which expands them into real engine kwargs in
+    `ModelConfig.to_engine_kwargs()`.
+    """
+
     cfg = dict(vllm_config or {})
     cfg["model"] = model_name
+    cfg.update(arctic_inference_config or {})
+
     known_fields = set(ModelConfig.model_fields.keys())
     extra = {k: v for k, v in cfg.items() if k not in known_fields}
     base = {k: v for k, v in cfg.items() if k in known_fields}
@@ -378,7 +391,7 @@ class ArcticRLRayServerState(ArcticRLServerState):
             vllm_cfg = dict(job_config.vllm_config or {})
             if colocate:
                 vllm_cfg["enable_sleep_mode"] = True
-            model_cfg = _build_model_config(job_config.model_name, vllm_cfg)
+            model_cfg = _build_model_config(job_config.model_name, vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
             tp = model_cfg.tensor_parallel_size
             num_replicas = gpus // tp
             if colocate and placement:
@@ -387,8 +400,8 @@ class ArcticRLRayServerState(ArcticRLServerState):
                 if tp > 1:
                     extra_env["VLLM_RAY_PER_WORKER_GPUS"] = str(_COLOCATE_GPU_FRACTIONS["sampling"])
                     vllm_cfg["distributed_executor_backend"] = "ray"
-                    model_cfg = _build_model_config(job_config.model_name, vllm_cfg)
-                if job_config.use_arctic_inference:
+                    model_cfg = _build_model_config(job_config.model_name, vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
+                if job_config.arctic_inference_config:
                     extra_env["ARCTIC_INFERENCE_ENABLED"] = "1"
                     # vllm-project/vllm#31199 was fixed in 0.18.0 (vllm-project/vllm#35420);
                     # override the global VLLM_DISABLE_COMPILE_CACHE=1 set in the verl runtime_env.
@@ -447,7 +460,7 @@ class ArcticRLRayServerState(ArcticRLServerState):
                 lp_vllm_cfg = dict(job_config.vllm_config or {})
                 if colocate:
                     lp_vllm_cfg["enable_sleep_mode"] = True
-                model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg)
+                model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
                 lp_tp = model_cfg.tensor_parallel_size
                 num_replicas = gpus // lp_tp
                 if colocate and placement:
@@ -464,8 +477,8 @@ class ArcticRLRayServerState(ArcticRLServerState):
                         # need to be set here.
                         lp_extra_env.pop("CUDA_VISIBLE_DEVICES", None)
                         lp_vllm_cfg["distributed_executor_backend"] = "ray"
-                        model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg)
-                    if job_config.use_arctic_inference:
+                        model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
+                    if job_config.arctic_inference_config:
                         lp_extra_env["ARCTIC_INFERENCE_ENABLED"] = "1"
                         # vllm-project/vllm#31199 was fixed in 0.18.0 (vllm-project/vllm#35420);
                         # override the global VLLM_DISABLE_COMPILE_CACHE=1 set in the verl runtime_env.
@@ -690,7 +703,7 @@ class ArcticRLRayServer:
     #         vllm_cfg = dict(job_config.vllm_config or {})
     #         if colocate:
     #             vllm_cfg["enable_sleep_mode"] = True
-    #         model_cfg = _build_model_config(job_config.model_name, vllm_cfg)
+    #         model_cfg = _build_model_config(job_config.model_name, vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
     #         tp = model_cfg.tensor_parallel_size
     #         num_replicas = gpus // tp
     #         if colocate and pg is not None:
@@ -699,7 +712,7 @@ class ArcticRLRayServer:
     #             if tp > 1:
     #                 extra_env["VLLM_RAY_PER_WORKER_GPUS"] = str(_COLOCATE_GPU_FRACTIONS["sampling"])
     #                 vllm_cfg["distributed_executor_backend"] = "ray"
-    #                 model_cfg = _build_model_config(job_config.model_name, vllm_cfg)
+    #                 model_cfg = _build_model_config(job_config.model_name, vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
     #             await pool.initialize(
     #                 model_cfg,
     #                 num_replicas=num_replicas,
@@ -742,7 +755,7 @@ class ArcticRLRayServer:
     #             lp_vllm_cfg = dict(job_config.vllm_config or {})
     #             if colocate:
     #                 lp_vllm_cfg["enable_sleep_mode"] = True
-    #             model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg)
+    #             model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
     #             lp_tp = model_cfg.tensor_parallel_size
     #             num_replicas = gpus // lp_tp
     #             if colocate and pg is not None:
@@ -754,7 +767,7 @@ class ArcticRLRayServer:
     #                     lp_extra_env["VLLM_RAY_BUNDLE_INDICES"] = ",".join(str(b) for b in lp_bundles[:lp_tp])
     #                     lp_extra_env.pop("CUDA_VISIBLE_DEVICES", None)
     #                     lp_vllm_cfg["distributed_executor_backend"] = "ray"
-    #                     model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg)
+    #                     model_cfg = _build_model_config(job_config.model_name, lp_vllm_cfg, arctic_inference_config=job_config.arctic_inference_config)
     #                 await pool.initialize(
     #                     model_cfg,
     #                     num_replicas=num_replicas,


### PR DESCRIPTION
## Summary
- Replace `use_arctic_inference` with a single `arctic_inference_config` dict on `ArcticRLClientConfig` and `JobConfig`.
- A non-empty config enables Arctic inference (`ARCTIC_INFERENCE_ENABLED=1`) and is unpacked onto `ModelConfig` in `_build_model_config`; `None`/empty means Arctic inference is off.
- Clients forward it only for vLLM (sampling/log-prob) jobs.

## Context
Part of a 3-repo change:
- ArcticInference snowflakedb/ArcticInference#263 defines `ModelConfig.use_fca`/`spec_model` and the engine-kwargs translation.
- arctic-verl snowflake-eng/arctic-verl#38 produces the `arctic_inference_config` dict.
