### PR TITLE
V1 (verl-project/verl main) plugin shims for the Arctic verl integration

### DIFF
--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -90,6 +90,31 @@ class CortexConfig(BaseModel):
         """The PAT for host/PAT auth: explicit `pat`, else the `pat_env_var` value."""
         return self.pat if self.pat is not None else os.environ.get(self.pat_env_var)
 
+    @classmethod
+    def from_env(cls, **overrides: Any) -> Self:
+        """Build a ``CortexConfig`` from ``ARCTIC_CORTEX_*`` env vars.
+
+        The one call-site framework adapters (SkyRL shim / verl adapter) use to
+        flip to Cortex from a shell-level env, so the env-var contract lives in
+        one place instead of being reinvented per integration. Explicit
+        ``overrides`` win.
+        """
+        env: dict[str, Any] = {}
+        for key, field in (
+            ("base_url", "ARCTIC_CORTEX_BASE_URL"),
+            ("host", "ARCTIC_CORTEX_HOST"),
+            ("pat_env_var", "ARCTIC_CORTEX_PAT_ENV_VAR"),
+            ("database", "ARCTIC_CORTEX_DATABASE"),
+            ("endpoint", "ARCTIC_CORTEX_ENDPOINT"),
+        ):
+            v = os.environ.get(field)
+            if v:
+                env[key] = v
+        schema = os.environ.get("ARCTIC_CORTEX_SCHEMA")
+        if schema:
+            env["schema"] = schema
+        return cls(**{**env, **overrides})
+
     @model_validator(mode="after")
     def _check(self) -> Self:
         if not (self.base_url or self.host):

--- a/arctic_platform/client/transports/cortex.py
+++ b/arctic_platform/client/transports/cortex.py
@@ -368,11 +368,25 @@ class CortexTransport(Transport):
         deadline = time.monotonic() + self.poll_timeout
         delay = self.poll_interval
         while time.monotonic() < deadline:
-            state = _short(self._job().get("status"))
+            job = self._job()
+            state = _short(job.get("status"))
             if state == "running":
                 return
             if state in _JOB_TERMINAL:
-                raise RuntimeError(f"cortex job {self.job_id} reached terminal state '{state}'")
+                # Surface the server-side reason and any per-sub-job status so
+                # callers can distinguish rate limits, allowlist rejections,
+                # capacity exhaustion, and genuine sub-job crashes.
+                reason = job.get("reason") or "(no reason)"
+                sub_states = ", ".join(
+                    f"{_short(sj.get('job_type', ''), 'job_type_')}={_short(sj.get('status'))}"
+                    for sj in (job.get("sub_jobs") or [])
+                )
+                detail = f" reason={reason!r}"
+                if sub_states:
+                    detail += f" sub_jobs=[{sub_states}]"
+                raise RuntimeError(
+                    f"cortex job {self.job_id} reached terminal state '{state}';{detail}"
+                )
             time.sleep(delay)
             delay = _next_delay(delay)
         raise TimeoutError(f"cortex job {self.job_id} did not become running within {self.poll_timeout}s")

--- a/arctic_platform/client/transports/cortex.py
+++ b/arctic_platform/client/transports/cortex.py
@@ -64,6 +64,11 @@ _OCTET_HEADERS = {"Content-Type": "application/octet-stream"}
 # forward-backward carries the large gradient frame; a mid-stream chunk-group
 # desync (GS restart) is recoverable only by re-posting the whole group.
 _GROUP_RESTART_OPS = {"forward-backward"}
+# Cortex sub-jobs are always awake; the client's colocated wake/sleep lifecycle
+# is a no-op here. Short-circuiting in the transport means the shim doesn't have
+# to wrap every wake/sleep call individually — including the ones ``sync_weights``
+# invokes internally.
+_NOOP_OPS = {"wake-inference", "sleep-inference", "wake-training", "sleep-training"}
 _CHUNK_GROUP_RESTART_REQUIRED = "chunk_group_restart_required"
 _CHUNK_GROUP_ERROR_CODES = {_CHUNK_GROUP_RESTART_REQUIRED, "chunk_group_conflict", "chunk_group_missing_chunks"}
 _JOB_TERMINAL = ("failed", "done", "cancelled", "canceled")
@@ -222,12 +227,16 @@ class CortexTransport(Transport):
 
     # ── deliver one op: submit + poll to completion ──────────────────────────
     def call(self, request: Request) -> dict:
+        if request.op in _NOOP_OPS:
+            return {}
         result = self._poll(self._submit(request))
         # generate returns token ids as DSSST1 tensors; on-prem returns plain
         # lists, so match that contract.
         return _to_python(result) if request.op == "generate" else result
 
     async def acall(self, request: Request) -> dict:
+        if request.op in _NOOP_OPS:
+            return {}
         result = await self._apoll(await self._asubmit(request))
         return _to_python(result) if request.op == "generate" else result
 

