### PR TITLE
feat(client): add on-prem HTTP transport

### DIFF
--- a/arctic_platform/client/UNIFICATION_NOTES.md
+++ b/arctic_platform/client/UNIFICATION_NOTES.md
@@ -25,6 +25,15 @@ is built lazily after jobs are initialized. `_rpc` resolves `op -> method` and
 forwards `(job_id, body)` unchanged, matching the server's uniform
 `op(job_id, body) -> dict` surface.
 
+## On-prem HTTP transport
+`HttpTransport` shares the same `OnPremTransport` control plane and only supplies
+the delivery primitives: it POSTs each op to `/{op}?job_id=...`. Tensor-bearing
+ops (`fwd_bwd`/`fwd_no_grad`) send an octet `torch.save` payload and decode octet
+responses; everything else is JSON. It also optionally launches a local server
+(`launch_local_server`) and polls `/health` + `/job/{id}` to wait for readiness.
+The Ray path forwards `(job_id, body)` to the same uniform server surface, so the
+two transports differ only in `_start`/`_rpc`/`_destroy`.
+
 ## Not yet in unified client (future work)
 Ops present in `arctic_platform/rl/*_client.py` but not yet on `ArcticRLClient`.
 Not on the immediate critical path, but they **block deleting the async

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -30,9 +30,12 @@ from arctic_platform.client.transport import Transport
 
 
 def make_transport(config: ArcticRLClientConfig) -> Transport:
+    from arctic_platform.client.transports.onprem_http import HttpTransport
     from arctic_platform.client.transports.onprem_ray import RayTransport
 
-    return RayTransport(config)
+    if config.backend == "onprem" and config.comm_protocol == "ray":
+        return RayTransport(config)
+    return HttpTransport(config)  # onprem (HTTP)
 
 
 class ArcticRLClient:

--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -48,6 +48,9 @@ class ArcticRLClientConfig(BaseModel):
     launch_local_server: bool = Field(False, description="onprem: spawn a local server before connecting.")
     startup_timeout: float = 600.0
     job_ready_timeout: float = 1800.0
+    request_timeout: float = Field(
+        1800.0, description="onprem HTTP: per-request timeout (seconds) applied to every call. Generous for long ops."
+    )
     ds_config: dict[str, Any] | None = None
     training_config: dict[str, Any] | None = None
     vllm_config: dict[str, Any] | None = None

--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -30,7 +30,7 @@ class ArcticRLClientConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", validate_default=True)
 
     backend: Literal["onprem"] = Field("onprem", description="Deployment target.")
-    comm_protocol: Literal["ray"] = Field("ray", description="onprem transport: in-process Ray.")
+    comm_protocol: Literal["http", "ray"] = Field("http", description="onprem transport: HTTP or in-process Ray.")
     model_name: str = Field(..., description="HF model id to train/serve.")
     seed: int | None = Field(None, description="Global seed.")
     dtype: str | None = Field(None, description="Parameter dtype override.")
@@ -41,8 +41,13 @@ class ArcticRLClientConfig(BaseModel):
     sampling_gpus: int = 0
     log_prob_gpus: int = 0
 
-    # onprem (Ray)
+    # onprem (HTTP + Ray)
+    host: str = "localhost"
+    port: int = 8000
     colocate: bool = False
+    launch_local_server: bool = Field(False, description="onprem: spawn a local server before connecting.")
+    startup_timeout: float = 600.0
+    job_ready_timeout: float = 1800.0
     ds_config: dict[str, Any] | None = None
     training_config: dict[str, Any] | None = None
     vllm_config: dict[str, Any] | None = None

