### PR TITLE
speculative decoding and TP=4 for ARL runs

### DIFF
--- a/recipes/rl/verl/long_context_qa/run_qwen3_32b_longcontext_grpo_arl.sh
+++ b/recipes/rl/verl/long_context_qa/run_qwen3_32b_longcontext_grpo_arl.sh
@@ -61,7 +61,7 @@ ARCTIC_ZERO_STAGE=3
 # colocate=True: training + sampling span all NGPU_PER_JOB bundles. log_prob off (no-KL + Zorro recompute).
 NGPU_PER_JOB=$((NGPU_PER_NODE*NNODES))
 NGPU_FOR_LOG_PROBS=0
-TP_SIZE=2                # sampling TP
+TP_SIZE=4                # sampling TP
 
 # ----- Training hyperparams -----
 BSZ=256                  # data.train_batch_size
@@ -199,6 +199,7 @@ python3 -m verl.trainer.main_ppo \
     remote_backend.weight_sync.cuda_ipc=True \
     remote_backend.weight_sync.low_memory=False \
     remote_backend.rollout.zorro_inference.enable=True \
+    remote_backend.rollout.speculative_decoding.model=Snowflake/Arctic-LSTM-Speculator-Qwen3-32B-longcontext \
     remote_backend.train.deepspeed.zero_optimization.offload_optimizer.device=cpu \
     remote_backend.train.deepspeed.zero_optimization.offload_param.device=none \
     remote_backend.train.deepspeed.zero_optimization.stage=$ARCTIC_ZERO_STAGE \

--- a/recipes/rl/verl/txt2sql/run_qwen3_32b_bird_grpo_arl_zorro_yes.sh
+++ b/recipes/rl/verl/txt2sql/run_qwen3_32b_bird_grpo_arl_zorro_yes.sh
@@ -147,7 +147,7 @@ python3 -m verl.trainer.main_ppo \
     custom_reward_function.path="${SCRIPT_DIR}/bird_reward.py" \
     custom_reward_function.name=compute_score \
     remote_backend.colocate=True \
-    remote_backend.sampling_tp_size=2 \
+    remote_backend.sampling_tp_size=4 \
     remote_backend.training_gpus=$NGPU_PER_JOB \
     remote_backend.sampling_gpus=$NGPU_PER_JOB \
     remote_backend.log_prob_gpus=0 \
@@ -155,6 +155,7 @@ python3 -m verl.trainer.main_ppo \
     remote_backend.weight_sync.low_memory=False \
     remote_backend.train.logits.optimization=memory \
     remote_backend.rollout.zorro_inference.enable=True \
+    remote_backend.rollout.speculative_decoding.model=Snowflake/Arctic-LSTM-Speculator-Qwen3-32B-bird \
     remote_backend.train.zorro_train.enable=True \
     remote_backend.train.zorro_train.max_rollouts=16 \
     remote_backend.train.deepspeed.zero_optimization.stage=3 \


### PR DESCRIPTION
1) include speculators for recipes:
- long context: https://huggingface.co/Snowflake/Arctic-LSTM-Speculator-Qwen3-32B-longcontext
- txt2sql: https://huggingface.co/Snowflake/Arctic-LSTM-Speculator-Qwen3-32B-bird
2) set sampling TP=4