--- a/arctic_platform/integrations/_cortex_shared.py
+++ b/arctic_platform/integrations/_cortex_shared.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Cortex ``forward-backward`` payload reshape, shared by the SkyRL shim and
+the verl adapter (both construct ``{batch, meta, processing}``; Cortex takes
+``{args, kwargs, context, processing}``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def to_cortex_fwd_bwd_payload(
+    batch: dict,
+    *,
+    dp_size: int,
+    processing: dict | None = None,
+) -> dict:
+    """Reshape ``{batch, meta, processing}`` -> Cortex ``{args, kwargs, context, processing}``.
+
+    Omits ``old_log_probs_shifted``; the server-side GRPO loss restores
+    ``π_old = π_new`` via ``logprobs.detach()``. Correct for single-epoch
+    on-policy GRPO only — recipes with ``ppo_epochs > 1`` or KL-to-reference
+    need the real rollout-time snapshot and should fail before reaching here.
+    """
+    import torch
+
+    b = batch["batch"] if isinstance(batch, dict) and "batch" in batch else batch
+    meta = batch.get("meta", {}) if isinstance(batch, dict) else {}
+    processing = processing or (batch.get("processing") if isinstance(batch, dict) else None) or {}
+
+    input_ids = b["input_ids"]
+    attention_mask = b.get("attention_mask")
+    prompt_len = int(meta.get("prompt_len", 0))
+    if not torch.is_tensor(input_ids):
+        raise TypeError(f"cortex fwd_bwd: input_ids must be a tensor, got {type(input_ids).__name__}")
+
+    total = int(input_ids.shape[-1])
+    response_len = max(total - prompt_len, 1)
+
+    args: list[Any] = [input_ids]
+    kwargs: dict[str, Any] = {
+        "response_length": response_len,
+        "prompt_length": prompt_len,
+    }
+    if attention_mask is not None:
+        kwargs["attention_mask"] = attention_mask
+    context: dict[str, Any] = {
+        "advantages": b.get("advantages"),
+        "response_mask": b.get("response_mask"),
+        "dp_size": int(dp_size),
+    }
+    context = {k: v for k, v in context.items() if v is not None}
+
+    return {"args": args, "kwargs": kwargs, "context": context, "processing": processing}

--- a/arctic_platform/integrations/skyrl/__init__.py
+++ b/arctic_platform/integrations/skyrl/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""SkyRL integration helpers for the Cortex backend."""
+
+from __future__ import annotations
+
+
+def install_cortex_driver_shims() -> None:
+    """Patch ``skyrl.train.utils.utils.peer_access_supported`` to ``False``.
+
+    SkyRL's ``prepare_runtime_environment`` probes ``cudaCanAccessPeer`` by
+    requesting a ``{"CPU":1,"GPU":2}`` Ray placement group, which hangs a
+    CPU-only Cortex driver. No-op unless SkyRL is importable.
+    """
+    try:
+        from skyrl.train.utils import utils as _skyrl_utils
+    except Exception:
+        return
+    if getattr(_skyrl_utils, "_cortex_shimmed", False):
+        return
+    _skyrl_utils.peer_access_supported = lambda max_num_gpus_per_node=1: False
+    _skyrl_utils._cortex_shimmed = True
+
+
+__all__ = ["install_cortex_driver_shims"]

--- a/arctic_platform/integrations/skyrl/__main__.py
+++ b/arctic_platform/integrations/skyrl/__main__.py
@@ -1,0 +1,23 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""SkyRL launcher that installs the Cortex driver shims first.
+
+    python -m arctic_platform.integrations.skyrl <hydra args>
+"""
+
+from __future__ import annotations
+
+import runpy
+import sys
+
+from arctic_platform.integrations.skyrl import install_cortex_driver_shims
+
+install_cortex_driver_shims()
+
+# Forward argv to SkyRL's own entrypoint. This intentionally re-uses whatever
+# SkyRL treats as its main module so we don't fork its argument surface.
+if __name__ == "__main__":
+    # Drop our own ``-m arctic_platform.integrations.skyrl`` from sys.argv so
+    # SkyRL sees the same CLI it would from ``python -m skyrl.train.entrypoints.main_base``.
+    sys.argv = [sys.argv[0]] + sys.argv[1:]
+    runpy.run_module("skyrl.train.entrypoints.main_base", run_name="__main__", alter_sys=True)

--- a/arctic_platform/integrations/verl/adapter.py
+++ b/arctic_platform/integrations/verl/adapter.py
@@ -44,6 +44,7 @@ from arctic_platform.client import OnPremConfig
 from arctic_platform.client import SamplingConfig
 from arctic_platform.client import TrainingConfig
 from arctic_platform.client import create_arctic_rl_client
+from arctic_platform.integrations._cortex_shared import to_cortex_fwd_bwd_payload
 from arctic_platform.rl.ray_server import ArcticRLRayServerState
 
 _ARCTIC_METRIC_REDUCTION_FN = {
@@ -600,6 +601,16 @@ class ArcticRLClientWrapper(RemoteBackend):
             onprem_kwargs["port"] = 7000
             onprem_kwargs["launch_local_server"] = True
 
+        # verl's YAML has no backend discriminator, so ARCTIC_BACKEND=cortex is
+        # the one shell-level knob that flips this adapter to Cortex. Cortex
+        # settings hydrate from ARCTIC_CORTEX_* via CortexConfig.from_env.
+        if os.environ.get("ARCTIC_BACKEND", "").strip().lower() == "cortex":
+            from arctic_platform.client import CortexConfig
+
+            backend_config = CortexConfig.from_env()
+        else:
+            backend_config = OnPremConfig(**onprem_kwargs)
+
         # attn_implementation also lives on ds_worker_config; keep it there for
         # the DeepSpeed worker (matches recipe/rl-correctness).
         ds_worker_config = self._create_ds_worker_config()
@@ -612,7 +623,7 @@ class ArcticRLClientWrapper(RemoteBackend):
             training_gpus=n_training_gpus,
             sampling_gpus=n_sampling_gpus,
             log_prob_gpus=n_log_prob_gpus,
-            backend=OnPremConfig(**onprem_kwargs),
+            backend=backend_config,
             training=TrainingConfig(
                 full_determinism=self._backend_config.train.determinism.get("full", False),
                 checkpoint_path=self.config.trainer.default_local_dir,
@@ -662,11 +673,55 @@ class ArcticRLClientWrapper(RemoteBackend):
     # backends are free to pick their own wire format; verl never calls
     # these directly.
 
+    def _is_cortex_backend(self) -> bool:
+        from arctic_platform.client import CortexConfig
+
+        return isinstance(self._client.config.backend, CortexConfig)
+
+    def _zero_logprob_response(self, payload: dict, *, caller: str) -> dict:
+        """Return zero log-probs / entropy shaped like a real fwd_no_grad.
+
+        Cortex has no ``/forward`` sub-job. Zero-filling is only safe when the
+        caller doesn't actually consume the values — single-epoch on-policy
+        GRPO with no KL-to-reference (server-side default
+        ``old_log_probs = logprobs.detach()`` restores π_old ≡ π_new). Recipes
+        with ``use_kl_loss`` / ``use_kl_in_reward`` on, or multi-epoch PPO,
+        need the real snapshot; fail loud instead of silently producing the
+        wrong training signal.
+        """
+        actor = self.config.actor_rollout_ref.actor
+        algo = getattr(self.config, "algorithm", None)
+        if getattr(actor, "use_kl_loss", False) or getattr(algo, "use_kl_in_reward", False):
+            raise NotImplementedError(
+                f"cortex backend: {caller} needs real ref log-probs "
+                "(actor.use_kl_loss / algorithm.use_kl_in_reward is on) but "
+                "Cortex has no /forward sub-job. Disable both, or use the "
+                "on-prem backend for KL-anchored training."
+            )
+        ppo_epochs = int(getattr(actor, "ppo_epochs", 1))
+        if ppo_epochs > 1:
+            raise NotImplementedError(
+                f"cortex backend: {caller} needs the rollout-time log-prob "
+                f"snapshot for ppo_epochs={ppo_epochs} (off-policy PPO). "
+                "Set actor.ppo_epochs=1, or use the on-prem backend."
+            )
+        # make_njt() slices from data["input_ids"], so match [B, T] with T ≥ 1.
+        b_data = payload.get("batch") if isinstance(payload, dict) else None
+        if not isinstance(b_data, dict):
+            b_data = payload if isinstance(payload, dict) else {}
+        ids = b_data.get("input_ids")
+        b = int(ids.shape[0]) if torch.is_tensor(ids) else 1
+        t = int(ids.shape[-1]) if torch.is_tensor(ids) else 1
+        z = torch.zeros((b, max(t, 1)), dtype=torch.float32)
+        return {"batch": {"log_probs": z, "entropy": z}}
+
     async def _send_compute_ref_log_prob(self, payload: dict):
         payload["processing"] = {
             "post": ["compute_entropy_and_logprobs"],
             "loss_fn": None,
         }
+        if self._is_cortex_backend():
+            return self._zero_logprob_response(payload, caller="compute_ref_log_prob")
         response = await self._client.fwd_no_grad(payload, reference_model=True)
         response["batch"]["log_probs"] = response["batch"].pop("logprobs")
         return response
@@ -676,6 +731,8 @@ class ArcticRLClientWrapper(RemoteBackend):
             "post": ["compute_entropy_and_logprobs"],
             "loss_fn": None,
         }
+        if self._is_cortex_backend():
+            return self._zero_logprob_response(payload, caller="compute_log_prob")
         response = await self._client.fwd_no_grad(payload, reference_model=False)
         response["batch"]["log_probs"] = response["batch"].pop("logprobs")
         return response
@@ -699,6 +756,15 @@ class ArcticRLClientWrapper(RemoteBackend):
             if name in payload["batch"]:
                 payload["batch"][name] = _left_pad(payload["batch"][name], seq_len)
         payload["batch"]["loss_mask"] = payload["batch"]["response_mask"]
+
+        if self._is_cortex_backend():
+            # Cortex takes {args, kwargs, context, processing}; on-prem takes
+            # {batch, meta, processing}. Reshape here, not on the wire.
+            payload = to_cortex_fwd_bwd_payload(
+                payload["batch"],
+                dp_size=int(self._client.config.training_gpus or 1),
+                processing=payload.get("processing"),
+            )
 
         fwd_bwd_response = await self._client.fwd_bwd(payload)
         step_response = await self._client.step()

--- a/arctic_platform/integrations/verl/examples/README-cortex.md
+++ b/arctic_platform/integrations/verl/examples/README-cortex.md
@@ -1,0 +1,41 @@
+# verl × Arctic-Platform × Cortex-training
+
+Companion to [`run_gsm8k_grpo_arl.sh`](run_gsm8k_grpo_arl.sh): same verl
+`RemoteBackend` adapter and same GRPO recipe on Qwen3-0.6B / GSM8K.
+`ARCTIC_BACKEND=cortex` (read in
+[`adapter.py::_create_rl_client_config`](../adapter.py)) swaps the default
+`OnPremConfig` for `CortexConfig.from_env()`. The verl YAML stays backend-agnostic.
+
+## Install + env
+
+```bash
+pip install arctic-platform[cortex]
+export ARCTIC_BACKEND=cortex
+export ARCTIC_CORTEX_HOST=<account>.<region>.snowflakecomputing.com
+export ARCTIC_CORTEX_DATABASE=<db>
+export ARCTIC_CORTEX_SCHEMA=<schema>
+export CORTEX_PAT=<pat>
+```
+
+## Run
+
+```bash
+./run_gsm8k_grpo_cortex.sh
+```
+
+## Adapter changes for the Cortex path
+
+Two shape mismatches versus the on-prem wire format live in
+`arctic_platform/integrations/verl/adapter.py`:
+
+* `_send_compute_{ref_,}log_prob`: return zero-shaped `log_probs` / `entropy`;
+  Cortex has no `/forward` sub-job. Only correct for single-epoch on-policy
+  GRPO without KL — `use_kl_loss`, `use_kl_in_reward`, or `ppo_epochs > 1`
+  raise `NotImplementedError`.
+* `_send_update_actor`: reshape `{batch, meta, processing}` →
+  `{args, kwargs, context, processing}` via
+  [`to_cortex_fwd_bwd_payload`](../../_cortex_shared.py) (shared with the
+  SkyRL shim).
+
+Everything else (`generate`, `sync_weights`, `save_checkpoint`, wake/sleep)
+goes through `ArcticRLClient` unchanged.

--- a/arctic_platform/integrations/verl/examples/run_gsm8k_grpo_cortex.sh
+++ b/arctic_platform/integrations/verl/examples/run_gsm8k_grpo_cortex.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# verl × Arctic-Platform × Cortex-training on Qwen3-0.6B / GSM8K.
+# Cortex sub-jobs own training + sampling; the verl driver is CPU-only.
+#
+# Pre-reqs (see README-cortex.md):
+#   1. pip install arctic-platform[cortex,verl]
+#   2. Data: python .../recipes/rl/verl/simple/download_data.py -> $DATA_DIR/{train,test}.parquet
+#   3. ARCTIC_BACKEND=cortex + ARCTIC_CORTEX_* env vars set.
+
+set -x
+
+if [[ "${ARCTIC_BACKEND:-}" != "cortex" ]]; then
+    echo "ERROR: ARCTIC_BACKEND=cortex is required. See README-cortex.md."
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1
+export HYDRA_FULL_ERROR=1
+export RAY_DEDUP_LOGS=0
+export HF_HOME="${HF_HOME:-${HOME}/.cache/huggingface}"
+
+# Plug the Arctic RemoteBackend into verl.
+export VERL_USE_EXTERNAL_MODULES=arctic_platform.integrations.verl.register
+ARCTIC_VERL_CONFIG_DIR="${REPO_ROOT}/arctic_platform/integrations/verl/config"
+
+# Cortex owns the GPUs; verl workers run against remote sub-jobs, not local.
+USE_LEGACY_WORKER_IMPL=disable
+ROLLOUT_NAME=arctic
+COLOCATE=False               # Cortex has no colocation lifecycle
+NGPU_PER_JOB=1               # target Cortex sub-job GPU count
+NGPU_FOR_LOG_PROBS=0         # no /forward on Cortex; zero-fill via _zero_logprob_response
+TP_SIZE=1
+
+BSZ=32
+PPO_MINI_BSZ=32
+UBS=8
+ROLL_N=8
+PROMPT_LEN=1024
+RESPONSE_LEN=1024
+MAX_TOKENS_PER_GPU=16384
+ROLLOUT_MAX_BATCHED=16384
+LR=1e-6
+CLIP_RATIO=0.2
+USE_KL_LOSS=False            # required: Cortex has no /forward for ref log-probs
+KL_LOSS_COEF=0.001
+TOTAL_EPOCHS=1
+SAVE_FREQ=-1
+TEST_FREQ=10
+
+LOGGER="['console']"
+
+MODEL_SHORT="${MODEL_SHORT:-Qwen3-0.6B}"
+MODEL="${MODEL:-Qwen/${MODEL_SHORT}}"
+experiment_name="gsm8k_grpo_${MODEL_SHORT}_cortex"
+
+flash_attention_v=flash_attention_2
+
+DATA_DIR="${DATA_DIR:-${HOME}/data/gsm8k}"
+TRAIN_FILES="${DATA_DIR}/train.parquet"
+VAL_FILES="${DATA_DIR}/test.parquet"
+
+CKPT_DIR="${CKPT_DIR:-${HOME}/checkpoints/gsm8k-rl-cortex}"
+
+python3 -m verl.trainer.main_ppo \
+    hydra.searchpath="[file://${ARCTIC_VERL_CONFIG_DIR}]" \
+    algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=True \
+    algorithm.use_kl_in_reward=False \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    data.train_files=$TRAIN_FILES \
+    data.val_files=$VAL_FILES \
+    data.train_batch_size=$BSZ \
+    data.max_prompt_length=$PROMPT_LEN \
+    data.max_response_length=$RESPONSE_LEN \
+    data.filter_overlong_prompts=True \
+    data.filter_overlong_prompts_workers=1 \
+    data.truncation=left \
+    data.seed=42 \
+    actor_rollout_ref.actor.data_loader_seed=42 \
+    actor_rollout_ref.model.path=$MODEL \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    +actor_rollout_ref.model.override_config.attn_implementation=$flash_attention_v \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$PPO_MINI_BSZ \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$UBS \
+    actor_rollout_ref.actor.ppo_epochs=1 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=$UBS \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=$UBS \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$MAX_TOKENS_PER_GPU \
+    actor_rollout_ref.actor.clip_ratio=$CLIP_RATIO \
+    actor_rollout_ref.actor.use_kl_loss=$USE_KL_LOSS \
+    actor_rollout_ref.actor.kl_loss_coef=$KL_LOSS_COEF \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.optim.lr=$LR \
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.05 \
+    actor_rollout_ref.actor.optim.betas='[0.9,0.95]' \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$TP_SIZE \
+    actor_rollout_ref.rollout.name=$ROLLOUT_NAME \
+    actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=4096 \
+    actor_rollout_ref.rollout.agent.num_workers=1 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.n=$ROLL_N \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.top_p=1.0 \
+    actor_rollout_ref.rollout.calculate_log_probs=False \
+    actor_rollout_ref.rollout.max_num_seqs=256 \
+    actor_rollout_ref.rollout.max_num_batched_tokens=$ROLLOUT_MAX_BATCHED \
+    actor_rollout_ref.nccl_timeout=1800 \
+    trainer.use_legacy_worker_impl=$USE_LEGACY_WORKER_IMPL \
+    trainer.remote_backend=arctic \
+    remote_backend=arctic \
+    trainer.balance_batch=False \
+    trainer.default_local_dir=$CKPT_DIR/$experiment_name \
+    trainer.logger=$LOGGER \
+    trainer.project_name=arctic_rl_gsm8k_cortex \
+    trainer.experiment_name=$experiment_name \
+    trainer.n_gpus_per_node=1 \
+    trainer.nnodes=1 \
+    trainer.save_freq=$SAVE_FREQ \
+    trainer.test_freq=$TEST_FREQ \
+    trainer.total_epochs=$TOTAL_EPOCHS \
+    trainer.val_before_train=False \
+    remote_backend.colocate=$COLOCATE \
+    remote_backend.log_prob_gpus=$NGPU_FOR_LOG_PROBS \
+    remote_backend.sampling_gpus=$NGPU_PER_JOB \
+    remote_backend.sampling_tp_size=$TP_SIZE \
+    remote_backend.train.deepspeed.zero_optimization.stage=2 \
+    remote_backend.training_gpus=$NGPU_PER_JOB \
+    "$@" 2>&1 | tee $experiment_name.log

--- a/arctic_platform/integrations/verl/register.py
+++ b/arctic_platform/integrations/verl/register.py
@@ -16,30 +16,12 @@
 """Plugin entry point for the Arctic RL <-> verl integration.
 
 Loaded by verl during ``verl/__init__.py`` bootstrap whenever the user
-sets::
+sets ``VERL_USE_EXTERNAL_MODULES=arctic_platform.integrations.verl.register``.
 
-    export VERL_USE_EXTERNAL_MODULES=arctic_platform.integrations.verl.register
-
-Registration is a module-level side effect. Three things wire up under
-the name ``"arctic"``:
-
-1. Backend class -- :class:`ArcticRLClientWrapper` registers itself with
-   :class:`verl.remote_backend.base.RemoteBackendRegistry` via
-   ``@RemoteBackendRegistry.register("arctic")`` applied at
-   ``adapter`` import time. That import is eager here because the
-   decorator is the mechanism of registration.
-2. ActorRollout forwarder worker -- registered lazily via
-   :meth:`RemoteBackendRegistry.register_worker`. ``main_ppo`` reads
-   the class back through
-   :meth:`RemoteBackendRegistry.get_worker` when
-   ``trainer.remote_backend=arctic``. Kept lazy so that jobs which
-   set ``VERL_USE_EXTERNAL_MODULES`` but use a different backend (or
-   just build config trees) don't pay the tensordict / DeepSpeed /
-   flops-counter import cost of :mod:`worker`.
-3. Rollout replica -- registered lazily with
-   :class:`verl.workers.rollout.replica.RolloutReplicaRegistry` so
-   ``actor_rollout_ref.rollout.name=arctic`` resolves to
-   :class:`ArcticReplica` without eagerly importing vLLM.
+Registers the ``"arctic"`` backend + forwarder worker + rollout replica.
+Auto-selects V0 (Snowflake-AI-Research/verl fork) or V1
+(verl-project/verl main) based on whether
+:mod:`verl.trainer.ppo.v1.trainer_remote_backend` imports.
 """
 
 from __future__ import annotations
@@ -48,26 +30,69 @@ from arctic_platform._dependency_groups import require_any_dep_group
 
 require_any_dep_group("verl")
 
-from verl.remote_backend.base import RemoteBackendRegistry  # noqa: E402
-from verl.workers.rollout.replica import RolloutReplicaRegistry  # noqa: E402
 
-# Importing the adapter is what actually registers the backend class:
-# `@RemoteBackendRegistry.register("arctic")` runs at class-definition
-# time. Everything below is lazy.
-from arctic_platform.integrations.verl import adapter as _adapter  # noqa: E402,F401
+def _register_v0() -> None:
+    """V0 (Snowflake-AI-Research/verl fork) registration path."""
+    from verl.remote_backend.base import RemoteBackendRegistry
+    from verl.workers.rollout.replica import RolloutReplicaRegistry
+
+    # Importing the adapter is what actually registers the backend class:
+    # `@RemoteBackendRegistry.register("arctic")` runs at class-definition time.
+    from arctic_platform.integrations.verl import adapter as _adapter  # noqa: F401
+
+    def _load_v0_worker() -> type:
+        from arctic_platform.integrations.verl.worker import ArcticRLActorRolloutRefWorker
+
+        return ArcticRLActorRolloutRefWorker
+
+    def _load_v0_replica() -> type:
+        from arctic_platform.integrations.verl.rollout import ArcticReplica
+
+        return ArcticReplica
+
+    RemoteBackendRegistry.register_worker("arctic", _load_v0_worker)
+    RolloutReplicaRegistry.register("arctic", _load_v0_replica)
 
 
-def _load_arctic_actor_rollout_worker() -> type:
-    from arctic_platform.integrations.verl.worker import ArcticRLActorRolloutRefWorker
+def _register_v1() -> None:
+    """V1 (verl-project/verl main) registration path.
 
-    return ArcticRLActorRolloutRefWorker
+    Points worker + replica loaders at the V1 wrappers so the base-class
+    contract matches :class:`ActorRolloutRefWorker` and the V1
+    :class:`LLMServerManager`.
+    """
+    from verl.remote_backend.base import RemoteBackendRegistry
+    from verl.workers.rollout.replica import RolloutReplicaRegistry
+
+    # Same adapter (backend business logic is V0/V1-agnostic); the decorator
+    # side effect populates RemoteBackendRegistry["arctic"].
+    from arctic_platform.integrations.verl import adapter as _adapter  # noqa: F401
+
+    def _load_v1_worker() -> type:
+        from arctic_platform.integrations.verl.v1.worker import ArcticV1ActorRolloutRefWorker
+
+        return ArcticV1ActorRolloutRefWorker
+
+    def _load_v1_replica() -> type:
+        from arctic_platform.integrations.verl.v1.replica import ArcticV1Replica
+
+        return ArcticV1Replica
+
+    RemoteBackendRegistry.register_worker("arctic", _load_v1_worker)
+    RolloutReplicaRegistry.register("arctic", _load_v1_replica)
 
 
-def _load_arctic_replica() -> type:
-    from arctic_platform.integrations.verl.rollout import ArcticReplica
+def _detect_and_register() -> None:
+    """Pick V0 or V1 based on what the installed verl exports. V1 wins
+    when both are importable (V1 companion PR ships
+    :mod:`verl.trainer.ppo.v1.trainer_remote_backend`).
+    """
+    try:
+        import verl.trainer.ppo.v1.trainer_remote_backend  # noqa: F401
+    except ImportError:
+        _register_v0()
+    else:
+        _register_v1()
 
-    return ArcticReplica
 
-
-RemoteBackendRegistry.register_worker("arctic", _load_arctic_actor_rollout_worker)
-RolloutReplicaRegistry.register("arctic", _load_arctic_replica)
+_detect_and_register()

--- a/arctic_platform/integrations/verl/v1/README.md
+++ b/arctic_platform/integrations/verl/v1/README.md
@@ -1,0 +1,162 @@
+<!--
+Copyright 2025 Snowflake Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Arctic verl integration — V1 setup (from scratch)
+
+End-to-end recipe for running the Arctic RL backend against
+`verl-project/verl` `main` (V1 trainer). Verified on an 8× H200 node with
+Python 3.12, torch 2.10.0+cu129, vLLM 0.18.0, flashinfer 0.6.6.
+
+Companion PRs:
+
+- verl-core (V1 seam): <https://github.com/verl-project/verl/pull/7102>
+- Arctic-Platform (this PR): <https://github.com/Snowflake-AI-Research/Arctic-Platform/pull/41>
+
+---
+
+## 1. Layout
+
+Pick a fast-scratch root (below assumes `/data-fast/karthik/`) and a
+sources root (below assumes `/modeling-code/karthik/abstract-remote-exps/`).
+Environment goes on the fast scratch; source checkouts can live anywhere
+you can `pip install -e`.
+
+```
+/data-fast/karthik/conda_envs/arctic_verl_v18/         # conda env
+/modeling-code/karthik/abstract-remote-exps/
+    ├── verl/                        # verl-project/verl @ main + this PR
+    ├── Arctic-Platform/             # this repo, karthik/verl-v1-plugin
+    ├── ArcticInference-internal/    # Arctic vLLM plugin
+    ├── ArcticTraining-dss/          # arctic-training training library
+    └── dss-client/                  # DSS client (dependency of arctic-training)
+```
+
+## 2. Clone the sources
+
+```bash
+SRC=/modeling-code/karthik/abstract-remote-exps
+mkdir -p "$SRC" && cd "$SRC"
+
+git clone https://github.com/verl-project/verl.git
+git -C verl fetch origin karthik/v1-remote-backend:v1-remote-backend
+git -C verl checkout v1-remote-backend
+
+git clone https://github.com/Snowflake-AI-Research/Arctic-Platform.git
+git -C Arctic-Platform checkout karthik/verl-v1-plugin
+
+# Internal repos (Snowflake org access required)
+git clone https://github.com/Snowflake-AI-Research/ArcticInference-internal.git
+git clone https://github.com/Snowflake-AI-Research/ArcticTraining-dss.git
+git clone https://github.com/Snowflake-AI-Research/dss-client.git
+```
+
+## 3. Create the env
+
+```bash
+ENV=/data-fast/karthik/conda_envs/arctic_verl_v18
+conda create -y -p "$ENV" python=3.12
+conda activate "$ENV"
+python -m pip install --upgrade pip
+```
+
+## 4. Install packages (order matters)
+
+```bash
+cd "$SRC"
+
+# 4a. torch first, pinned to the cu129 wheels.
+python -m pip install --index-url https://download.pytorch.org/whl/cu129 \
+    torch==2.10.0 torchvision
+
+# 4b. dss-client BEFORE arctic-training (arctic-training imports it at install-time).
+python -m pip install -e dss-client
+
+# 4c. arctic-training (depends on dss-client).
+python -m pip install -e ArcticTraining-dss
+
+# 4d. Arctic inference vLLM plugin (installs vllm==0.18.0 as a dep).
+python -m pip install -e ArcticInference-internal
+
+# 4e. Arctic-Platform (this repo).
+python -m pip install -e Arctic-Platform
+
+# 4f. verl (V1 branch with the RemoteBackend seam).
+python -m pip install -e verl
+
+# 4g. flashinfer downgrades torch as a side effect; reinstall torch afterwards.
+python -m pip install flashinfer-python
+python -m pip install --index-url https://download.pytorch.org/whl/cu129 \
+    --force-reinstall --no-deps torch==2.10.0 torchvision
+```
+
+Sanity:
+
+```bash
+python - <<'PY'
+import torch, vllm, flashinfer, verl, arctic_platform, arctic_inference, arctic_training
+print("torch      :", torch.__version__, "cuda", torch.version.cuda)
+print("vllm       :", vllm.__version__)
+print("flashinfer :", flashinfer.__version__)
+print("verl       :", verl.__file__)
+PY
+```
+
+Expected: `torch 2.10.0+cu129 cuda 12.9`, `vllm 0.18.0`, `flashinfer 0.6.6`.
+
+## 5. Data + reward function
+
+The BIRD text-to-SQL launcher expects:
+
+- `/data/snowflakesql/txt2sql/train.parquet` (see the Snowflake-internal
+  data mirror; earlier ablations also used
+  `train_128_avg9k.parquet` if the full file is unavailable).
+- validation parquet at `/code/users/truwase/data/open-source-text2sql/val.parquet`
+  (override via `VAL_FILES`).
+- Reward function at
+  `Arctic-Platform/recipes/rl/verl/txt2sql/bird_reward.py` (already in
+  this repo). Launcher wires it via
+  `reward.custom_reward_function.path`.
+
+GSM8K launcher expects `/code/shared/gsm8k/{train,test}.parquet`.
+
+## 6. Run
+
+Smoke test on 1× GPU (1.7B, GSM8K):
+
+```bash
+cd "$SRC/Arctic-Platform"
+bash arctic_platform/integrations/verl/v1/examples/run_gsm8k_grpo_arl_v1.sh
+```
+
+8× H200, Qwen3-8B, BIRD (recipe-aligned):
+
+```bash
+bash /data-fast/karthik/run_bird_arctic_v1_recipe.sh
+```
+
+## 7. Env vars the plugin cares about
+
+Set in the launcher; override on the command line if needed.
+
+| Variable | Purpose |
+| :--- | :--- |
+| `VERL_USE_EXTERNAL_MODULES=arctic_platform.integrations.verl.register` | Loads the plugin at verl bootstrap. |
+| `USE_ARCTIC_TRAINING_CLIENT=1` | Route training through the Arctic RL server. |
+| `ARCTIC_INFERENCE_ENABLED=1` | Register the Arctic vLLM plugin (Forest Cascade Attention hooks). |
+| `VLLM_BATCH_INVARIANT=0` | Off = throughput mode. Set to `1` only for bit-exact reproducibility (disables CUDA graphs / speculative decoding). |
+| `VLLM_ENABLE_V1_MULTIPROCESSING=0` | Required by the Arctic vLLM plugin. |
+| `HF_HOME` | Model cache. Point at the shared cache if available (`/checkpoint/huggingface`). |
+| `HF_HUB_OFFLINE=0` | Allow HF hub access on first pull; flip to `1` once the model is cached. |
+
+## 8. Known follow-up
+
+Under vLLM 0.18.0 the default `cudagraph_mode=FULL_AND_PIECEWISE`
+silently disables Forest Cascade Attention when `enforce_eager=False`.
+The pre-plugin recipe worked around this with
+`actor_rollout_ref.rollout.enforce_eager=True` (forces
+`cudagraph_mode=NONE`), which the current launcher also does. Tracking
+a real fix in `parse_arctic_inference_rollout` (override
+`compilation_config.cudagraph_mode=PIECEWISE` when
+`zorro_inference.enable=True`) in a separate PR.

--- a/arctic_platform/integrations/verl/v1/__init__.py
+++ b/arctic_platform/integrations/verl/v1/__init__.py
@@ -1,5 +1,17 @@
-# Copyright 2026 Snowflake Inc.
+# Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """V1 (verl-project/verl main) compatibility wrappers for the Arctic backend.
 
 Kept in a separate subpackage so V0 (Snowflake-AI-Research/verl) users can

--- a/arctic_platform/integrations/verl/v1/__init__.py
+++ b/arctic_platform/integrations/verl/v1/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2026 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""V1 (verl-project/verl main) compatibility wrappers for the Arctic backend.
+
+Kept in a separate subpackage so V0 (Snowflake-AI-Research/verl) users can
+continue to import ``arctic_platform.integrations.verl`` without paying for
+V1's transfer_queue / TransferQueue import overhead, and so V1 users can plug
+in via the same plugin bootstrap without pulling in V0-only imports.
+"""

--- a/arctic_platform/integrations/verl/v1/examples/run_gsm8k_grpo_arl_v1.sh
+++ b/arctic_platform/integrations/verl/v1/examples/run_gsm8k_grpo_arl_v1.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Canonical GSM8K example for the Arctic RemoteBackend on verl **V1**
+# (verl-project/verl main). Companion of ``../../examples/run_gsm8k_grpo_arl.sh``
+# which targets the V0 (Snowflake-AI-Research/verl) trainer.
+#
+# Demonstrates the generic ``verl.remote_backend`` abstraction with the
+# Arctic adapter, selected via the Hydra option group (``remote_backend=arctic``).
+# Single-GPU, GRPO, Qwen3-0.6B; intended as a quick convergence sanity check.
+#
+# Requirements:
+#   pip install "arctic_platform[verl]"
+#   pip install verl==<version pinned in your launcher>
+#
+# The verl side is loaded via the VERL_USE_EXTERNAL_MODULES plugin hook
+# below; no verl source-tree modification is required.
+#
+# Notes:
+#   * Weight sync runs over CUDA IPC (colocate=True + weight_sync.cuda_ipc=True)
+#     to bypass NCCL for intra-node weight transfer. The non-colocate NCCL
+#     path can deadlock in ``PyNcclCommunicator.all_reduce`` on hosts that
+#     export ``NCCL_NET_PLUGIN=ofi`` (OFI is not a valid transport for
+#     intra-node comms), so the recipe pins the CUDA-IPC path here.
+#   * ``remote_backend=arctic`` alone is sufficient: verl's main_ppo copies
+#     the Hydra group choice into ``trainer.remote_backend`` automatically
+#     (see Snowflake-AI-Research/verl companion PR).
+
+set -x
+export PYTHONUNBUFFERED=1
+export HYDRA_FULL_ERROR=1
+export RAY_DEDUP_LOGS=0
+export HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-1}
+export HF_HOME=${HF_HOME:-${HOME}/.cache/huggingface}
+export USE_ARCTIC_TRAINING_CLIENT=1
+export VLLM_BATCH_INVARIANT=1
+export VLLM_ENABLE_V1_MULTIPROCESSING=0
+
+# Plug the Arctic backend into verl without patching the verl source tree.
+export VERL_USE_EXTERNAL_MODULES=arctic_platform.integrations.verl.register
+
+# Add the plugin's config dir to Hydra's search path so `remote_backend=arctic`
+# resolves to `arctic_platform/integrations/verl/config/arctic.yaml`. Hydra
+# accepts either `file://` URIs or plain absolute paths in `hydra.searchpath`.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The remote_backend/arctic.yaml lives in the V0 config dir; the schema is
+# identical between V0 and V1 so we point Hydra at the same directory.
+ARCTIC_VERL_CONFIG_DIR="${SCRIPT_DIR}/../../config"
+
+gpu_name=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader -i 0 2>/dev/null || echo "")
+if   [[ $gpu_name == *"H200"* ]]; then flash_attention_v=flash_attention_3
+elif [[ $gpu_name == *"B200"* || $gpu_name == *"B300"* ]]; then flash_attention_v=flash_attention_2
+else flash_attention_v=flash_attention_2
+fi
+
+DATA_DIR="${DATA_DIR:-/code/shared/gsm8k}"
+
+python3 -m verl.trainer.main_ppo \
+    hydra.searchpath="[file://${ARCTIC_VERL_CONFIG_DIR}]" \
+    algorithm.adv_estimator=grpo \
+    data.train_files=${DATA_DIR}/train.parquet \
+    data.val_files=${DATA_DIR}/test.parquet \
+    data.train_batch_size=16 \
+    data.max_prompt_length=512 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    data.shuffle=False \
+    +data.seed=42 \
+    actor_rollout_ref.actor.data_loader_seed=42 \
+    reward.num_workers=1 \
+    actor_rollout_ref.rollout.agent.num_workers=1 \
+    actor_rollout_ref.model.path=Qwen/Qwen3-0.6B \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_remove_padding=False \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=16 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    +actor_rollout_ref.model.override_config.attn_implementation=$flash_attention_v \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=16 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=arctic \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.n=5 \
+    actor_rollout_ref.rollout.calculate_log_probs=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=16 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=False \
+    actor_rollout_ref.ref.strategy=fsdp2 \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger="['console']" \
+    trainer.experiment_name=gsm8k_grpo_qwen3_0p6b_ngpu1_gbs16_rolln5_zorroTrue \
+    trainer.project_name=arctic_rl_gsm8k_arctic_platform \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=1 \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_training_steps=80 \
+    trainer.total_epochs=15 \
+    remote_backend=arctic \
+    remote_backend.colocate=True \
+    remote_backend.training_gpus=1 \
+    remote_backend.sampling_gpus=1 \
+    remote_backend.log_prob_gpus=0 \
+    remote_backend.train.deepspeed.zero_optimization.stage=2 \
+    remote_backend.train.deepspeed.zero_optimization.offload_optimizer.device=none \
+    remote_backend.train.deepspeed.zero_optimization.offload_param.device=none \
+    remote_backend.train.zorro_train.enable=True \
+    remote_backend.weight_sync.cuda_ipc=True \
+    "$@" 2>&1

--- a/arctic_platform/integrations/verl/v1/replica.py
+++ b/arctic_platform/integrations/verl/v1/replica.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""V1 rollout replica for the Arctic backend.
+
+Thin subclass of :class:`ArcticReplica` that adapts the constructor to
+verl V1's ``LLMServerManager.replica_init_kwargs`` forwarding and swaps
+in :class:`ArcticV1LLMServer` (which tags
+``TokenOutput.extra_fields["global_steps"]``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import ray
+from omegaconf import DictConfig
+from verl.workers.config import RolloutConfig
+
+from arctic_platform.integrations.verl.rollout import ArcticReplica
+from arctic_platform.integrations.verl.v1.server import ArcticV1LLMServer
+
+
+class ArcticV1Replica(ArcticReplica):
+    """V1-compatible ArcticReplica. Uses :class:`ArcticV1LLMServer` and
+    exposes :meth:`set_global_steps` for the ``remote_backend``
+    checkpoint-engine short-circuit fan-out.
+    """
+
+    def __init__(
+        self,
+        replica_rank: int,
+        config: RolloutConfig,
+        model_config: DictConfig,
+        gpus_per_node: int = 8,
+        is_reward_model: bool = False,
+        is_teacher_model: bool = False,
+        name_suffix: str = "",
+        *,
+        main_config: DictConfig,
+        backend_handle: dict,
+        **_ignored_kwargs,
+    ) -> None:
+        super().__init__(
+            replica_rank=replica_rank,
+            config=config,
+            model_config=model_config,
+            gpus_per_node=gpus_per_node,
+            is_reward_model=is_reward_model,
+            main_config=main_config,
+            backend_handle=backend_handle,
+        )
+        self.server_class = ray.remote(ArcticV1LLMServer)
+        # V1 additions; downstream code may inspect them.
+        self.is_teacher_model = is_teacher_model
+        self.name_suffix = f"_{name_suffix}" if name_suffix else ""
+
+    async def set_global_steps(self, global_steps: int) -> None:
+        """Publish the current policy version to every server in this replica.
+
+        Called from ``CheckpointEngineManager`` after
+        ``actor_wg.update_weights`` on the ``remote_backend`` short-circuit.
+        """
+        if not self.servers:
+            return
+        await asyncio.gather(*(s.set_global_steps.remote(global_steps) for s in self.servers))

--- a/arctic_platform/integrations/verl/v1/replica.py
+++ b/arctic_platform/integrations/verl/v1/replica.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Snowflake Inc.
+# Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/arctic_platform/integrations/verl/v1/server.py
+++ b/arctic_platform/integrations/verl/v1/server.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Snowflake Inc.
+# Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/arctic_platform/integrations/verl/v1/server.py
+++ b/arctic_platform/integrations/verl/v1/server.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""V1-compatible Arctic LLM server.
+
+Emits ``TokenOutput.extra_fields["global_steps"]`` (V1's real field; V0
+used ``extra_info`` which pydantic silently drops) and exposes
+:meth:`set_global_steps` so :class:`ArcticV1Replica` can fan the current
+policy version out after each ``CheckpointEngineManager`` weight sync.
+The V0 server file stays untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from verl.workers.rollout.replica import TokenOutput
+
+from arctic_platform.integrations.verl.rollout import ArcticLLMServer
+
+
+class ArcticV1LLMServer(ArcticLLMServer):
+    """V1-compat Arctic LLM server: publishes ``global_steps`` on every generation."""
+
+    async def set_global_steps(self, global_steps: int) -> None:
+        """Publish the current policy version onto this server so subsequent
+        :meth:`generate` calls tag their outputs with the right version.
+        """
+        self.global_steps = global_steps
+
+    async def generate(
+        self,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        request_id: str,
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+        priority: int = 0,
+    ) -> TokenOutput:
+        out: TokenOutput = await super().generate(
+            prompt_ids=prompt_ids,
+            sampling_params=sampling_params,
+            request_id=request_id,
+            image_data=image_data,
+            video_data=video_data,
+            priority=priority,
+        )
+        # Re-publish global_steps under V1's real field name.
+        extra_fields = dict(out.extra_fields or {})
+        extra_fields["global_steps"] = self.global_steps
+        return out.model_copy(update={"extra_fields": extra_fields})

--- a/arctic_platform/integrations/verl/v1/server.py
+++ b/arctic_platform/integrations/verl/v1/server.py
@@ -23,7 +23,8 @@ The V0 server file stays untouched.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
+from typing import Optional
 
 from verl.workers.rollout.replica import TokenOutput
 

--- a/arctic_platform/integrations/verl/v1/worker.py
+++ b/arctic_platform/integrations/verl/v1/worker.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""V1 forwarder worker for the Arctic backend.
+
+Subclasses :class:`verl.workers.engine_workers.ActorRolloutRefWorker` and
+overrides only the surfaces Arctic implements itself; Ray dispatch,
+profiler wiring, and worker-group plumbing come from the base class
+unchanged. Reuses the V0 worker's payload helpers so the wire format to
+the Arctic RL server is byte-identical to V0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Awaitable, Optional, TypeVar
+
+import torch
+from omegaconf import DictConfig, OmegaConf
+from tensordict import TensorDict
+from verl.remote_backend.base import RemoteBackend, RemoteBackendRegistry
+from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
+from verl.utils import hf_tokenizer
+from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.flops_counter import FlopsCounter
+from verl.utils.profiler import DistProfiler, DistProfilerExtension
+from verl.workers.config import ActorConfig, HFModelConfig
+from verl.workers.engine_workers import ActorRolloutRefWorker
+
+# Eager: populates RemoteBackendRegistry in every Ray child process; the
+# V0 worker supplies payload marshaling helpers reused below.
+from arctic_platform.integrations.verl import adapter as _adapter  # noqa: F401
+from arctic_platform.integrations.verl.worker import ArcticRLActorRolloutRefWorker as _ArcticV0Worker
+
+T = TypeVar("T")
+
+
+class _AsyncRunner:
+    """Runs coroutines on a dedicated background event loop.
+
+    V1's ``@register`` decorator stack drops coroutine-function status, so
+    the ``single_controller`` machinery binds worker methods with the sync
+    fast-path (``ray.get(handle.method.remote(...))``). We expose
+    ``compute_log_prob`` / ``update_actor`` / ``update_weights`` as sync
+    methods and drive the async backend RPCs on this persistent loop
+    (avoids per-call ``asyncio.run`` teardown of the Ray client's loop state).
+    """
+
+    _instance: Optional["_AsyncRunner"] = None
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._loop.run_forever,
+            name="ArcticV1WorkerAsyncLoop",
+            daemon=True,
+        )
+        self._thread.start()
+
+    @classmethod
+    def get(cls) -> "_AsyncRunner":
+        if cls._instance is None:
+            cls._instance = _AsyncRunner()
+        return cls._instance
+
+    def run(self, coro: Awaitable[T]) -> T:
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+
+def _njt_to_left_padded(njt: torch.Tensor, pad_value, max_len: int) -> torch.Tensor:
+    """Densify a nested-jagged tensor into ``[B, max_len]`` left-padded with ``pad_value``."""
+    offsets = njt.offsets().tolist()
+    values = njt.values()
+    batch = len(offsets) - 1
+    dense = values.new_full((batch, max_len), fill_value=pad_value)
+    for b in range(batch):
+        seg = values[offsets[b] : offsets[b + 1]]
+        length = seg.shape[0]
+        if length == 0:
+            continue
+        dense[b, max_len - length :] = seg
+    return dense
+
+
+def _njt_to_right_padded(njt: torch.Tensor, pad_value, max_len: int) -> torch.Tensor:
+    """Densify a nested-jagged tensor into ``[B, max_len]`` right-padded with ``pad_value``."""
+    offsets = njt.offsets().tolist()
+    values = njt.values()
+    batch = len(offsets) - 1
+    dense = values.new_full((batch, max_len), fill_value=pad_value)
+    for b in range(batch):
+        seg = values[offsets[b] : offsets[b + 1]]
+        length = seg.shape[0]
+        if length == 0:
+            continue
+        dense[b, :length] = seg
+    return dense
+
+
+# Response-aligned fields that get left-padded (or right-padded onto a
+# ``response_length`` tensor). Values are ``(pad_value, dtype_default)``;
+# ``dtype_default=None`` means keep the tensor's own dtype.
+_RESPONSE_FIELDS: dict[str, tuple[float, Optional[torch.dtype]]] = {
+    "response_mask": (0, None),
+    "loss_mask": (0, None),
+    "old_log_probs": (0.0, None),
+    "advantages": (0.0, None),
+    "ref_log_prob": (0.0, None),
+    "rollout_is_weights": (1.0, None),
+}
+
+
+def _to_v0_padded_batch(
+    data: TensorDict,
+    *,
+    pad_token_id: int,
+    max_prompt_len: int,
+    max_response_len: int,
+) -> TensorDict:
+    """Convert a V1 nested-jagged batch into V0's dense-padded shape.
+
+    V0's Arctic adapter and the Arctic-side load balancer index the wire
+    payload with Python ``list[int]`` slices (unsupported on NJT), so we
+    densify here to the V0 layout:
+
+    * ``prompts``: ``[B, max_prompt_len]`` left-padded with ``pad_token_id``.
+    * ``responses`` / response-aligned fields: ``[B, max_response_len]``
+      right-padded.
+    * ``attention_mask``: ``[B, max_prompt_len + max_response_len]`` dense.
+    * ``input_ids`` / ``position_ids`` are left to the V0 helper
+      ``_no_padding_2_padding_prompt_response``.
+
+    ``max_prompt_len`` / ``max_response_len`` MUST be the CONFIG maxes
+    (``config.data.{max_prompt_length,max_response_length}``), not batch-
+    local maxes: ZoRRo's :class:`Qwen3ModelOncePatcher` derives
+    ``prompt_len = input_ids.shape[1] - config.max_response_length`` on
+    every forward, so padding to a batch-local response max sends its
+    response slice into the prompt column and
+    ``extract_unpadded_responses_from_deduped_packed_ids`` returns the
+    wrong span. No-op for fields that are already dense.
+    """
+    prompts = data["prompts"]
+    responses = data["responses"]
+
+    if not prompts.is_nested and not responses.is_nested:
+        # Already V0-shaped (dense batch); trust the caller.
+        return data
+
+    prompt_lens = prompts.offsets().diff()
+    response_lens = responses.offsets().diff()
+
+    out = data.clone(recurse=False)
+
+    out["prompts"] = _njt_to_left_padded(prompts, pad_token_id, max_prompt_len)
+    out["responses"] = _njt_to_right_padded(responses, pad_token_id, max_response_len)
+
+    # Rebuild a dense left-pad-prompt / right-pad-response mask sized to
+    # the config maxes so ZoRRo's post-fwd unpad reads the right slice.
+    batch = prompt_lens.shape[0]
+    seq_len = max_prompt_len + max_response_len
+    device = prompts.values().device
+    mask = torch.zeros(batch, seq_len, dtype=torch.long, device=device)
+    prompt_lens_cpu = prompt_lens.tolist()
+    response_lens_cpu = response_lens.tolist()
+    for b in range(batch):
+        pl = int(prompt_lens_cpu[b])
+        rl = int(response_lens_cpu[b])
+        mask[b, max_prompt_len - pl : max_prompt_len] = 1
+        mask[b, max_prompt_len : max_prompt_len + rl] = 1
+    out["attention_mask"] = mask
+
+    for key, (pad_val, _dtype) in _RESPONSE_FIELDS.items():
+        if key not in out.keys():
+            continue
+        val = out[key]
+        if getattr(val, "is_nested", False):
+            out[key] = _njt_to_right_padded(val, pad_val, max_response_len)
+
+    return out
+
+class ArcticV1ActorRolloutRefWorker(ActorRolloutRefWorker):
+    """CPU-only V1 forwarder that drives an Arctic :class:`RemoteBackend`.
+
+    Single-instance worker group (``n_gpus_per_node * nnodes == 1``); the
+    backend owns its own training / sampling / log-prob GPUs. Overrides
+    only ``init_model`` (rank-0 mesh registration; Arctic already owns
+    engines/servers), the compute/update methods (forward to the backend,
+    reusing V0 payload marshaling), and the weight-sync + checkpoint
+    hooks. ``to`` / ``set_loss_fn`` / ``reset`` / ``load_checkpoint`` are
+    no-ops (backend owns state).
+    """
+
+    def __init__(
+        self,
+        config: DictConfig,
+        role: str,
+        distillation_config: Optional[Any] = None,
+        *,
+        main_config: DictConfig,
+        backend_handle: dict,
+        **kwargs,
+    ):
+        # Skip ActorRolloutRefWorker.__init__: it reads megatron/veomni
+        # router-replay + profiler fields Arctic doesn't populate. Set the
+        # base state we need explicitly.
+        from verl.single_controller.base import Worker
+
+        Worker.__init__(self)
+        self.config = config
+        self.distillation_config = distillation_config
+        self.role = role
+        self.actor = None
+        self.ref = None
+        self.rollout = None
+        assert self.role in ["actor", "rollout", "ref", "actor_rollout", "actor_rollout_ref"]
+        self._is_actor = self.role in ["actor", "actor_rollout", "actor_rollout_ref"]
+        self._is_rollout = self.role in ["rollout", "actor_rollout", "actor_rollout_ref"]
+        self._is_ref = self.role in ["ref", "actor_rollout_ref"]
+        # Routing decisions happen inside the Arctic inference engine.
+        self.enable_routing_replay = False
+
+        DistProfilerExtension.__init__(
+            self, DistProfiler(rank=self.rank, config=None, tool_config=None)
+        )
+
+        # --- Arctic-specific setup -------------------------------------- #
+
+        self.main_config: DictConfig = main_config
+
+        # CONFIG maxes for the V1->V0 densifier; see ``_to_v0_padded_batch``.
+        self._config_max_prompt_len: int = int(self.main_config.data.max_prompt_length)
+        self._config_max_response_len: int = int(self.main_config.data.max_response_length)
+
+        backend_name = self.main_config.trainer.get("remote_backend")
+        if backend_name is None:
+            raise ValueError(
+                "ArcticV1ActorRolloutRefWorker requires main_config.trainer.remote_backend to be set. "
+                "Use the Hydra `remote_backend=arctic` group choice or set the field explicitly."
+            )
+
+        # Zorro fast path emits response-aligned model output; the forwarder
+        # shifts it back to "predict-next" before writing to TransferQueue so
+        # the pad->njt helper uses one uniform slice.
+        self.zorro_train_enable = bool(
+            OmegaConf.select(
+                self.main_config,
+                "remote_backend.train.zorro_train.enable",
+                default=False,
+            )
+        )
+
+        backend_cls = RemoteBackendRegistry.get(backend_name)
+        self.backend: RemoteBackend = backend_cls.from_config(self.main_config, handle=backend_handle)
+
+        if self._is_actor:
+            self.model_config: HFModelConfig = omega_conf_to_dataclass(self.config.model)
+            self.actor_config: ActorConfig = omega_conf_to_dataclass(self.config.actor)
+            self.actor_config.model_config = self.model_config
+
+            trust_remote_code = self.config.model.get("trust_remote_code", False)
+            self.tokenizer = hf_tokenizer(self.config.model.path, trust_remote_code=trust_remote_code)
+            if self.tokenizer.pad_token_id is None:
+                self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+            self.pad_token_id = self.tokenizer.pad_token_id
+
+            self.flops_counter = FlopsCounter(self.model_config.hf_config)
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        # Register mesh dispatch metadata for actor / ref / rollout. With the
+        # single-forwarder invariant (n_gpus_per_node * nnodes == 1) rank 0
+        # is the only rank; dp_rank=0 and is_collect=True mirror the V0 setup.
+        self._register_dispatch_collect_info("actor", dp_rank=self.rank, is_collect=True)
+        self._register_dispatch_collect_info("ref", dp_rank=self.rank, is_collect=True)
+        self._register_dispatch_collect_info("rollout", dp_rank=self.rank, is_collect=True)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def to(self, device, model=True, optimizer=True, grad=True):
+        return  # backend owns device residency
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def set_loss_fn(self, loss_fn):
+        return  # loss is owned by backend (or sent in-band per call)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def reset(self):
+        return  # backend owns engine state
+
+    # ------------------------------------------------------------------ #
+    # Core dispatched ops
+    # ------------------------------------------------------------------ #
+    # Reuse the V0 worker's `_run_log_prob` / `_run_update_actor` payload
+    # marshaling to keep the wire between forwarder and Arctic server
+    # byte-identical to V0. Only the dispatch decorators + method
+    # signatures change to satisfy the V1 base-class contract.
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="ref"))
+    @DistProfiler.annotate(color="olive", role="ref_compute_log_prob")
+    def compute_ref_log_prob(self, data: TensorDict) -> TensorDict:
+        data = _to_v0_padded_batch(
+            data,
+            pad_token_id=self.pad_token_id,
+            max_prompt_len=self._config_max_prompt_len,
+            max_response_len=self._config_max_response_len,
+        )
+        return _AsyncRunner.get().run(
+            _ArcticV0Worker._run_log_prob(self, data, ref=True, calculate_entropy=False)
+        )
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))
+    @DistProfiler.annotate(color="blue", role="actor_compute_log_prob")
+    def compute_log_prob(self, data: TensorDict) -> TensorDict:
+        data = _to_v0_padded_batch(
+            data,
+            pad_token_id=self.pad_token_id,
+            max_prompt_len=self._config_max_prompt_len,
+            max_response_len=self._config_max_response_len,
+        )
+        return _AsyncRunner.get().run(
+            _ArcticV0Worker._run_log_prob(self, data, ref=False, calculate_entropy=True)
+        )
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))
+    @DistProfiler.annotate(color="red", role="actor_update")
+    def update_actor(self, data: TensorDict) -> TensorDict:
+        data = _to_v0_padded_batch(
+            data,
+            pad_token_id=self.pad_token_id,
+            max_prompt_len=self._config_max_prompt_len,
+            max_response_len=self._config_max_response_len,
+        )
+        return _AsyncRunner.get().run(_ArcticV0Worker._run_update_actor(self, data))
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
+    def update_weights(self, global_steps: int = None, mode: str = "auto"):
+        # mode is ignored: CheckpointEngineManager only dispatches this on the
+        # 'remote_backend' short-circuit path, where the backend owns transfer.
+        # blocking=False mirrors the built-in ActorRolloutRefWorker.update_weights
+        # so CheckpointEngineManager can wrap the resulting ObjectRef in ray.get.
+        _AsyncRunner.get().run(self.backend.update_weights())
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
+    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
+        assert self._is_actor, "save_checkpoint only supported on actor role"
+        _AsyncRunner.get().run(self.backend.save_checkpoint())
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=False):
+        # Arctic reloads at driver startup via `create_arctic_rl_client`; the
+        # per-worker load path is a no-op. The trainer only calls this on
+        # `trainer.resume_mode != "disable"`, and only when a `global_step_*`
+        # dir exists; ignoring the call there is safe.
+        return
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def destroy(self):
+        if self.backend is not None:
+            _AsyncRunner.get().run(self.backend.destroy())
+            self.backend = None

--- a/arctic_platform/integrations/verl/v1/worker.py
+++ b/arctic_platform/integrations/verl/v1/worker.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Snowflake Inc.
+# Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/arctic_platform/integrations/verl/v1/worker.py
+++ b/arctic_platform/integrations/verl/v1/worker.py
@@ -25,18 +25,27 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from typing import Any, Awaitable, Optional, TypeVar
+from typing import Any
+from typing import Awaitable
+from typing import Optional
+from typing import TypeVar
 
 import torch
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
+from omegaconf import OmegaConf
 from tensordict import TensorDict
-from verl.remote_backend.base import RemoteBackend, RemoteBackendRegistry
-from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
+from verl.remote_backend.base import RemoteBackend
+from verl.remote_backend.base import RemoteBackendRegistry
+from verl.single_controller.base.decorator import Dispatch
+from verl.single_controller.base.decorator import make_nd_compute_dataproto_dispatch_fn
+from verl.single_controller.base.decorator import register
 from verl.utils import hf_tokenizer
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.flops_counter import FlopsCounter
-from verl.utils.profiler import DistProfiler, DistProfilerExtension
-from verl.workers.config import ActorConfig, HFModelConfig
+from verl.utils.profiler import DistProfiler
+from verl.utils.profiler import DistProfilerExtension
+from verl.workers.config import ActorConfig
+from verl.workers.config import HFModelConfig
 from verl.workers.engine_workers import ActorRolloutRefWorker
 
 # Eager: populates RemoteBackendRegistry in every Ray child process; the
@@ -190,6 +199,7 @@ def _to_v0_padded_batch(
 
     return out
 
+
 class ArcticV1ActorRolloutRefWorker(ActorRolloutRefWorker):
     """CPU-only V1 forwarder that drives an Arctic :class:`RemoteBackend`.
 
@@ -231,9 +241,7 @@ class ArcticV1ActorRolloutRefWorker(ActorRolloutRefWorker):
         # Routing decisions happen inside the Arctic inference engine.
         self.enable_routing_replay = False
 
-        DistProfilerExtension.__init__(
-            self, DistProfiler(rank=self.rank, config=None, tool_config=None)
-        )
+        DistProfilerExtension.__init__(self, DistProfiler(rank=self.rank, config=None, tool_config=None))
 
         # --- Arctic-specific setup -------------------------------------- #
 
@@ -319,9 +327,7 @@ class ArcticV1ActorRolloutRefWorker(ActorRolloutRefWorker):
             max_prompt_len=self._config_max_prompt_len,
             max_response_len=self._config_max_response_len,
         )
-        return _AsyncRunner.get().run(
-            _ArcticV0Worker._run_log_prob(self, data, ref=True, calculate_entropy=False)
-        )
+        return _AsyncRunner.get().run(_ArcticV0Worker._run_log_prob(self, data, ref=True, calculate_entropy=False))
 
     @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))
     @DistProfiler.annotate(color="blue", role="actor_compute_log_prob")