--- a/arctic_platform/client/examples/sft_example.py
+++ b/arctic_platform/client/examples/sft_example.py
@@ -13,13 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unified SFT training example for the on-prem Ray backend.
+"""Unified SFT training example across the on-prem backends.
 
+    python arctic_platform/client/examples/sft_example.py --backend onprem-http
     python arctic_platform/client/examples/sft_example.py --backend onprem-ray
 
-The backend follows the pathway: build config -> ArcticRLClient ->
+Every backend follows the *same* pathway: build config -> ArcticRLClient ->
 loop(fwd_bwd + step) -> shutdown, with a single unified fwd_bwd/step/report.
-The client + transport hide all wire/protocol differences.
+The client + transports hide all wire/protocol differences.
 """
 
 from __future__ import annotations
@@ -61,35 +62,40 @@ def _metric(x) -> float:
 
 
 # ── per-backend: config ──────────────────────────────────────────────────────
-def _onprem_ray_config(stack: contextlib.ExitStack) -> ArcticRLClientConfig:
-    ckpt = stack.enter_context(tempfile.TemporaryDirectory(prefix="arl_onprem_ckpt_"))
-    return ArcticRLClientConfig(
-        backend="onprem",
-        comm_protocol="ray",
-        model_name=MODEL,
-        seed=SEED,
-        training_gpus=N_GPUS,
-        checkpoint_path=ckpt,  # server requires this for training jobs
-        ds_config={
-            "train_micro_batch_size_per_gpu": 1,
-            "train_batch_size": N_GPUS,
-            "gradient_accumulation_steps": 1,
-            "zero_optimization": {
-                "stage": 3,
-                "offload_optimizer": {"device": "none"},
-                "offload_param": {"device": "none"},
+def _onprem_config(comm_protocol: str, launch_local_server: bool) -> Callable:
+    def build(stack: contextlib.ExitStack) -> ArcticRLClientConfig:
+        ckpt = stack.enter_context(tempfile.TemporaryDirectory(prefix="arl_onprem_ckpt_"))
+        return ArcticRLClientConfig(
+            backend="onprem",
+            comm_protocol=comm_protocol,
+            launch_local_server=launch_local_server,
+            model_name=MODEL,
+            seed=SEED,
+            training_gpus=N_GPUS,
+            checkpoint_path=ckpt,  # server requires this for training jobs
+            job_ready_timeout=600.0,
+            ds_config={
+                "train_micro_batch_size_per_gpu": 1,
+                "train_batch_size": N_GPUS,
+                "gradient_accumulation_steps": 1,
+                "zero_optimization": {
+                    "stage": 3,
+                    "offload_optimizer": {"device": "none"},
+                    "offload_param": {"device": "none"},
+                },
             },
-        },
-        training_config={
-            "optimizer": {"lr": LR, "weight_decay": 0.0, "betas": [0.9, 0.999]},
-            "lr_scheduler": {"warmup_ratio": 0.0},
-            "training_horizon": 1,
-            "max_length": SEQ_LEN,
-            "model_config": None,
-            "attn_implementation": ATTN,
-            "gradient_accumulation_steps": 1,
-        },
-    )
+            training_config={
+                "optimizer": {"lr": LR, "weight_decay": 0.0, "betas": [0.9, 0.999]},
+                "lr_scheduler": {"warmup_ratio": 0.0},
+                "training_horizon": 1,
+                "max_length": SEQ_LEN,
+                "model_config": None,
+                "attn_implementation": ATTN,
+                "gradient_accumulation_steps": 1,
+            },
+        )
+
+    return build
 
 
 # ── shared data, per-backend packaging ───────────────────────────────────────
@@ -145,13 +151,14 @@ class Profile:
 
 
 BACKENDS: dict[str, Profile] = {
-    "onprem-ray": Profile(_onprem_ray_config, _onprem_batch),
+    "onprem-http": Profile(_onprem_config("http", True), _onprem_batch),
+    "onprem-ray": Profile(_onprem_config("ray", False), _onprem_batch),
 }
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--backend", choices=list(BACKENDS), default="onprem-ray")
+    ap.add_argument("--backend", choices=list(BACKENDS), default="onprem-http")
     profile = BACKENDS[ap.parse_args().backend]
 
     with contextlib.ExitStack() as stack:

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -1,0 +1,142 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Blocking HTTP transport (on-prem) + tensor codec."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.config import JobId
+from arctic_platform.client.transport import JOB_TYPES
+from arctic_platform.client.transport import Request
+from arctic_platform.client.transports.onprem import OnPremTransport
+
+
+def _dumps(obj: Any) -> bytes:
+    import io
+
+    import torch
+
+    buf = io.BytesIO()
+    torch.save(obj, buf)
+    return buf.getvalue()
+
+
+def _loads(data: bytes) -> Any:
+    import io
+
+    import torch
+
+    return torch.load(io.BytesIO(data), map_location="cpu", weights_only=False)
+
+
+class HttpTransport(OnPremTransport):
+    """Blocking HTTP + tensor codec. Serves onprem (local/remote)."""
+
+    def __init__(self, config: ArcticRLClientConfig) -> None:
+        super().__init__(config)
+        import requests
+
+        self.base_url = f"http://{config.host}:{config.port}"
+        self.session = requests.Session()
+        self.proc = None
+        if config.launch_local_server:
+            self._launch_server()
+
+    def _start(self, payload: dict) -> JobId:
+        resp = self.session.post(f"{self.base_url}/initialize", json=payload)
+        resp.raise_for_status()
+        return resp.json()["job_id"]
+
+    def _rpc(self, request: Request) -> dict:
+        # Tensor-bearing ops send an octet torch payload; the rest send JSON.
+        payload = (
+            {"data": _dumps(request.body), "headers": {"Content-Type": "application/octet-stream"}}
+            if request.binary
+            else {"json": request.body}
+        )
+        params = {} if request.job_id is None else {"job_id": request.job_id}
+        resp = self.session.post(f"{self.base_url}/{request.op}", params=params, **payload)
+        resp.raise_for_status()
+        # Tensor-bearing responses come back as octet; everything else is JSON.
+        if "application/octet-stream" in resp.headers.get("Content-Type", ""):
+            return _loads(resp.content)
+        return resp.json()
+
+    def _destroy(self, job_id: JobId, job_type: str) -> None:
+        try:
+            self.session.post(f"{self.base_url}/destroy", params={"job_id": job_id}, json={"job_type": job_type})
+        except Exception:
+            pass
+
+    def _wait_running(self) -> None:
+        for job_type in JOB_TYPES:
+            job_id = getattr(self.jobs, job_type)
+            if job_id is not None:
+                self._poll(
+                    lambda jid=job_id: self._is_running(jid), self.config.job_ready_timeout, f"{job_type} {job_id}"
+                )
+
+    def shutdown(self) -> None:
+        super().shutdown()
+        if self.proc and self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=10)
+            except Exception:
+                self.proc.kill()
+
+    def _is_running(self, job_id: JobId) -> bool:
+        resp = self.session.get(f"{self.base_url}/job/{job_id}", timeout=5)
+        return resp.ok and resp.json().get("status") == "RUNNING"
+
+    def _launch_server(self) -> None:
+        import subprocess
+        import sys
+
+        cfg = self.config
+        cmd = [
+            sys.executable,
+            "-m",
+            "arctic_platform.rl.http_server",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(cfg.port),
+            "--training-gpus",
+            str(cfg.training_gpus),
+            "--sampling-gpus",
+            str(cfg.sampling_gpus),
+            "--log-prob-gpus",
+            str(cfg.log_prob_gpus),
+        ]
+        if cfg.colocate:
+            cmd.append("--colocate")
+        self.proc = subprocess.Popen(cmd)
+        self._poll(lambda: self.session.get(f"{self.base_url}/health", timeout=3).ok, cfg.startup_timeout, "server")
+
+    @staticmethod
+    def _poll(pred, timeout: float, what: str) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if pred():
+                    return
+            except Exception:
+                pass
+            time.sleep(2)
+        raise TimeoutError(f"Timed out waiting for {what} after {timeout}s")

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -52,13 +52,14 @@ class HttpTransport(OnPremTransport):
         import requests
 
         self.base_url = f"http://{config.host}:{config.port}"
