### PR TITLE
feat(client): unified ArcticRLClient + on-prem Ray transport

### DIFF
--- a/arctic_platform/client/UNIFICATION_NOTES.md
+++ b/arctic_platform/client/UNIFICATION_NOTES.md
@@ -24,3 +24,18 @@ wrapper (typed async ops) that snapshots workers at construction, so the wrapper
 is built lazily after jobs are initialized. `_rpc` resolves `op -> method` and
 forwards `(job_id, body)` unchanged, matching the server's uniform
 `op(job_id, body) -> dict` surface.
+
+## Not yet in unified client (future work)
+Ops present in `arctic_platform/rl/*_client.py` but not yet on `ArcticRLClient`.
+Not on the immediate critical path, but they **block deleting the async
+clients**, so parity here is a prerequisite for retiring `rl/*_client.py`:
+- `sleep_inference` / `wake_inference`
+- `sleep_training` / `wake_training`
+- `sleep_log_prob` / `wake_log_prob`
+- `empty_training_cache`
+- `weight_norm`
+- `save_weights` (disk-based weight reload): a weight-sync variant that reloads
+  the sampling engine from a checkpoint on disk. Deliberately omitted for now —
+  server-side reload is unimplemented on-prem (the old ray client raised
+  `NotImplementedError`; the http client was a warn-on-error stub). Add back once
+  a backend actually supports it.

--- a/arctic_platform/client/UNIFICATION_NOTES.md
+++ b/arctic_platform/client/UNIFICATION_NOTES.md
@@ -1,0 +1,26 @@
+# RL client unification notes
+
+Goal: one `ArcticRLClient` frontend where **every backend accepts identical
+per-op args/kwargs and returns identically-shaped responses**, so each transport
+is a dumb forwarder of `Request(op, job_id, body)` with no per-op rewiring.
+
+This package is the target design. The op *surface* (names, args, canonical
+body, which job each op targets, response contract) is defined once in
+`client.py`; a transport owns only job identity + wire mechanics.
+
+## Design in place (this package)
+- `Transport` ABC + `JobHandles` + `Request` (single op vocabulary in `client.py`).
+- `OnPremTransport` base: job creation, ordering, payload building, and a uniform
+  `call` that posts/dispatches the op against its target job. Concrete transports
+  implement only the delivery primitives (`_start`, `_rpc`, `_destroy`,
+  `_wait_running`).
+- `JOB_CREATE_ORDER` + `ArcticRLClientConfig.gpus_for()` centralize GPU-gating and
+  creation order so transports no longer hand-roll them.
+
+## On-prem Ray transport
+`RayTransport` makes in-process Ray actor calls — no HTTP, no serialization. The
+server splits into a `state` actor (job creation) and an `ArcticRLRayServer`
+wrapper (typed async ops) that snapshots workers at construction, so the wrapper
+is built lazily after jobs are initialized. `_rpc` resolves `op -> method` and
+forwards `(job_id, body)` unchanged, matching the server's uniform
+`op(job_id, body) -> dict` surface.

--- a/arctic_platform/client/__init__.py
+++ b/arctic_platform/client/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from arctic_platform.client.client import ArcticRLClient
+from arctic_platform.client.client import create_arctic_rl_client
+from arctic_platform.client.client import make_transport
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.transport import JobHandles
+from arctic_platform.client.transport import Request
+from arctic_platform.client.transport import Transport
+
+__all__ = [
+    "ArcticRLClient",
+    "ArcticRLClientConfig",
+    "JobHandles",
+    "Request",
+    "Transport",
+    "create_arctic_rl_client",
+    "make_transport",
+]

--- a/arctic_platform/client/__init__.py
+++ b/arctic_platform/client/__init__.py
@@ -16,11 +16,14 @@ from arctic_platform.client.client import ArcticRLClient
 from arctic_platform.client.client import create_arctic_rl_client
 from arctic_platform.client.client import make_transport
 from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.transport import OPS
 from arctic_platform.client.transport import JobHandles
 from arctic_platform.client.transport import Request
 from arctic_platform.client.transport import Transport