@@ -332,9 +338,7 @@ class ArcticV1ActorRolloutRefWorker(ActorRolloutRefWorker):
             max_prompt_len=self._config_max_prompt_len,
             max_response_len=self._config_max_response_len,
         )
-        return _AsyncRunner.get().run(
-            _ArcticV0Worker._run_log_prob(self, data, ref=False, calculate_entropy=True)
-        )
+        return _AsyncRunner.get().run(_ArcticV0Worker._run_log_prob(self, data, ref=False, calculate_entropy=True))
 
     @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))
     @DistProfiler.annotate(color="red", role="actor_update")

--- a/arctic_platform/rl/_cortex_dispatch.py
+++ b/arctic_platform/rl/_cortex_dispatch.py
@@ -1,0 +1,173 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Cortex dispatch shim for the legacy ``arctic_platform.rl`` API.
+
+Translates ``arctic_platform.rl.ArcticRLClientConfig`` (what SkyRL builds) into
+the unified ``arctic_platform.client.ArcticRLClientConfig`` with a
+``CortexConfig`` backend, then wraps ``ArcticRLClient`` and rewrites the two
+calls whose shapes diverge on Cortex:
+
+* ``fwd_bwd``: reshape ``{batch, meta, processing}`` -> Cortex's
+  ``{args, kwargs, context, processing}``.
+* ``fwd_no_grad``: return ``[B, T]`` zeros; Cortex has no ``/forward``.
+
+Cortex deployment settings live on ``CortexConfig``; env-var hydration is
+``CortexConfig.from_env()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from arctic_platform.integrations._cortex_shared import to_cortex_fwd_bwd_payload
+from arctic_platform.rl.config import ArcticRLClientConfig as _LegacyConfig
+
+__all__ = ["create_cortex_client"]
+
+
+def _to_unified_config(legacy: _LegacyConfig):
+    """Legacy ``arctic_platform.rl`` config -> nested unified client config.
+
+    Optimizer + gradient-clipping are merged into ``training.ds_config`` so
+    Cortex's ``to_cortex()`` sub-job builder can lift them; the legacy
+    ``training_config`` dict is otherwise opaque to Cortex.
+    """
+    from arctic_platform.client.config import ArcticRLClientConfig as U
+    from arctic_platform.client.config import CortexConfig
+    from arctic_platform.client.config import SamplingConfig
+    from arctic_platform.client.config import TrainingConfig
+
+    ds_config = dict(legacy.ds_config or {})
+    tc_in = dict(legacy.training_config or {})
+    if "optimizer" in tc_in and "optimizer" not in ds_config:
+        ds_config["optimizer"] = tc_in["optimizer"]
+
+    fields: dict[str, Any] = {
+        "model_name": legacy.model_name,
+        "seed": legacy.seed,
+        "training_gpus": legacy.training_gpus,
+        "sampling_gpus": legacy.sampling_gpus,
+        "log_prob_gpus": legacy.log_prob_gpus,
+        "job_ready_timeout": legacy.job_ready_timeout,
+        "backend": CortexConfig.from_env(),
+        "training": TrainingConfig(
+            ds_config=ds_config or None,
+            ds_worker_config=legacy.ds_worker_config or None,
+            checkpoint_path=legacy.checkpoint_path,
+            full_determinism=legacy.full_determinism,
+        ),
+        "sampling": SamplingConfig(
+            vllm=dict(legacy.vllm_config or {}),
+            arctic_inference_config=legacy.arctic_inference_config or None,
+        ),
+    }
+    for k in ("training_job_id", "sampling_job_id", "log_prob_job_id"):
+        v = getattr(legacy, k, None)
+        if v is not None:
+            fields[k] = v
+    return U(**fields)
+
+
+class _CortexClientShim:
+    """Async facade over ``ArcticRLClient`` for the legacy SkyRL adapter.
+
+    Everything unified-client-compatible is delegated via ``__getattr__``. Only
+    the two shape mismatches (``fwd_bwd`` payload reshape, ``fwd_no_grad`` zeros
+    stub) and the legacy-config-shaped ``reconnect_config()`` live here.
+    """
+
+    def __init__(self, legacy_config: _LegacyConfig) -> None:
+        from arctic_platform.client import ArcticRLClient
+
+        self._legacy_config = legacy_config
+        self._unified_config = _to_unified_config(legacy_config)
+        self._client = ArcticRLClient(self._unified_config)
+
+    @property
+    def config(self) -> _LegacyConfig:
+        return self._legacy_config
+
+    @property
+    def training_job_id(self) -> Any:
+        return self._client.jobs.training
+
+    @property
+    def sampling_job_id(self) -> Any:
+        return self._client.jobs.sampling
+
+    @property
+    def log_prob_job_id(self) -> Any:
+        return self._client.jobs.log_prob
+
+    def reconnect_config(self) -> _LegacyConfig:
+        # SkyRL passes this back into `create_arctic_rl_client` in a forwarder
+        # process; the shape must be the legacy config (not the unified one).
+        return self._legacy_config.model_copy(
+            update={
+                "training_job_id": self._client.jobs.training,
+                "sampling_job_id": self._client.jobs.sampling,
+                "log_prob_job_id": self._client.jobs.log_prob,
+            }
+        )
+
+    def get_server_state(self) -> Any:
+        return None  # Cortex has no in-process state
+
+    def shutdown(self):
+        # SkyRL calls this sync; verl awaits it. Inside a running loop return
+        # the coroutine; otherwise drive it to completion in a fresh loop so
+        # sync callers don't leak jobs.
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self._client.shutdown())
+            return None
+        return self._client.shutdown()
+
+    # Everything else on ArcticRLClient (generate, step, save_checkpoint,
+    # sync_weights, wake_inference, sleep_inference, reset_prefix_cache, ...)
+    # is exposed as-is. Cortex-specific behaviour lives in CortexTransport
+    # (wake/sleep -> no-op) and the unified client (colocate defaults False).
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+    async def fwd_bwd(self, batch: dict, **legacy_kwargs: Any) -> dict:
+        processing = legacy_kwargs.pop("processing", None)
+        legacy_kwargs.pop("router_replay", None)
+        return await self._client.fwd_bwd(
+            to_cortex_fwd_bwd_payload(
+                batch,
+                dp_size=int(self._unified_config.training_gpus or 1),
+                processing=processing,
+            )
+        )
+
+    async def fwd_no_grad(self, batch: dict, **_: Any) -> dict:
+        # Cortex has no /forward op. Return zero log-probs so SkyRL's
+        # approx_kl / clip_ratio display metrics still compute; the server-side
+        # GRPO loss restores π_old = π_new via ``old_log_probs = logprobs.detach()``.
+        # Only correct for single-epoch on-policy GRPO without KL — see
+        # docs/cortex-integration.md.
+        import torch
+
+        b_data = batch.get("batch") if isinstance(batch, dict) else None
+        if not isinstance(b_data, dict):
+            b_data = batch if isinstance(batch, dict) else {}
+        ids = b_data.get("input_ids")
+        b, t = (int(ids.shape[0]), int(ids.shape[-1])) if torch.is_tensor(ids) else (1, 1)
+        z = torch.zeros((b, max(t, 1)), dtype=torch.float32)
+        return {"batch": {"logprobs": z, "log_probs": z, "entropy": z, "entropies": z}}
+
+    async def save_weights(self, path: str) -> dict:
+        # SkyRL's disk-based inference-side weight reload. Cortex sub-jobs
+        # don't share local disk; silent no-op would leave sampling on stale
+        # weights forever.
+        raise NotImplementedError(
+            "Cortex has no disk-based weight reload; use sync_weights() (NCCL) "
+            f"or save_checkpoint(). (save_weights(path={path!r}) was called.)"
+        )
+
+
+def create_cortex_client(config: _LegacyConfig) -> _CortexClientShim:
+    return _CortexClientShim(config)