+        self.timeout = config.request_timeout
         self.session = requests.Session()
         self.proc = None
         if config.launch_local_server:
             self._launch_server()
 
     def _start(self, payload: dict) -> JobId:
-        resp = self.session.post(f"{self.base_url}/initialize", json=payload)
+        resp = self.session.post(f"{self.base_url}/initialize", json=payload, timeout=self.timeout)
         resp.raise_for_status()
         return resp.json()["job_id"]
 
@@ -70,7 +71,7 @@ class HttpTransport(OnPremTransport):
             else {"json": request.body}
         )
         params = {} if request.job_id is None else {"job_id": request.job_id}
-        resp = self.session.post(f"{self.base_url}/{request.op}", params=params, **payload)
+        resp = self.session.post(f"{self.base_url}/{request.op}", params=params, timeout=self.timeout, **payload)
         resp.raise_for_status()
         # Tensor-bearing responses come back as octet; everything else is JSON.
         if "application/octet-stream" in resp.headers.get("Content-Type", ""):
@@ -78,10 +79,9 @@ class HttpTransport(OnPremTransport):
         return resp.json()
 
     def _destroy(self, job_id: JobId, job_type: str) -> None:
-        try:
-            self.session.post(f"{self.base_url}/destroy", params={"job_id": job_id}, json={"job_type": job_type})
-        except Exception:
-            pass
+        self.session.post(
+            f"{self.base_url}/destroy", params={"job_id": job_id}, json={"job_type": job_type}, timeout=self.timeout
+        )
 
     def _wait_running(self) -> None:
         for job_type in JOB_TYPES:
@@ -101,7 +101,7 @@ class HttpTransport(OnPremTransport):
                 self.proc.kill()
 
     def _is_running(self, job_id: JobId) -> bool:
-        resp = self.session.get(f"{self.base_url}/job/{job_id}", timeout=5)
+        resp = self.session.get(f"{self.base_url}/job/{job_id}", timeout=self.timeout)
         return resp.ok and resp.json().get("status") == "RUNNING"
 
     def _launch_server(self) -> None:
@@ -127,7 +127,9 @@ class HttpTransport(OnPremTransport):
         if cfg.colocate:
             cmd.append("--colocate")
         self.proc = subprocess.Popen(cmd)
-        self._poll(lambda: self.session.get(f"{self.base_url}/health", timeout=3).ok, cfg.startup_timeout, "server")
+        self._poll(
+            lambda: self.session.get(f"{self.base_url}/health", timeout=self.timeout).ok, cfg.startup_timeout, "server"
+        )
 
     @staticmethod
     def _poll(pred, timeout: float, what: str) -> None:

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -205,3 +205,10 @@ class TestTransportSelection:
         monkeypatch.setattr(ray_mod, "RayTransport", DummyRay)
         cfg = ArcticRLClientConfig(model_name="m", comm_protocol="ray", training_gpus=1)
         assert isinstance(client_module.make_transport(cfg), DummyRay)
+
+    def test_make_transport_selects_http_for_onprem(self):
+        """onprem + http (the default) routes to HttpTransport."""
+        from arctic_platform.client.transports.onprem_http import HttpTransport
+
+        cfg = ArcticRLClientConfig(model_name="m", comm_protocol="http", training_gpus=1)
+        assert isinstance(client_module.make_transport(cfg), HttpTransport)


### PR DESCRIPTION
Add HttpTransport (onprem/dss) alongside the existing Ray transport: it POSTs each op to /{op}?job_id=..., sending an octet torch payload for tensor-bearing ops and JSON otherwise, and can launch/await a local server. Widen the config (comm_protocol http|ray defaulting to http; add the dss backend + HTTP fields) and route make_transport to HttpTransport for onprem-http. Extend the client op tests with make_transport selection for http/dss.