+from arctic_platform.client.transport import unresolved_ops
 
 __all__ = [
+    "OPS",
     "ArcticRLClient",
     "ArcticRLClientConfig",
     "JobHandles",
@@ -28,4 +31,5 @@ __all__ = [
     "Transport",
     "create_arctic_rl_client",
     "make_transport",
+    "unresolved_ops",
 ]

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -70,11 +70,10 @@ class ArcticRLClient:
         return self.transport.call(Request("step", self.jobs.require("training"), {"learning_rate": learning_rate}))
 
     def save_checkpoint(self, stage_info: dict | None = None, path: str | None = None) -> dict:
+        # `path` is this call's destination; when None the server uses the job's
+        # config.checkpoint_path. An explicit `path` here wins over the config.
         body = {"stage_info": stage_info, "path": path}
         return self.transport.call(Request("save-checkpoint", self.jobs.require("training"), body))
-
-    def save_weights(self, path: str) -> dict:
-        return self.transport.call(Request("save-weights", self.jobs.require("sampling"), {"checkpoint_path": path}))
 
     # ── sampling / log-prob ──────────────────────────────────────────────
     def generate(self, prompts: list, sampling_params: dict | None = None, routing_key: Any = None) -> list:

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -1,0 +1,121 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The single frontend + the single definition of the op API.
+
+Every op lives here exactly once: friendly signature -> canonical `Request`
+(op name, target job, user-data body). Job ids and wire mechanics belong to the
+transport, so the client never mentions them. Switching deployment == changing
+`config.backend`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.transport import Request
+from arctic_platform.client.transport import Transport
+
+
+def make_transport(config: ArcticRLClientConfig) -> Transport:
+    from arctic_platform.client.transports.onprem_ray import RayTransport
+
+    return RayTransport(config)
+
+
+class ArcticRLClient:
+    def __init__(self, config: ArcticRLClientConfig) -> None:
+        self.config = config
+        self.transport = make_transport(config)
+        self.jobs = self.transport.initialize()
+
+    # ── training ─────────────────────────────────────────────────────────
+    def fwd_bwd(self, batch: dict, processing: dict | None = None, router_replay: Any = None) -> dict:
+        # NOTE: the call *signature* is unified across backends, but `batch`'s
+        # *content* is not: Cortex expects an RPC-style
+        # {"args": [...], "kwargs": {...}} that the server tokenizes, while on-prem
+        # expects a pre-tokenized verl-GRPO {"batch", "meta", "processing"}. The
+        # client forwards `batch` verbatim, so today the caller must still match
+        # the target backend's data contract.
+        # TODO(unify-backends): converge the server-side fwd_bwd on ONE batch
+        # contract (ideally Cortex's) so this frontend is truly backend-agnostic
+        # and callers stop branching on backend. Until then `processing` is folded
+        # into the body here, which is why callers can leave it inside `batch`.
+        body = dict(batch)
+        body.update({k: v for k, v in (("processing", processing), ("router_replay", router_replay)) if v is not None})
+        return self.transport.call(Request("fwd-bwd", self.jobs.require("training"), body, binary=True))
+
+    def fwd_no_grad(self, batch: dict) -> dict:
+        return self.transport.call(Request("fwd-no-grad", self.jobs.require("training"), dict(batch), binary=True))
+
+    def step(self, learning_rate: float | None = None) -> dict:
+        # NOTE: response *shapes* also diverge across backends -- on-prem returns
+        # {"metrics": {"grad_norm", ...}, ...} (scalars can be per-DP-rank lists),
+        # while Cortex returns just the loss with no metrics dict. Callers cope
+        # via graceful key lookups today.
+        # TODO(unify-backends): converge the server-side fwd_bwd/step *responses*
+        # on ONE schema (loss + metrics) so callers never key on backend.
+        return self.transport.call(Request("step", self.jobs.require("training"), {"learning_rate": learning_rate}))
+
+    def save_checkpoint(self, stage_info: dict | None = None, path: str | None = None) -> dict:
+        body = {"stage_info": stage_info, "path": path}
+        return self.transport.call(Request("save-checkpoint", self.jobs.require("training"), body))
+
+    def save_weights(self, path: str) -> dict:
+        return self.transport.call(Request("save-weights", self.jobs.require("sampling"), {"checkpoint_path": path}))
+
+    # ── sampling / log-prob ──────────────────────────────────────────────
+    def generate(self, prompts: list, sampling_params: dict | None = None, routing_key: Any = None) -> list:
+        body = {"prompts": prompts, "sampling_params": sampling_params, "routing_key": routing_key}
+        return self.transport.call(Request("generate", self.jobs.require("sampling"), body))["results"]
+
+    def log_probs(self, prompts: list, completions: list | None = None, top_k: int = 1) -> dict:
+        body = {"prompts": prompts, "completions": completions, "top_k": top_k}
+        return self.transport.call(Request("log-probs", self.jobs.require("log_prob"), body))
+
+    # ── weight sync + cache ──────────────────────────────────────────────
+    def sync_weights(self) -> dict:
+        # sync-weights has no primary job id; both ids travel in the body.
+        tid, sid = self.jobs.require("training"), self.jobs.require("sampling")
+        return self.transport.call(Request("sync-weights", None, {"training_job_id": tid, "sampling_job_id": sid}))
+
+    def reset_prefix_cache(self, drain: bool = True, timeout_s: float = 60.0) -> dict:
+        body = {"drain": drain, "timeout_s": timeout_s}
+        return self.transport.call(Request("reset-prefix-cache", self.jobs.require("sampling"), body))
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+    def reconnect_config(self) -> ArcticRLClientConfig:
+        """A serializable config that reattaches to these jobs in another process."""
+        return self.config.model_copy(
+            update={
+                "training_job_id": self.jobs.training,
+                "sampling_job_id": self.jobs.sampling,
+                "log_prob_job_id": self.jobs.log_prob,
+            }
+        )
+
+    def shutdown(self) -> None:
+        self.transport.shutdown()
+
+    def __enter__(self) -> ArcticRLClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.shutdown()
+
+
+def create_arctic_rl_client(config: ArcticRLClientConfig) -> ArcticRLClient:
+    """Factory matching the current OSS entrypoint shape."""
+    return ArcticRLClient(config)

--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""One config for every backend. Switching deployment == changing `backend`."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+JobId = int | str
+
+
+class ArcticRLClientConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", validate_default=True)
+
+    backend: Literal["onprem"] = Field("onprem", description="Deployment target.")
+    comm_protocol: Literal["ray"] = Field("ray", description="onprem transport: in-process Ray.")
+    model_name: str = Field(..., description="HF model id to train/serve.")
+    seed: int | None = Field(None, description="Global seed.")
+    dtype: str | None = Field(None, description="Parameter dtype override.")
+    max_seq_len: int = Field(8192, description="Max sequence length.")
+
+    # GPU allocation — a job type is created only when its count is > 0.
+    training_gpus: int = 0
+    sampling_gpus: int = 0
+    log_prob_gpus: int = 0
+
+    # onprem (Ray)
+    colocate: bool = False
+    ds_config: dict[str, Any] | None = None
+    training_config: dict[str, Any] | None = None
+    vllm_config: dict[str, Any] | None = None
+    checkpoint_path: str | None = Field(None, description="onprem: dir for training checkpoints/weight sync.")
+
+    # Reconnect: attach to pre-existing jobs instead of creating new ones.
+    training_job_id: JobId | None = None
+    sampling_job_id: JobId | None = None
+    log_prob_job_id: JobId | None = None
+
+    def gpus_for(self, job_type: str) -> int:
+        """GPU count allocated to a job type (0 == the job type is disabled)."""
+        return getattr(self, f"{job_type}_gpus")

--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -46,7 +46,14 @@ class ArcticRLClientConfig(BaseModel):
     ds_config: dict[str, Any] | None = None
     training_config: dict[str, Any] | None = None
     vllm_config: dict[str, Any] | None = None
-    checkpoint_path: str | None = Field(None, description="onprem: dir for training checkpoints/weight sync.")
+    checkpoint_path: str | None = Field(
+        None,
+        description=(
+            "onprem: training job's base checkpoint dir, set at init (resume-from + weight sync). "
+            "This is the default destination; a per-call save_checkpoint(path=...) overrides it for "
+            "that call and falls back to this dir when path is None."
+        ),
+    )
 
     # Reconnect: attach to pre-existing jobs instead of creating new ones.
     training_job_id: JobId | None = None

--- a/arctic_platform/client/examples/sft_example.py
+++ b/arctic_platform/client/examples/sft_example.py
@@ -13,9 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unified training example for the on-prem Ray backend.
+"""Unified SFT training example for the on-prem Ray backend.
 
-    python arctic_platform/client/examples/train_example.py --backend onprem-ray
+    python arctic_platform/client/examples/sft_example.py --backend onprem-ray
 
 The backend follows the pathway: build config -> ArcticRLClient ->
 loop(fwd_bwd + step) -> shutdown, with a single unified fwd_bwd/step/report.

--- a/arctic_platform/client/examples/train_example.py
+++ b/arctic_platform/client/examples/train_example.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unified training example for the on-prem Ray backend.
+
+    python arctic_platform/client/examples/train_example.py --backend onprem-ray
+
+The backend follows the pathway: build config -> ArcticRLClient ->
+loop(fwd_bwd + step) -> shutdown, with a single unified fwd_bwd/step/report.
+The client + transport hide all wire/protocol differences.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from typing import Callable
+
+ARCTIC = Path(__file__).resolve().parents[3]  # Arctic-Platform/
+# Run-from-anywhere: the package root + the RL test harness on the path.
+sys.path.insert(0, str(ARCTIC))
+sys.path.insert(0, str(ARCTIC / "tests" / "rl"))
+
+from arctic_platform.client import ArcticRLClient  # noqa: E402
+from arctic_platform.client import ArcticRLClientConfig  # noqa: E402
+
+STEPS = 20
+SEED = 42
+N_GPUS = 8
+
+MODEL = "Qwen/Qwen3-0.6B"
+LR = 1e-5
+PROMPT = "who trained you?\nMichael Wyatt at Snowflake"
+PROMPT_LEN = 8
+RESPONSE_LEN = 8
+SEQ_LEN = PROMPT_LEN + RESPONSE_LEN
+ROLLOUT_N = 1
+ATTN = "sdpa"  # flash_attention_2 needs the flash_attn package; sdpa ships with torch
+
+
+def _metric(x) -> float:
+    """step merges across DP ranks, so a replicated scalar can arrive as a per-rank list."""
+    return float(x[0] if isinstance(x, (list, tuple)) else x)
+
+
+# ── per-backend: config ──────────────────────────────────────────────────────
+def _onprem_ray_config(stack: contextlib.ExitStack) -> ArcticRLClientConfig:
+    ckpt = stack.enter_context(tempfile.TemporaryDirectory(prefix="arl_onprem_ckpt_"))
+    return ArcticRLClientConfig(
+        backend="onprem",
+        comm_protocol="ray",
+        model_name=MODEL,
+        seed=SEED,
+        training_gpus=N_GPUS,
+        checkpoint_path=ckpt,  # server requires this for training jobs
+        ds_config={
+            "train_micro_batch_size_per_gpu": 1,
+            "train_batch_size": N_GPUS,
+            "gradient_accumulation_steps": 1,
+            "zero_optimization": {
+                "stage": 3,
+                "offload_optimizer": {"device": "none"},
+                "offload_param": {"device": "none"},
+            },
+        },
+        training_config={
+            "optimizer": {"lr": LR, "weight_decay": 0.0, "betas": [0.9, 0.999]},
+            "lr_scheduler": {"warmup_ratio": 0.0},
+            "training_horizon": 1,
+            "max_length": SEQ_LEN,
+            "model_config": None,
+            "attn_implementation": ATTN,
+            "gradient_accumulation_steps": 1,
+        },
+    )
+
+
+# ── shared data, per-backend packaging ───────────────────────────────────────
+def _tokens() -> dict:
+    """Tokenize the shared PROMPT with the shared MODEL — the payload the backend sends."""
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    if tokenizer.pad_token_id is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    encoded = tokenizer(
+        [PROMPT] * N_GPUS,
+        return_tensors="pt",
+        padding="max_length",
+        truncation=True,
+        max_length=SEQ_LEN,
+        add_special_tokens=True,
+    )
+    input_ids = encoded["input_ids"].contiguous()
+    attention_mask = encoded["attention_mask"].contiguous()
+    # `prompts` = the prompt-length slice, matching the verl batch key set.
+    return {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "prompts": input_ids[:, :PROMPT_LEN].contiguous(),
+    }
+
+
+def _onprem_batch(tokens: dict) -> Any:
+    from rl_harness import build_update_actor_payload
+
+    # `processing` stays inside the payload: client.fwd_bwd folds a `processing=`
+    # kwarg into the body anyway, so leaving it in yields the identical wire body
+    # and lets the backend share the same `client.fwd_bwd(batch)` call.
+    return build_update_actor_payload(tokens, False, ROLLOUT_N, PROMPT_LEN, RESPONSE_LEN)
+
+
+# ── unified across all backends ──────────────────────────────────────────────
+def _report(step: int, out: dict, step_out: dict) -> str:
+    """One report for every backend, via graceful key lookups on the responses."""
+    loss = _metric(out.get("avg_loss", out.get("loss")))
+    line = f"step {step + 1}/{STEPS} loss={loss:.4g}"
+    grad_norm = (step_out or {}).get("metrics", {}).get("grad_norm")
+    if grad_norm is not None:
+        line += f" grad_norm={_metric(grad_norm):.4g}"
+    return line
+
+
+@dataclass
+class Profile:
+    config: Callable[[contextlib.ExitStack], ArcticRLClientConfig]
+    batch: Callable[[dict], Any]  # packages the shared tokens into the backend's wire shape
+
+
+BACKENDS: dict[str, Profile] = {
+    "onprem-ray": Profile(_onprem_ray_config, _onprem_batch),
+}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--backend", choices=list(BACKENDS), default="onprem-ray")
+    profile = BACKENDS[ap.parse_args().backend]
+
+    with contextlib.ExitStack() as stack:
+        config = profile.config(stack)
+        batch = profile.batch(_tokens())  # same tokens, backend-specific wire shape
+
+        client = ArcticRLClient(config)
+        print(f"training job: {client.jobs.training}")
+        try:
+            for step in range(STEPS):
+                # RL note: a full loop would create a sampling job, generate() a
+                # rollout, score it into advantages, then feed that here.
+                out = client.fwd_bwd(batch)
+                step_out = client.step()
+                print(_report(step, out, step_out))
+        finally:
+            client.shutdown()
+            print("shutdown complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/arctic_platform/client/transport.py
+++ b/arctic_platform/client/transport.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The pluggable seam: a transport is just "how do we deliver an op here".
+
+The op *surface* (names, args, canonical body, which job each op targets,
+response contract) is defined once in the client. A transport owns only job
+identity + wire mechanics: given a `Request`, deliver it to its deployment and
+return a canonical response dict. It never redefines the API.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.config import JobId
+
+JOB_TYPES = ("training", "sampling", "log_prob")
+# Creation order shared by every backend: inference jobs first so training (the
+# NCCL root) rendezvouses last.
+JOB_CREATE_ORDER = ("sampling", "log_prob", "training")
+
+
+@dataclass
+class JobHandles:
+    training: JobId | None = None
+    sampling: JobId | None = None
+    log_prob: JobId | None = None
+
+    @classmethod
+    def from_config(cls, config: ArcticRLClientConfig) -> JobHandles:
+        return cls(config.training_job_id, config.sampling_job_id, config.log_prob_job_id)
+
+    @property
+    def any_set(self) -> bool:
+        return any(getattr(self, jt) is not None for jt in JOB_TYPES)
+
+    def set(self, job_type: str, job_id: JobId) -> None:
+        setattr(self, job_type, job_id)
+
+    def require(self, job_type: str) -> JobId:
+        job_id = getattr(self, job_type)
+        if job_id is None:
+            raise ValueError(f"No {job_type} job initialized.")
+        return job_id
+
+
+@dataclass
+class Request:
+    """A canonical op call, built by the client.
+
+    The client owns job identity (it holds `JobHandles` after `initialize`), so it
+    resolves and sets `job_id` here directly; `body` carries everything else. This
+    keeps transports as pure forwarders: on-prem hands `(job_id, body)` straight to
+    the server, `binary` just picks the body codec (octet tensors vs JSON).
+    """
+
+    op: str  # canonical op name, e.g. "fwd-bwd"
+    job_id: JobId | None = None  # primary target id (client-resolved); None -> omit
+    body: dict[str, Any] = field(default_factory=dict)
+    binary: bool = False  # body carries tensors -> octet, else JSON
+
+
+class Transport(ABC):
+    jobs: JobHandles
+
+    @abstractmethod
+    def initialize(self) -> JobHandles:
+        """Create jobs (or attach to reconnect ids) and return their handles."""
+
+    @abstractmethod
+    def call(self, request: Request) -> dict:
+        """Deliver one op to this deployment; return a canonical response dict."""
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Tear down jobs / connections."""

--- a/arctic_platform/client/transport.py
+++ b/arctic_platform/client/transport.py
@@ -36,6 +36,32 @@ JOB_TYPES = ("training", "sampling", "log_prob")
 # NCCL root) rendezvouses last.
 JOB_CREATE_ORDER = ("sampling", "log_prob", "training")
 
+# The canonical op vocabulary: every op the client can lower to a Request. A
+# transport is expected to resolve all of these; `unresolved_ops` lets it check
+# its own coverage up front instead of failing with an AttributeError mid-run.
+OPS = frozenset(
+    {
+        "fwd-bwd",
+        "fwd-no-grad",
+        "step",
+        "save-checkpoint",
+        "generate",
+        "log-probs",
+        "sync-weights",
+        "reset-prefix-cache",
+    }
+)
+
+
+def method_name(op: str) -> str:
+    """Canonical op name -> the method name a transport target exposes."""
+    return op.replace("-", "_")
+
+
+def unresolved_ops(target: object) -> list[str]:
+    """Ops in `OPS` that `target` exposes no matching method for."""
+    return sorted(op for op in OPS if not hasattr(target, method_name(op)))
+
 
 @dataclass
 class JobHandles:

--- a/arctic_platform/client/transports/__init__.py
+++ b/arctic_platform/client/transports/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/arctic_platform/client/transports/onprem.py
+++ b/arctic_platform/client/transports/onprem.py
@@ -1,0 +1,98 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""On-prem transport base for the Arctic-Platform server.
+
+HTTP and in-process Ray share one control plane (`OnPremTransport`:
+job creation, ordering, payload building, `call`); they differ only in three
+primitives (`_start`, `_rpc`, `_destroy`). `call` is uniform — post/dispatch the
+op against its target job — because the server exposes a uniform
+`op(job_id, body) -> dict` surface.
+
+Concrete transports live alongside this base: `HttpTransport` in
+`onprem_http.py` and `RayTransport` in `onprem_ray.py`.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.config import JobId
+from arctic_platform.client.transport import JOB_CREATE_ORDER
+from arctic_platform.client.transport import JOB_TYPES
+from arctic_platform.client.transport import JobHandles
+from arctic_platform.client.transport import Request
+from arctic_platform.client.transport import Transport
+
+
+class OnPremTransport(Transport):
+    def __init__(self, config: ArcticRLClientConfig) -> None:
+        self.config = config
+        self.jobs = JobHandles()
+
+    def initialize(self) -> JobHandles:
+        reconnect = JobHandles.from_config(self.config)
+        if reconnect.any_set:
+            self.jobs = reconnect
+            return self.jobs
+        cfg = self.config
+        for job_type in JOB_CREATE_ORDER:
+            if cfg.gpus_for(job_type) > 0:
+                self.jobs.set(job_type, self._start(self._init_payload(job_type)))
+        self._wait_running()
+        return self.jobs
+
+    def call(self, request: Request) -> dict:
+        # The client already resolved the job id onto the request; just deliver it.
+        return self._rpc(request)
+
+    def shutdown(self) -> None:
+        for job_type in JOB_TYPES:
+            job_id = getattr(self.jobs, job_type)
+            if job_id is not None:
+                self._destroy(job_id, job_type)
+
+    def _init_payload(self, job_type: str) -> dict[str, Any]:
+        cfg = self.config
+        payload: dict[str, Any] = {"model_name": cfg.model_name, "job_type": job_type, "seed": cfg.seed}
+        if job_type in ("training", "log_prob"):
+            if cfg.ds_config:
+                payload["ds_config"] = cfg.ds_config
+            if job_type == "training":
+                if cfg.training_config:
+                    payload["training_config"] = cfg.training_config
+                if cfg.checkpoint_path:
+                    payload["checkpoint_path"] = cfg.checkpoint_path
+        elif cfg.vllm_config:
+            payload["vllm_config"] = cfg.vllm_config
+        return payload
+
+    # delivery primitives — the only things a concrete transport implements
+    @abstractmethod
+    def _start(self, payload: dict) -> JobId:
+        """Create one job and return its id."""
+
+    @abstractmethod
+    def _rpc(self, request: Request) -> dict:
+        """Deliver one op and return its response dict."""
+
+    @abstractmethod
+    def _destroy(self, job_id: JobId, job_type: str) -> None:
+        """Tear down one job."""
+
+    @abstractmethod
+    def _wait_running(self) -> None:
+        """Block until all created jobs are ready."""

--- a/arctic_platform/client/transports/onprem.py
+++ b/arctic_platform/client/transports/onprem.py
@@ -26,6 +26,7 @@ Concrete transports live alongside this base: `HttpTransport` in
 
 from __future__ import annotations
 
+import logging
 from abc import abstractmethod
 from typing import Any
 
@@ -36,6 +37,9 @@ from arctic_platform.client.transport import JOB_TYPES
 from arctic_platform.client.transport import JobHandles
 from arctic_platform.client.transport import Request
 from arctic_platform.client.transport import Transport
+from arctic_platform.client.transport import unresolved_ops
+
+logger = logging.getLogger(__name__)
 
 
 class OnPremTransport(Transport):
@@ -64,6 +68,12 @@ class OnPremTransport(Transport):
             job_id = getattr(self.jobs, job_type)
             if job_id is not None:
                 self._destroy(job_id, job_type)
+
+    def _check_op_coverage(self, target: object) -> None:
+        """Warn (don't fail) if the delivery target can't resolve some canonical op."""
+        missing = unresolved_ops(target)
+        if missing:
+            logger.warning("%s cannot resolve ops (they will fail if called): %s", type(self).__name__, missing)
 
     def _init_payload(self, job_type: str) -> dict[str, Any]:
         cfg = self.config

--- a/arctic_platform/client/transports/onprem_ray.py
+++ b/arctic_platform/client/transports/onprem_ray.py
@@ -16,9 +16,12 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from arctic_platform.client.config import ArcticRLClientConfig
 from arctic_platform.client.config import JobId
 from arctic_platform.client.transport import Request
+from arctic_platform.client.transport import method_name
 from arctic_platform.client.transports.onprem import OnPremTransport
 
 
@@ -44,6 +47,8 @@ class RayTransport(OnPremTransport):
             colocate=config.colocate,
         )
         self._server = None  # ArcticRLRayServer, built once jobs exist