--- a/arctic_platform/rl/client.py
+++ b/arctic_platform/rl/client.py
@@ -28,20 +28,25 @@ from __future__ import annotations
 import logging
 
 from arctic_platform.rl.config import ArcticRLClientConfig
-from arctic_platform.rl.http_client import ArcticRLHTTPClient
-from arctic_platform.rl.ray_client import ArcticRLRayClient
-
-# from arctic_platform.rl.ray_server import ArcticRLRayServerState
 from arctic_platform.rl.server import ArcticRLServerState
 
 logger = logging.getLogger(__name__)
 
 
 def create_arctic_rl_client(config: ArcticRLClientConfig, arctic_rl_server_state: ArcticRLServerState = None):
+    # Backends are imported lazily so a CPU-only Cortex driver doesn't pay the
+    # http_client / ray_client import cost.
+    if config.backend == "cortex":
+        from arctic_platform.rl._cortex_dispatch import create_cortex_client
+
+        return create_cortex_client(config)
+
     if config.comm_protocol == "http":
+        from arctic_platform.rl.http_client import ArcticRLHTTPClient
+
         return ArcticRLHTTPClient(config)
-    elif config.comm_protocol == "ray":
-        # assert arctic_rl_server_state is not None, "arctic_rl_server_state is required for comm_protocol: ray"
+    if config.comm_protocol == "ray":
+        from arctic_platform.rl.ray_client import ArcticRLRayClient
+
         return ArcticRLRayClient(config, arctic_rl_server_state)
-    else:
-        raise ValueError(f"Invalid communication protocol: {config.comm_protocol}")
+    raise ValueError(f"Invalid communication protocol: {config.comm_protocol}")

--- a/arctic_platform/rl/config.py
+++ b/arctic_platform/rl/config.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import os
+from typing import Any
 from typing import Literal
 from typing import Optional
 
@@ -26,7 +28,7 @@ from pydantic import model_validator
 
 
 class ArcticRLClientConfig(BaseModel):
-    backend: Literal["local", "dss-platform"] = "local"
+    backend: Literal["local", "dss-platform", "cortex"] = "local"
     comm_protocol: Literal["http", "ray"] = "http"
     checkpoint_path: Optional[str] = None
 
@@ -117,6 +119,23 @@ class ArcticRLClientConfig(BaseModel):
     sampling_job_id: Optional[int] = Field(default=None, exclude=True)
     log_prob_job_id: Optional[int] = Field(default=None, exclude=True)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _backend_from_env(cls, data: Any) -> Any:
+        """Let ``ARCTIC_BACKEND=cortex`` promote SkyRL's baked-in ``backend="local"``.
+
+        SkyRL hard-codes ``backend="local"``; treating that as unset lets a
+        shell-level ``ARCTIC_BACKEND=cortex`` flip routing without patching
+        SkyRL. Any other explicit backend still wins.
+        """
+        if not isinstance(data, dict):
+            return data
+        if os.environ.get("ARCTIC_BACKEND", "").strip().lower() != "cortex":
+            return data
+        if data.get("backend", "local") == "local":
+            data = {**data, "backend": "cortex"}
+        return data
+
     @model_validator(mode="after")
     def _derive_host_port(self) -> "ArcticRLClientConfig":
         """Derive host/port from comm_protocol unless explicitly provided.
@@ -126,6 +145,8 @@ class ArcticRLClientConfig(BaseModel):
         the driver node by IP rather than "localhost". Values passed explicitly
         by the caller are left untouched (e.g. reconnecting to a known server).
         """