+        # One long-lived loop for every op instead of asyncio.run() per call.
+        self._loop = asyncio.new_event_loop()
 
     def _start(self, payload: dict) -> JobId:
         import ray
@@ -55,16 +60,17 @@ class RayTransport(OnPremTransport):
         from arctic_platform.rl.ray_server import ArcticRLRayServer
 
         self._server = ArcticRLRayServer(self._state)
+        self._check_op_coverage(self._server)
 
     def _rpc(self, request: Request) -> dict:
-        import asyncio
-
         # Pass job_id only when set (some ops, e.g. sync-weights, omit it), then the body.
-        method = getattr(self._server, request.op.replace("-", "_"))
+        method = getattr(self._server, method_name(request.op))
         args = (request.body,) if request.job_id is None else (request.job_id, request.body)
-        return asyncio.run(method(*args))
+        return self._loop.run_until_complete(method(*args))
 
     def _destroy(self, job_id: JobId, job_type: str) -> None:
-        import asyncio
+        self._loop.run_until_complete(self._server.destroy(job_id, job_type))
 
-        asyncio.run(self._server.destroy(job_id, job_type))
+    def shutdown(self) -> None:
+        super().shutdown()
+        self._loop.close()

--- a/arctic_platform/client/transports/onprem_ray.py
+++ b/arctic_platform/client/transports/onprem_ray.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""In-process Ray transport — no HTTP, no serialization."""
+
+from __future__ import annotations
+
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.config import JobId
+from arctic_platform.client.transport import Request
+from arctic_platform.client.transports.onprem import OnPremTransport
+
+
+class RayTransport(OnPremTransport):
+    """In-process Ray actor calls — no HTTP, no serialization.
+
+    The server splits into a ``state`` actor (job creation) and an
+    ``ArcticRLRayServer`` wrapper (typed async ops) that snapshots workers at
+    construction, so the wrapper is built lazily after jobs are initialized.
+
+    `_rpc` resolves ``op -> method`` and forwards the request unchanged.
+    """
+
+    def __init__(self, config: ArcticRLClientConfig) -> None:
+        super().__init__(config)
+        from arctic_platform.rl.ray_server import create_arctic_rl_ray_server_state
+
+        self._state = create_arctic_rl_ray_server_state(
+            training_gpus=config.training_gpus,
+            sampling_gpus=config.sampling_gpus,
+            log_prob_gpus=config.log_prob_gpus,
+            log_prob_engine="deepspeed",
+            colocate=config.colocate,
+        )
+        self._server = None  # ArcticRLRayServer, built once jobs exist
+
+    def _start(self, payload: dict) -> JobId:
+        import ray
+
+        return ray.get(self._state.initialize.remote(payload))["job_id"]
+
+    def _wait_running(self) -> None:
+        # Build the wrapper after initialize(): it snapshots training_workers.
+        from arctic_platform.rl.ray_server import ArcticRLRayServer
+
+        self._server = ArcticRLRayServer(self._state)
+
+    def _rpc(self, request: Request) -> dict:
+        import asyncio
+
+        # Pass job_id only when set (some ops, e.g. sync-weights, omit it), then the body.
+        method = getattr(self._server, request.op.replace("-", "_"))
+        args = (request.body,) if request.job_id is None else (request.job_id, request.body)
+        return asyncio.run(method(*args))
+
+    def _destroy(self, job_id: JobId, job_type: str) -> None:
+        import asyncio
+
+        asyncio.run(self._server.destroy(job_id, job_type))

--- a/arctic_platform/rl/ray_server.py
+++ b/arctic_platform/rl/ray_server.py
@@ -717,7 +717,8 @@ class ArcticRLRayServer:
 
         return merged
 
-    async def step(self, job_id: int) -> dict[str, Any]:
+    async def step(self, job_id: int, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        # `body` is unused; accepted so the client can call with (job_id, body).
         self._verify_job(job_id, "training")
         # results = await asyncio.gather(*[w.step.remote() for w in self.training_workers])
         refs = [w.step.remote() for w in self.training_workers]
@@ -737,7 +738,8 @@ class ArcticRLRayServer:
         logger.info("Empty training cache: %s", results)
         return {"job_id": job_id, "workers": results}
 
-    async def save_checkpoint(self, job_id: int):
+    async def save_checkpoint(self, job_id: int, body: dict[str, Any] | None = None):
+        # `body` is unused; accepted so the client can call with (job_id, body).
         self._verify_job(job_id, "training")
         info = self.jobs[job_id]
         checkpoint_path = info.get("checkpoint_path", None)
@@ -761,8 +763,9 @@ class ArcticRLRayServer:
         results = await self.arctic_rl_ray_server_state.wake_inference.remote(tags)
         return {"job_id": job_id, **results}
 
-    async def reset_prefix_cache(self, job_id: int):
+    async def reset_prefix_cache(self, job_id: int, body: dict[str, Any] | None = None):
         """Reset the prefix cache on the sampling inference engines."""
+        # `body` is unused; accepted so the client can call with (job_id, body).
         self._verify_job(job_id, "sampling")
         return await self.arctic_rl_ray_server_state.reset_prefix_cache.remote(job_id)
 

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -1,0 +1,173 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The op surface of ArcticRLClient must lower to one canonical Request each.
+
+A FakeTransport records the Request every op produces so we can assert the
+mapping (target job, body, binary flag) with no live backend or GPUs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from arctic_platform.client import ArcticRLClient
+from arctic_platform.client import ArcticRLClientConfig
+from arctic_platform.client import JobHandles
+from arctic_platform.client import Request
+from arctic_platform.client import Transport
+from arctic_platform.client import client as client_module
+
+TRAINING, SAMPLING, LOG_PROB = 1, 2, 3
+
+
+class FakeTransport(Transport):
+    def __init__(self, config: ArcticRLClientConfig) -> None:
+        self.config = config
+        self.jobs = JobHandles()
+        self.calls: list[Request] = []
+
+    def initialize(self) -> JobHandles:
+        self.jobs = JobHandles(training=TRAINING, sampling=SAMPLING, log_prob=LOG_PROB)
+        return self.jobs
+
+    def call(self, request: Request) -> dict:
+        self.calls.append(request)
+        return {"results": ["ok"], "loss": 0.0}
+
+    def shutdown(self) -> None:
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch) -> ArcticRLClient:
+    monkeypatch.setattr(client_module, "make_transport", FakeTransport)
+    cfg = ArcticRLClientConfig(model_name="m", training_gpus=1, sampling_gpus=1, log_prob_gpus=1)
+    return ArcticRLClient(cfg)
+
+
+def _last(client: ArcticRLClient) -> Request:
+    return client.transport.calls[-1]
+
+
+class TestOpMapping:
+    def test_fwd_bwd_targets_training_binary(self, client):
+        """fwd_bwd -> training job, binary payload, body carries the batch."""
+        client.fwd_bwd({"input_ids": [1, 2]})
+        req = _last(client)
+        assert req.op == "fwd-bwd"
+        assert req.job_id == TRAINING
+        assert req.binary is True
+        assert req.body["input_ids"] == [1, 2]
+
+    def test_fwd_bwd_folds_processing_and_router_replay(self, client):
+        """Non-None processing/router_replay are folded into the body."""
+        client.fwd_bwd({"input_ids": [1]}, processing={"p": 1}, router_replay={"r": 2})
+        body = _last(client).body
+        assert body["processing"] == {"p": 1}
+        assert body["router_replay"] == {"r": 2}
+
+    def test_fwd_no_grad_targets_training_binary(self, client):
+        """fwd_no_grad -> training job, binary payload."""
+        client.fwd_no_grad({"input_ids": [1]})
+        req = _last(client)
+        assert req.op == "fwd-no-grad"
+        assert req.job_id == TRAINING
+        assert req.binary is True
+
+    def test_step_targets_training(self, client):
+        """step -> training job, learning_rate in body."""
+        client.step(learning_rate=0.5)
+        req = _last(client)
+        assert req.op == "step"
+        assert req.job_id == TRAINING
+        assert req.binary is False
+        assert req.body == {"learning_rate": 0.5}
+
+    def test_save_checkpoint_targets_training(self, client):
+        """save_checkpoint -> training job."""
+        client.save_checkpoint(stage_info={"s": 1}, path="/tmp/x")
+        req = _last(client)
+        assert req.op == "save-checkpoint"
+        assert req.job_id == TRAINING
+        assert req.body == {"stage_info": {"s": 1}, "path": "/tmp/x"}
+
+    def test_save_weights_targets_sampling(self, client):
+        """save_weights -> sampling job."""
+        client.save_weights("/tmp/w")
+        req = _last(client)
+        assert req.op == "save-weights"
+        assert req.job_id == SAMPLING
+        assert req.body == {"checkpoint_path": "/tmp/w"}
+
+    def test_generate_targets_sampling_and_unwraps_results(self, client):
+        """generate -> sampling job; returns the 'results' list."""
+        out = client.generate(["hi"], sampling_params={"n": 1}, routing_key="k")
+        req = _last(client)
+        assert req.op == "generate"
+        assert req.job_id == SAMPLING
+        assert req.body == {"prompts": ["hi"], "sampling_params": {"n": 1}, "routing_key": "k"}
+        assert out == ["ok"]
+
+    def test_log_probs_targets_log_prob(self, client):
+        """log_probs -> log_prob job."""
+        client.log_probs(["hi"], completions=["there"], top_k=3)
+        req = _last(client)
+        assert req.op == "log-probs"
+        assert req.job_id == LOG_PROB
+        assert req.body == {"prompts": ["hi"], "completions": ["there"], "top_k": 3}
+
+    def test_reset_prefix_cache_targets_sampling(self, client):
+        """reset_prefix_cache -> sampling job."""
+        client.reset_prefix_cache(drain=False, timeout_s=5.0)
+        req = _last(client)
+        assert req.op == "reset-prefix-cache"
+        assert req.job_id == SAMPLING
+        assert req.body == {"drain": False, "timeout_s": 5.0}
+
+    def test_sync_weights_has_no_primary_job_id(self, client):
+        """sync_weights -> job_id None; both ids ride in the body."""
+        client.sync_weights()
+        req = _last(client)
+        assert req.op == "sync-weights"
+        assert req.job_id is None
+        assert req.body == {"training_job_id": TRAINING, "sampling_job_id": SAMPLING}
+
+
+class TestLifecycle:
+    def test_reconnect_config_copies_job_ids(self, client):
+        """reconnect_config bakes the live job ids into a fresh config."""
+        cfg = client.reconnect_config()
+        assert cfg.training_job_id == TRAINING
+        assert cfg.sampling_job_id == SAMPLING
+        assert cfg.log_prob_job_id == LOG_PROB
+
+    def test_require_raises_for_uninitialized_job(self):
+        """JobHandles.require guards against calling an op before its job exists."""
+        with pytest.raises(ValueError, match="No training job"):
+            JobHandles().require("training")
+
+
+class TestTransportSelection:
+    def test_make_transport_selects_ray(self, monkeypatch):
+        """onprem + ray routes to RayTransport (constructed lazily, so patch it)."""
+        import arctic_platform.client.transports.onprem_ray as ray_mod
+
+        class DummyRay:
+            def __init__(self, config):
+                self.config = config
+
+        monkeypatch.setattr(ray_mod, "RayTransport", DummyRay)
+        cfg = ArcticRLClientConfig(model_name="m", comm_protocol="ray", training_gpus=1)
+        assert isinstance(client_module.make_transport(cfg), DummyRay)

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -22,12 +22,15 @@ from __future__ import annotations
 
 import pytest
 
+from arctic_platform.client import OPS
 from arctic_platform.client import ArcticRLClient
 from arctic_platform.client import ArcticRLClientConfig
 from arctic_platform.client import JobHandles
 from arctic_platform.client import Request
 from arctic_platform.client import Transport
 from arctic_platform.client import client as client_module
+from arctic_platform.client import unresolved_ops
+from arctic_platform.client.transport import method_name
 
 TRAINING, SAMPLING, LOG_PROB = 1, 2, 3
 
@@ -103,14 +106,6 @@ class TestOpMapping:
         assert req.job_id == TRAINING
         assert req.body == {"stage_info": {"s": 1}, "path": "/tmp/x"}
 
-    def test_save_weights_targets_sampling(self, client):
-        """save_weights -> sampling job."""
-        client.save_weights("/tmp/w")
-        req = _last(client)
-        assert req.op == "save-weights"
-        assert req.job_id == SAMPLING
-        assert req.body == {"checkpoint_path": "/tmp/w"}
-
     def test_generate_targets_sampling_and_unwraps_results(self, client):
         """generate -> sampling job; returns the 'results' list."""
         out = client.generate(["hi"], sampling_params={"n": 1}, routing_key="k")
@@ -157,6 +152,45 @@ class TestLifecycle:
         """JobHandles.require guards against calling an op before its job exists."""
         with pytest.raises(ValueError, match="No training job"):
             JobHandles().require("training")
+
+
+class TestOpRegistry:
+    """Contract: the client's op vocabulary and OPS stay in lockstep, and a
+    transport's op coverage is checkable without a live backend."""
+
+    def test_client_emits_exactly_the_registered_ops(self, client):
+        """Driving every client op must produce exactly the canonical OPS set."""
+        client.fwd_bwd({"input_ids": [1]})
+        client.fwd_no_grad({"input_ids": [1]})
+        client.step()
+        client.save_checkpoint()
+        client.generate(["hi"])
+        client.log_probs(["hi"])
+        client.sync_weights()
+        client.reset_prefix_cache()
+        assert {req.op for req in client.transport.calls} == OPS
+
+    def test_unresolved_ops_flags_a_missing_method(self):
+        """A target missing one op's method is reported (renamed/dropped op -> caught early)."""
+
+        class PartialServer:
+            pass
+
+        server = PartialServer()
+        for op in OPS - {"step"}:
+            setattr(server, method_name(op), lambda *a, **k: None)
+        assert unresolved_ops(server) == ["step"]
+
+    def test_unresolved_ops_empty_when_fully_covered(self):
+        """A target exposing every op resolves cleanly."""
+
+        class FullServer:
+            pass
+
+        server = FullServer()
+        for op in OPS:
+            setattr(server, method_name(op), lambda *a, **k: None)
+        assert unresolved_ops(server) == []
 
 
 class TestTransportSelection:


### PR DESCRIPTION
Add the unified RL client frontend: a single op API (client.py) that lowers every op to a canonical Request(op, job_id, body), a Transport ABC with JobHandles/Request (transport.py), a backend config (config.py), and the shared OnPremTransport base with the in-process Ray transport (onprem.py, onprem_ray.py). ray_server.py accepts (job_id, body) on step/save_checkpoint/reset_prefix_cache so the client can forward uniformly.

Includes tests/client/test_client_ops.py covering the op->Request mapping via a FakeTransport (no GPUs/backends needed).