+        if self.backend == "cortex":
+            return self  # no local server; host/port live on CortexConfig
         # Lazy import to avoid pulling ray in at config import time.
         from arctic_platform.rl.ray_cluster import primary_ip
 

--- a/docs/cortex-integration.md
+++ b/docs/cortex-integration.md
@@ -1,0 +1,67 @@
+# Cortex-training as an Arctic-Platform backend
+
+Run SkyRL or verl RL recipes against Cortex-training GPUs without changing
+either framework. The driver is CPU-only; every GPU op (training
+fwd/bwd/step, sampling generate, weight-sync) is dispatched to Cortex
+sub-jobs over SnowAPI.
+
+## Supported training regime
+
+Cortex sub-jobs expose training + sampling + weight-sync but no `/forward`
+sub-job, no disk-shared weight reload, and no colocation lifecycle. That
+constrains what recipes work correctly on this backend:
+
+* **Single-epoch on-policy GRPO only.** `π_old ≡ π_new` is restored by the
+  server-side GRPO loss defaulting `old_log_probs = logprobs.detach()` when
+  `context.old_log_probs_shifted` is absent. Multi-epoch PPO
+  (`ppo_epochs > 1`) needs the rollout-time snapshot and will raise from the
+  verl adapter.
+* **No KL-to-reference.** `use_kl_loss=True` or `use_kl_in_reward=True`
+  needs real ref log-probs; the adapter raises. Disable both, or run on the
+  on-prem backend for KL-anchored recipes.
+* **Weight sync via NCCL only.** `save_weights` (SkyRL's disk-based reload)
+  raises `NotImplementedError`; use `sync_weights()` or `save_checkpoint()`.
+* **`wake_*` / `sleep_*` are no-ops.** Cortex sub-jobs are always awake;
+  the transport short-circuits these ops.
+
+## What's provided
+
+* **Unified client** —
+  [`arctic_platform.client.ArcticRLClient`](../arctic_platform/client/client.py)
+  routes to `CortexTransport` whenever `backend` is a `CortexConfig`.
+  `CortexConfig.from_env()` hydrates from `ARCTIC_CORTEX_*` env vars —
+  explicit constructor args always win.
+* **Legacy shim** —
+  [`arctic_platform.rl._cortex_dispatch`](../arctic_platform/rl/_cortex_dispatch.py)
+  wraps the unified client behind the legacy `arctic_platform.rl` surface
+  so SkyRL, which still builds `arctic_platform.rl.ArcticRLClientConfig`,
+  routes to Cortex. That legacy config has a `_backend_from_env` validator
+  that flips `backend="local"` → `"cortex"` when `ARCTIC_BACKEND=cortex`.
+* **verl adapter** —
+  [`arctic_platform.integrations.verl.adapter`](../arctic_platform/integrations/verl/adapter.py)
+  reads `ARCTIC_BACKEND=cortex` at one call-site and swaps its default
+  `OnPremConfig` for `CortexConfig.from_env()`. verl's YAML has no backend
+  discriminator field, so this env knob is the only way to route without
+  patching verl itself.
+* **SkyRL driver shim** —
+  [`arctic_platform.integrations.skyrl`](../arctic_platform/integrations/skyrl/__init__.py)
+  provides `install_cortex_driver_shims()` to patch out SkyRL's
+  `peer_access_supported` probe (hangs a CPU-only driver). Invoked
+  automatically by `python -m arctic_platform.integrations.skyrl`.
+* **Recipes** —
+  [`recipes/rl/skyrl/simple_gsm8k_cortex/`](../recipes/rl/skyrl/simple_gsm8k_cortex/README.md)
+  (SkyRL GRPO on GSM8K) and
+  [`arctic_platform/integrations/verl/examples/README-cortex.md`](../arctic_platform/integrations/verl/examples/README-cortex.md)
+  (verl GRPO on GSM8K).
+
+## Env vars
+
+| Env var | Default | Description |
+|---|---|---|
+| `ARCTIC_BACKEND` | *(unset)* | Set to `cortex` to route through Cortex. Read by the legacy `ArcticRLClientConfig` validator (SkyRL path) and by the verl adapter's `_create_rl_client_config` (verl path). |
+| `ARCTIC_CORTEX_HOST` | *(required for PAT auth)* | Snowflake host, e.g. `<account>.<region>.snowflakecomputing.com`. |
+| `ARCTIC_CORTEX_BASE_URL` | *(optional)* | Direct/mock GS URL for dev; bypasses PAT auth (mutually exclusive with `_HOST`). |
+| `CORTEX_PAT` | *(required for PAT auth)* | Snowflake Programmatic Access Token. Env var name overridable via `ARCTIC_CORTEX_PAT_ENV_VAR`. |
+| `ARCTIC_CORTEX_DATABASE` | *(required for PAT auth)* | Snowflake database. |
+| `ARCTIC_CORTEX_SCHEMA` | *(required for PAT auth)* | Snowflake schema. |
+| `ARCTIC_CORTEX_ENDPOINT` | `cortex-training` | SnowAPI endpoint name. |

--- a/recipes/rl/skyrl/simple_gsm8k_cortex/README.md
+++ b/recipes/rl/skyrl/simple_gsm8k_cortex/README.md
@@ -1,0 +1,55 @@
+# Simple — GRPO on GSM8K, Cortex backend
+
+Same recipe as [`simple_gsm8k/`](../simple_gsm8k/), with training + sampling
+dispatched to Cortex-training sub-jobs instead of a local Ray + vLLM stack.
+The SkyRL driver runs on a CPU-only laptop / VM; Cortex owns the GPUs.
+
+| Knob | Value |
+| --- | --- |
+| Model | `Qwen/Qwen3-0.6B` |
+| Reward | SkyRL built-in `gsm8k` env (exact match on `#### <number>`) |
+| Trainer | Cortex training sub-job (server-side GRPO loss) |
+| Sampling | Cortex sampling sub-job (vLLM inside Cortex) |
+| Sequence lengths | prompt 512, response 1024 |
+| GPUs | Cortex allocates; driver is CPU-only |
+
+## 1. Install
+
+`pip install arctic-platform[cortex]` on the driver — no local GPU deps.
+SkyRL still needs to be cloned at the pinned commit (see
+[`../README.md`](../README.md)) with `SKYRL_HOME` exported. The Arctic RL
+× SkyRL integration code lives under `$SKYRL_HOME/integrations/arctic_rl/`.
+
+## 2. Set Cortex env
+
+```bash
+export ARCTIC_BACKEND=cortex
+export ARCTIC_CORTEX_HOST=<account>.<region>.snowflakecomputing.com
+export ARCTIC_CORTEX_DATABASE=<db>
+export ARCTIC_CORTEX_SCHEMA=<schema>
+export CORTEX_PAT=<your PAT>
+```
+
+`ArcticRLClientConfig`'s `_backend_from_env` validator promotes SkyRL's
+baked-in `backend="local"` to `"cortex"` when `ARCTIC_BACKEND=cortex`;
+`CortexConfig.from_env()` reads the rest.
+
+## 3. Run
+
+```bash
+python download_data.py
+./run_qwen3_0.6b_gsm8k_grpo_cortex.sh
+```
+
+The launcher uses `python -m arctic_platform.integrations.skyrl` instead
+of `python -m skyrl.train.entrypoints.main_base` so the driver-side
+`peer_access_supported` shim is installed before SkyRL's Ray probe runs.
+
+## Notes
+
+* Only single-epoch on-policy GRPO is supported (`use_kl_loss=false`,
+  `use_kl_in_reward=false`, `ppo_epochs=1`); see
+  [`docs/cortex-integration.md`](../../../../docs/cortex-integration.md)
+  for why.
+* Weight sync is NCCL between Cortex sub-jobs. The driver never touches
+  weights.

--- a/recipes/rl/skyrl/simple_gsm8k_cortex/run_qwen3_0.6b_gsm8k_grpo_cortex.sh
+++ b/recipes/rl/skyrl/simple_gsm8k_cortex/run_qwen3_0.6b_gsm8k_grpo_cortex.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# GRPO training for Qwen3-0.6B on GSM8K with the Arctic RL Cortex backend.
+# Cortex sub-jobs own training + sampling; the SkyRL driver is CPU-only.
+#
+# Pre-reqs (see README.md):
+#   1. pip install arctic-platform[cortex]
+#   2. SkyRL cloned at the pinned commit with SKYRL_HOME exported.
+#   3. ARCTIC_BACKEND=cortex + ARCTIC_CORTEX_* env vars set.
+#   4. Data: `python download_data.py` -> $DATA_DIR/{train,validation}.parquet.
+
+set -euo pipefail
+
+if [[ -z "${SKYRL_HOME:-}" || ! -d "${SKYRL_HOME}/integrations/arctic_rl" ]]; then
+    echo "ERROR: SKYRL_HOME is unset or doesn't contain integrations/arctic_rl/."
+    exit 1
+fi
+if [[ "${ARCTIC_BACKEND:-}" != "cortex" ]]; then
+    echo "ERROR: ARCTIC_BACKEND=cortex is required. See README.md."
+    exit 1
+fi
+
+export PYTHONPATH="${SKYRL_HOME}:${PYTHONPATH:-}"
+export PYTHONUNBUFFERED=1
+export HYDRA_FULL_ERROR=1
+export RAY_DEDUP_LOGS=0
+export HF_HOME="${HF_HOME:-${HOME}/.cache/huggingface}"
+
+# Cortex owns the GPUs; the driver has none. SkyRL's colocated placement
+# groups would deadlock on a CPU driver.
+NGPU_PER_NODE=1  # target Cortex GPU count for training
+NUM_NODES=1
+TP_SIZE=1
+NUM_ENGINES=1
+
+TRAIN_BSZ=32
+MINI_BSZ=4
+N_SAMPLES=4
+PROMPT_LEN=512
+RESPONSE_LEN=1024
+LR=1e-6
+TOTAL_EPOCHS=1
+EVAL_INTERVAL=10
+
+LOGGER="${LOGGER:-console}"
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+MODEL_SHORT="$(basename "${MODEL}")"
+EXPERIMENT_NAME="gsm8k_grpo_${MODEL_SHORT}_cortex"
+
+DATA_DIR="${DATA_DIR:-${HOME}/data/gsm8k}"
+TRAIN_FILES="${DATA_DIR}/train.parquet"
+VAL_FILES="${DATA_DIR}/validation.parquet"
+
+CKPT_DIR="${CKPT_DIR:-${HOME}/checkpoints/${EXPERIMENT_NAME}}"
+mkdir -p "${CKPT_DIR}"
+
+# Launch via arctic_platform.integrations.skyrl so the driver-side
+# peer_access_supported shim is installed before SkyRL's Ray probe.
+python -m arctic_platform.integrations.skyrl \
+    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+    trainer.arctic_rl.colocate=false \
+    trainer.algorithm.advantage_estimator=grpo \
+    trainer.policy.model.path="${MODEL}" \
+    data.train_data="['${TRAIN_FILES}']" \
+    data.val_data="['${VAL_FILES}']" \
+    trainer.placement.colocate_all=false \
+    trainer.placement.policy_num_nodes=${NUM_NODES} \
+    trainer.placement.policy_num_gpus_per_node=${NGPU_PER_NODE} \
+    generator.inference_engine.backend=vllm \
+    generator.inference_engine.num_engines=${NUM_ENGINES} \
+    generator.inference_engine.tensor_parallel_size=${TP_SIZE} \
+    generator.inference_engine.run_engines_locally=false \
+    generator.inference_engine.weight_sync_backend=nccl \
+    generator.inference_engine.async_engine=true \
+    generator.batched=true \
+    generator.n_samples_per_prompt=${N_SAMPLES} \
+    environment.env_class=gsm8k \
+    trainer.epochs=${TOTAL_EPOCHS} \
+    trainer.train_batch_size=${TRAIN_BSZ} \
+    trainer.policy_mini_batch_size=${MINI_BSZ} \
+    trainer.max_prompt_length=${PROMPT_LEN} \
+    generator.sampling_params.max_generate_length=${RESPONSE_LEN} \
+    trainer.eval_batch_size=256 \
+    trainer.eval_before_train=false \
+    trainer.eval_interval=${EVAL_INTERVAL} \
+    trainer.update_epochs_per_batch=1 \
+    trainer.policy.optimizer_config.lr=${LR} \
+    trainer.algorithm.use_kl_loss=false \
+    trainer.algorithm.use_kl_in_reward=false \
+    trainer.logger="${LOGGER}" \
+    trainer.project_name=arctic_rl_gsm8k_cortex \
+    trainer.run_name="${EXPERIMENT_NAME}" \
+    trainer.resume_mode=null \
+    trainer.log_path="${CKPT_DIR}/logs" \
+    trainer.ckpt_path="${CKPT_DIR}/ckpt" \
+    "$@" 2>&1 | tee "${CKPT_DIR}/${EXPERIMENT_NAME}.log"

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -390,3 +390,149 @@ class TestWeightSyncStrategyInit:
         payload = cfg.to_onprem("sampling")
         assert "cuda_ipc" not in payload
         assert "low_memory" not in payload
+
+
+@pytest.fixture(autouse=True)
+def _isolate_arctic_env(monkeypatch):
+    """Clear ARCTIC_BACKEND / ARCTIC_CORTEX_* before each test; a leaked env from
+    a parallel process would flip config promotion under our feet."""
+    import os
+
+    for k in list(os.environ):
+        if k.startswith("ARCTIC_BACKEND") or k.startswith("ARCTIC_CORTEX_"):
+            monkeypatch.delenv(k, raising=False)
+
+
+class TestCortexConfigFromEnv:
+    """``CortexConfig.from_env`` reads ``ARCTIC_CORTEX_*`` and lets explicit
+    kwargs win. This is the one call-site framework adapters use to flip to
+    Cortex from a shell-level env."""
+
+    def test_base_url_only_bypasses_pat(self, monkeypatch):
+        monkeypatch.setenv("ARCTIC_CORTEX_BASE_URL", "http://mock")
+        from arctic_platform.client import CortexConfig
+
+        cfg = CortexConfig.from_env()
+        assert cfg.base_url == "http://mock"
+        assert cfg.host is None
+
+    def test_host_path_requires_db_schema_pat(self, monkeypatch):
+        monkeypatch.setenv("ARCTIC_CORTEX_HOST", "acct.snowflakecomputing.com")
+        monkeypatch.setenv("ARCTIC_CORTEX_DATABASE", "db")
+        monkeypatch.setenv("ARCTIC_CORTEX_SCHEMA", "sch")
+        monkeypatch.setenv("CORTEX_PAT", "pat-value")
+        from arctic_platform.client import CortexConfig
+
+        cfg = CortexConfig.from_env()
+        assert cfg.host == "acct.snowflakecomputing.com"
+        assert cfg.database == "db"
+        assert cfg.schema_ == "sch"
+        assert cfg.resolve_pat() == "pat-value"
+
+    def test_explicit_override_wins(self, monkeypatch):
+        monkeypatch.setenv("ARCTIC_CORTEX_BASE_URL", "http://env")
+        from arctic_platform.client import CortexConfig
+
+        cfg = CortexConfig.from_env(base_url="http://explicit")
+        assert cfg.base_url == "http://explicit"
+
+
+class TestUnifiedConfigDoesNotReadEnv:
+    """``ArcticRLClientConfig`` does not swap ``backend`` from env vars.
+    ``ARCTIC_BACKEND`` is only honored at framework adapter call-sites (verl's
+    ``_create_rl_client_config``, the legacy ``arctic_platform.rl`` validator)."""
+
+    def test_no_env_promotion_on_unified_config(self, monkeypatch):
+        monkeypatch.setenv("ARCTIC_BACKEND", "cortex")
+        cfg = ArcticRLClientConfig(model_name="m", backend=OnPremConfig(), training_gpus=1)
+        assert cfg.backend.type == "onprem"
+
+
+class TestCortexTransportNoopOps:
+    """``wake_*`` / ``sleep_*`` short-circuit in the Cortex transport so the
+    shim doesn't have to wrap each call — including the ones ``sync_weights``
+    invokes internally."""
+
+    def test_call_returns_empty_for_noop_op(self, monkeypatch):
+        monkeypatch.setenv("ARCTIC_CORTEX_BASE_URL", "http://mock")
+        from arctic_platform.client import CortexConfig
+        from arctic_platform.client.transport import Request
+        from arctic_platform.client.transports.cortex import CortexTransport
+
+        cfg = ArcticRLClientConfig(
+            model_name="m", backend=CortexConfig.from_env(), training_gpus=1, sampling_gpus=1
+        )
+        t = CortexTransport(cfg)
+        # Would normally raise NotImplementedError on the transport; the noop
+        # short-circuit means the shim never has to guard these calls.
+        assert t.call(Request("wake-inference", 1, None)) == {}
+        assert t.call(Request("sleep-training", 1, {"mode": "all"})) == {}
+
+
+class TestLegacyBackendEnvPromotion:
+    """Legacy ``arctic_platform.rl.config.ArcticRLClientConfig`` (the shape
+    SkyRL builds) promotes ``backend="local"`` -> ``"cortex"`` when
+    ``ARCTIC_BACKEND=cortex`` is set. Explicit non-default backends still win.
+    """
+
+    def test_local_default_gets_promoted(self, monkeypatch):
+        monkeypatch.setenv("ARCTIC_BACKEND", "cortex")
+        from arctic_platform.rl.config import ArcticRLClientConfig as Legacy
+
+        cfg = Legacy(model_name="m", backend="local", training_gpus=1)
+        assert cfg.backend == "cortex"
+
+    def test_explicit_non_default_backend_wins(self, monkeypatch):
+        monkeypatch.setenv("ARCTIC_BACKEND", "cortex")
+        from arctic_platform.rl.config import ArcticRLClientConfig as Legacy
+
+        cfg = Legacy(model_name="m", backend="dss-platform", training_gpus=1)
+        assert cfg.backend == "dss-platform"
+
+
+class TestCortexSharedHelper:
+    """``to_cortex_fwd_bwd_payload`` lives under ``arctic_platform.integrations``
+    so the SkyRL shim and the verl adapter share the reshape rule."""
+
+    def test_integration_path_importable(self):
+        from arctic_platform.integrations._cortex_shared import to_cortex_fwd_bwd_payload
+
+        assert callable(to_cortex_fwd_bwd_payload)
+
+    def test_reshape_omits_old_log_probs(self):
+        import torch
+
+        from arctic_platform.integrations._cortex_shared import to_cortex_fwd_bwd_payload
+
+        ids = torch.zeros((2, 10), dtype=torch.int64)
+        out = to_cortex_fwd_bwd_payload(
+            {"batch": {"input_ids": ids, "advantages": torch.zeros((2, 4))}, "meta": {"prompt_len": 6}},
+            dp_size=1,
+        )
+        assert "args" in out and "kwargs" in out and "context" in out
+        assert out["kwargs"]["prompt_length"] == 6
+        assert out["kwargs"]["response_length"] == 4
+        assert "old_log_probs_shifted" not in out["context"]
+
+
+class TestCortexShimSaveWeightsFailsLoud:
+    """``save_weights`` raises ``NotImplementedError`` — Cortex sub-jobs don't
+    share disk, so a silent no-op would leave sampling on stale weights."""
+
+    def test_save_weights_raises(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.setenv("ARCTIC_CORTEX_BASE_URL", "http://mock")
+        from arctic_platform.rl._cortex_dispatch import _CortexClientShim
+        from arctic_platform.rl.config import ArcticRLClientConfig as Legacy
+
+        legacy = Legacy(model_name="m", backend="cortex", training_gpus=1, sampling_gpus=1)
+
+        # Skip the real ArcticRLClient constructor (needs live transport init).
+        shim = _CortexClientShim.__new__(_CortexClientShim)
+        shim._legacy_config = legacy
+        shim._unified_config = None
+        shim._client = None
+
+        with pytest.raises(NotImplementedError, match="Cortex has no disk-based"):
+            asyncio.run(shim.save_weights("/tmp/w"))


### PR DESCRIPTION
# V1 (verl-project/verl main) plugin shims for the Arctic verl integration

## Summary

Adds V1-compatible wrappers so a single plugin install works against both
the Snowflake fork (V0, `Snowflake-AI-Research/verl@release/v0.7.1`) and
upstream (V1, `verl-project/verl@main`). V0 modules are untouched;
`register.py` auto-detects which verl is installed based on whether
`verl.trainer.ppo.v1.trainer_remote_backend` imports.

Companion verl-core PR (adds the V1 seam this plugin plugs into): https://github.com/verl-project/verl/pull/7102
after the verl PR is opened._

## New files

- **`arctic_platform/integrations/verl/v1/worker.py`**
  `ArcticV1ActorRolloutRefWorker`, subclass of verl V1's
  `ActorRolloutRefWorker`. Highlights:
  - Skips base-class megatron/veomni init paths Arctic doesn't populate.
  - `_AsyncRunner` drives the async backend RPCs on a persistent
    background asyncio loop (compensates for V1's `@register` decorator
    stack dropping coroutine-function status).
  - `_to_v0_padded_batch` densifies V1's nested-jagged batches to V0's
    dense-padded layout using **config** `max_prompt_length` /
    `max_response_length` (not batch-local maxes) so ZoRRo's
    `Qwen3ModelOncePatcher` can derive the correct prompt/response split
    (`prompt_len = input_ids.shape[1] - max_response_length` on every
    forward — batch-local padding silently corrupts this).
- **`arctic_platform/integrations/verl/v1/replica.py`** — `ArcticV1Replica`
  adapts the V0 `ArcticReplica` constructor to V1's
  `LLMServerManager.replica_init_kwargs` forwarding and points to
  `ArcticV1LLMServer`.
- **`arctic_platform/integrations/verl/v1/server.py`** —
  `ArcticV1LLMServer` publishes
  `TokenOutput.extra_fields["global_steps"]` (V1's real field; V0 used
  `extra_info` which pydantic silently drops) and adds a
  `set_global_steps` hook so `CheckpointEngineManager` can fan the
  current policy version out to servers after each weight sync.
- **`arctic_platform/integrations/verl/v1/examples/run_gsm8k_grpo_arl_v1.sh`**
  V1-recipe smoke launcher.

## Updated files

- **`arctic_platform/integrations/verl/register.py`** — auto-detects V0 vs
  V1 by trying to `import verl.trainer.ppo.v1.trainer_remote_backend`.

## Validation

BIRD text-to-SQL, Qwen3-8B, 8× H200, recipe-aligned with
`recipe/skyrl-integration/recipes/rl/verl/txt2sql/run_qwen3_32b_bird_grpo_arl_zorro_yes.sh`,
5 steps each.

| Metric                | Stock V1 (vLLM+FSDP2) | Arctic V1 + ZoRRo (this PR) | Speedup |
| :-------------------- | --------------------: | --------------------------: | ------: |
| `timing_s/update_actor` |               380.9 |                       166.0 | **2.30×** |
| `timing_s/gen`          |               200.6 |                       204.7 |   0.98× |
| `timing_s/step` (total) |               731.4 |                       438.3 | **1.67×** |

Convergence: `critic/score/mean` matches step-over-step between stock and
Arctic paths (step 1: 0.635 vs 0.635; step 5: 0.63 vs 0.63).

## Known follow-up (not in this PR)

Inference (`gen`) is currently at parity, not ahead. The pre-plugin
recipe forced `actor_rollout_ref.rollout.enforce_eager=True`, which sets
`cudagraph_mode=NONE` and lets FCA fire (all 8 inference workers log
`Forest Cascade Attention ENABLED (... cudagraph_mode=NONE)`); with that
knob flipped, `gen` drops to ~191 s (~7% inference speedup on 8B BIRD).
The current plugin recipe (`recipe/skyrl-integration/.../run_qwen3_32b_bird_grpo_arl_zorro_yes.sh`)
uses `enforce_eager=False`, and vLLM 0.18.0's new default
`cudagraph_mode=FULL_AND_PIECEWISE` silently disables FCA there. Fixing
this cleanly means having `parse_arctic_inference_rollout` in
`arctic_platform/rl/utils/server_models.py` override
`compilation_config.cudagraph_mode=PIECEWISE` when
`zorro_inference.enable=True` and `enforce_eager=False`. Tracking as a
separate PR.


