### PR TITLE
feat(client): add Cortex transport + DSSST1 wire codec

### DIFF
--- a/arctic_platform/client/UNIFICATION_NOTES.md
+++ b/arctic_platform/client/UNIFICATION_NOTES.md
@@ -2,28 +2,100 @@
 
 Goal: one `ArcticRLClient` frontend where **every backend accepts identical
 per-op args/kwargs and returns identically-shaped responses**, so each transport
-is a dumb forwarder of `Request(op, job_id, body)` with no per-op rewiring.
+is a dumb forwarder of `Request(op, job_id, body)` with no per-op rewiring. The
+on-prem transports (HTTP + Ray) already meet this bar; Cortex does not yet (see
+"Cortex transport" below).
 
-This package is the target design. The op *surface* (names, args, canonical
-body, which job each op targets, response contract) is defined once in
-`client.py`; a transport owns only job identity + wire mechanics.
+This package is the target design. These notes track what still diverges in the
+three existing clients so the remaining convergence work is explicit. Most of the
+hard blockers are **server-side** — the clients can only converge once the
+servers accept the same contract.
 
-## Design in place (this package)
+## Clients being reconciled
+
+1. **arctictraining** — `ArcticTraining-dss/arctic_training/arctic_rl/client.py`.
+   One sync class; `backend ∈ {local, dss-platform, neutrino}`; branches
+   internally on `self._is_neutrino` in nearly every method.
+2. **NeutrinoClient** — `dss-client/dss_client/neutrino_client.py`. A low-level
+   SnowAPI client (not an `ArcticRLClient`). Our `CortexTransport` now
+   reimplements a trimmed subset of it.
+3. **arctic_platform** — `arctic_platform/rl/{client,http_client,ray_client}.py`.
+   `create_arctic_rl_client` picks `ArcticRLHTTPClient` or `ArcticRLRayClient`
+   by `comm_protocol`; **all ops are `async def`**.
+
+## Per-op API divergence
+
+| op | arctictraining (sync) | arctic_platform (async) | this package |
+|----|----|----|----|
+| `fwd_bwd` | `(batch, processing=None, router_replay=None)` | `(batch, processing=None)` | `(batch, processing=None, router_replay=None)` |
+| `fwd_no_grad` | `(batch)` | `(batch, reference_model)` | `(batch)` |
+| `step` | `(learning_rate=None)` | `()` — no LR | `(learning_rate=None)` |
+| `generate` | `(prompts, sampling_params=None, routing_key=None, strict=False)` | `(prompts, sampling_params=None)` | `(prompts, sampling_params=None, routing_key=None)` |
+| `sync_weights` | `()` | `(cuda_ipc=False, low_memory=False)` | `()` |
+| `save_checkpoint` | `(stage_info=None, path=None, checkpoint_type="resumable")` | `()` | `(stage_info=None, path=None)` |
+| `reset_prefix_cache` | `(drain=True, timeout_s=60, retry_interval_s=0.1)` | `()` | `(drain=True, timeout_s=60)` |
+| `log_probs` | `(prompts, completions=None, top_k=1)` | `(prompts, completions=None, top_k=1)` | `(prompts, completions=None, top_k=1)` |
+
+## What's missing / divergent per client
+
+### arctictraining `ArcticRLClient`
+- Sync class that branches on `if self._is_neutrino` in every op — exactly the
+  divergence this design removes (op logic single-sourced in `client.py`,
+  backend behind a transport).
+- Richest surface today: router-replay bootstrap/meta/attach, `generate_stream`
+  + `get_request_status` + `cancel_request`, resume-from-checkpoint preflight,
+  Neutrino experiment naming, save-checkpoint id resolution.
+- Neutrino branch raises `NotImplementedError` for `fwd_no_grad`, `log_probs`,
+  `save_weights` (disk reload) — same gaps as our `CortexTransport`.
+- No colocation lifecycle ops; no CUDA-IPC weight sync.
+
+### `NeutrinoClient` (dss-client)
+- Not an `ArcticRLClient`: a transport-level SnowAPI client. Ops are named
+  `forward_backward` / `step` / `save` / `generate` / `weight_sync` /
+  `operation`, return **request ids the caller must `poll_request`**, and there
+  is no unified op vocabulary or response shaping.
+- No `fwd_no_grad` / `log_probs` / `save_weights`; no colocation ops.
+- Has (unused by the minimal transport): chunked octet uploads, client-side
+  prompt-length validation, capacity, log/event streaming, router-replay ops,
+  checkpoint list/export, retry/backoff plumbing.
+- Owns the client-side tokenization helpers (`build_forward_backward_kwargs`);
+  the cortex fwd-bwd batch is prepared here, not in the frontend. (Our example
+  reimplements a slice of this inline.)
+
+### arctic_platform `ArcticRLClient` (rl/)
+- **Async** ops (`async def fwd_bwd/step/generate/...`) vs sync cortex/dss — a
+  fundamental calling-convention mismatch to reconcile.
+- Split into two classes chosen by `comm_protocol`, with per-op signatures that
+  drift from cortex/dss: `step()` has no `learning_rate`; `generate()` lacks
+  `routing_key`/`strict`; `fwd_no_grad(batch, reference_model)` carries an extra
+  routing flag; `sync_weights(cuda_ipc, low_memory)` + `colocate`;
+  `save_checkpoint()` / `reset_prefix_cache()` take no args.
+- **Wire codec divergence**: uses `torch.save` / `torch.load` (pickle) on the
+  wire, while cortex/dss use the DSSST1 safetensors `wire` codec. Our
+  `onprem_http` mirrors the pickle path (`_dumps`/`_loads`) to match today's
+  server; it cannot switch to `wire` until the on-prem server does.
+- Large colocation surface with no cortex/dss twin: `sleep_/wake_inference`,
+  `sleep_/wake_training`, `sleep_/wake_log_prob`, `empty_training_cache`,
+  `weight_norm`.
+- Ray path: `ArcticRLRayServer` methods take a uniform `(job_id, body)` shape
+  matching the HTTP `POST /{op}` surface, so `RayTransport._rpc` forwards
+  `(job_id, body)` with no per-op binding.
+
+## Server-side blockers (cannot be fixed in the client)
+- **fwd_bwd batch contract**: cortex expects RPC-style `{args, kwargs}` tokenized
+  server-side; on-prem expects pre-tokenized verl-GRPO `{batch, meta, processing}`.
+- **Response schema**: cortex returns loss only; on-prem returns
+  `{metrics: {grad_norm, ...}}` (scalars sometimes per-DP-rank lists).
+- **One wire codec** (DSSST1 safetensors) across all servers so transports share
+  serialization.
+- **Sync vs async**: pick one convention for the frontend.
+
+## Sharing already in place (this package)
 - `Transport` ABC + `JobHandles` + `Request` (single op vocabulary in `client.py`).
-- `OnPremTransport` base: job creation, ordering, payload building, and a uniform
-  `call` that posts/dispatches the op against its target job. Concrete transports
-  implement only the delivery primitives (`_start`, `_rpc`, `_destroy`,
-  `_wait_running`).
-- `JOB_CREATE_ORDER` + `ArcticRLClientConfig.gpus_for()` centralize GPU-gating and
-  creation order so transports no longer hand-roll them.
-
-## On-prem Ray transport
-`RayTransport` makes in-process Ray actor calls — no HTTP, no serialization. The
-server splits into a `state` actor (job creation) and an `ArcticRLRayServer`
-wrapper (typed async ops) that snapshots workers at construction, so the wrapper
-is built lazily after jobs are initialized. `_rpc` resolves `op -> method` and
-forwards `(job_id, body)` unchanged, matching the server's uniform
-`op(job_id, body) -> dict` surface.
+- `OnPremTransport` base shared by `onprem_http` and `onprem_ray`.
+- `JOB_CREATE_ORDER` + `ArcticRLClientConfig.gpus_for()` shared by cortex and
+  on-prem job initialization.
+- Cortex and on-prem no longer hand-roll GPU-gating / creation order separately.
 
 ## On-prem HTTP transport
 `HttpTransport` shares the same `OnPremTransport` control plane and only supplies
@@ -33,6 +105,19 @@ responses; everything else is JSON. It also optionally launches a local server
 (`launch_local_server`) and polls `/health` + `/job/{id}` to wait for readiness.
 The Ray path forwards `(job_id, body)` to the same uniform server surface, so the
 two transports differ only in `_start`/`_rpc`/`_destroy`.
+
+## Cortex transport: the remaining non-trivial forwarder
+`CortexTransport` is the one transport that still does per-op translation: each
+op has a handler mapping the canonical `body` to a SnowAPI call (path, wire
+framing, sub-job routing, submit→poll). It shares only the `Transport` ABC and
+the `wire` codec with on-prem, because Cortex's async submit→poll model has no
+counterpart in on-prem's synchronous request/response.
+
+The eventual goal is to unify the Cortex and on-prem **server** APIs (op names,
+argument shapes, response schemas) so `CortexTransport` can collapse to the same
+dumb `_rpc(request)` as the on-prem transports — forwarding just `(job_id, body)`
+with no per-method translation. Until the servers converge on the blockers above,
+Cortex keeps its per-op handlers.
 
 ## Not yet in unified client (future work)
 Ops present in `arctic_platform/rl/*_client.py` but not yet on `ArcticRLClient`.

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -30,6 +30,10 @@ from arctic_platform.client.transport import Transport
 
 
 def make_transport(config: ArcticRLClientConfig) -> Transport:
+    if config.backend == "cortex":
+        from arctic_platform.client.transports.cortex import CortexTransport
+
+        return CortexTransport(config)
     from arctic_platform.client.transports.onprem_http import HttpTransport
     from arctic_platform.client.transports.onprem_ray import RayTransport
 

--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -29,12 +29,12 @@ JobId = int | str
 class ArcticRLClientConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", validate_default=True)
 
-    backend: Literal["onprem"] = Field("onprem", description="Deployment target.")
+    backend: Literal["onprem", "cortex"] = Field("onprem", description="Deployment target.")
     comm_protocol: Literal["http", "ray"] = Field("http", description="onprem transport: HTTP or in-process Ray.")
     model_name: str = Field(..., description="HF model id to train/serve.")
     seed: int | None = Field(None, description="Global seed.")
     dtype: str | None = Field(None, description="Parameter dtype override.")
-    max_seq_len: int = Field(8192, description="Max sequence length.")
+    max_seq_len: int = Field(8192, description="Max sequence length (cortex sub-jobs).")
 
     # GPU allocation — a job type is created only when its count is > 0.
     training_gpus: int = 0
@@ -62,6 +62,14 @@ class ArcticRLClientConfig(BaseModel):
             "that call and falls back to this dir when path is None."
         ),
     )
+
+    # cortex (SnowAPI)
+    cortex_base_url: str | None = Field(None, description="Mock/direct GS URL; bypasses PAT auth.")
+    cortex_host: str | None = None
+    cortex_pat_env_var: str = "CORTEX_PAT"
+    cortex_database: str = ""
+    cortex_schema: str = ""
+    cortex_endpoint: str = "cortex-training"
 
     # Reconnect: attach to pre-existing jobs instead of creating new ones.
     training_job_id: JobId | None = None

--- a/arctic_platform/client/examples/sft_example.py
+++ b/arctic_platform/client/examples/sft_example.py
@@ -13,14 +13,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unified SFT training example across the on-prem backends.
+"""Unified SFT training example across all three backends.
 
     python arctic_platform/client/examples/sft_example.py --backend onprem-http
     python arctic_platform/client/examples/sft_example.py --backend onprem-ray
+    python arctic_platform/client/examples/sft_example.py --backend cortex
 
 Every backend follows the *same* pathway: build config -> ArcticRLClient ->
 loop(fwd_bwd + step) -> shutdown, with a single unified fwd_bwd/step/report.
 The client + transports hide all wire/protocol differences.
+
+The data is identical across backends: one MODEL tokenizes one PROMPT into one
+set of tensors (`_tokens`). Only the fwd_bwd wire *shape* differs (Cortex:
+{input_ids, labels}; on-prem: verl-GRPO {batch, meta, processing}), because the
+servers still accept different contracts — so each backend just repackages the
+same tokens. Converging the shape is a server-side change tracked in
+ArcticRLClient.fwd_bwd; the connection config is the only other per-backend bit.
+
+The cortex backend authenticates with a PAT read from the CORTEX_PAT env var:
+
+    export CORTEX_PAT=<your programmatic access token>
 """
 
 from __future__ import annotations
@@ -46,6 +58,8 @@ STEPS = 20
 SEED = 42
 N_GPUS = 8
 
+# Same data for every backend: one model tokenizes one prompt into one set of
+# tensors. Each backend's batch builder only *repackages* those tensors.
 MODEL = "Qwen/Qwen3-0.6B"
 LR = 1e-5
 PROMPT = "who trained you?\nMichael Wyatt at Snowflake"
@@ -55,6 +69,12 @@ SEQ_LEN = PROMPT_LEN + RESPONSE_LEN
 ROLLOUT_N = 1
 ATTN = "sdpa"  # flash_attention_2 needs the flash_attn package; sdpa ships with torch
 
+# cortex connection
+CORTEX_HOST = "dsa-test.qa6.us-west-2.aws.snowflakecomputing.com"
+CORTEX_DATABASE = "NEUTRINO_DB"
+CORTEX_SCHEMA = "PUBLIC"
+CORTEX_ENDPOINT = "cortex-training"
+
 
 def _metric(x) -> float:
     """step merges across DP ranks, so a replicated scalar can arrive as a per-rank list."""
@@ -62,6 +82,28 @@ def _metric(x) -> float:
 
 
 # ── per-backend: config ──────────────────────────────────────────────────────
+def _cortex_config(stack: contextlib.ExitStack) -> ArcticRLClientConfig:
+    return ArcticRLClientConfig(
+        backend="cortex",
+        model_name=MODEL,
+        training_gpus=N_GPUS,
+        max_seq_len=SEQ_LEN,
+        dtype="bfloat16",
+        seed=SEED,
+        cortex_host=CORTEX_HOST,
+        cortex_pat_env_var="CORTEX_PAT",  # export CORTEX_PAT=<token> before running
+        cortex_database=CORTEX_DATABASE,
+        cortex_schema=CORTEX_SCHEMA,
+        cortex_endpoint=CORTEX_ENDPOINT,
+        training_config={
+            "optimizer": {"name": "AdamW", "lr": LR, "weight_decay": 0.0, "betas": [0.9, 0.999], "eps": 1e-8},
+            "train_batch_size": N_GPUS,
+            "gradient_clipping": 1.0,
+            "model_provider": "huggingface",
+        },
+    )
+
+
 def _onprem_config(comm_protocol: str, launch_local_server: bool) -> Callable:
     def build(stack: contextlib.ExitStack) -> ArcticRLClientConfig:
         ckpt = stack.enter_context(tempfile.TemporaryDirectory(prefix="arl_onprem_ckpt_"))
@@ -99,8 +141,13 @@ def _onprem_config(comm_protocol: str, launch_local_server: bool) -> Callable:
 
 
 # ── shared data, per-backend packaging ───────────────────────────────────────
+# The tokens are identical across backends; only the wire *shape* differs, because
+# the servers still accept different fwd_bwd contracts (Cortex: RPC-style
+# {input_ids, labels}; on-prem: verl-GRPO {batch, meta, processing}). See
+# ArcticRLClient.fwd_bwd's TODO — converging that is a server-side change, after
+# which the two packagers below collapse into one.
 def _tokens() -> dict:
-    """Tokenize the shared PROMPT with the shared MODEL — the payload the backend sends."""
+    """Tokenize the shared PROMPT with the shared MODEL — the payload both backends send."""
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL)
@@ -124,18 +171,36 @@ def _tokens() -> dict:
     }
 
 
+def _cortex_batch(tokens: dict) -> Any:
+    import torch
+
+    input_ids = tokens["input_ids"]
+    # next-token labels, with padding positions masked out to ignore_index (-100).
+    labels = torch.roll(input_ids, shifts=-1, dims=1)
+    labels[:, -1] = -100
+    shifted_mask = torch.roll(tokens["attention_mask"], shifts=-1, dims=1)
+    shifted_mask[:, -1] = 0
+    labels = labels.masked_fill(shifted_mask == 0, -100)
+    return {"args": [], "kwargs": {"input_ids": input_ids, "labels": labels.contiguous()}}
+
+
 def _onprem_batch(tokens: dict) -> Any:
     from rl_harness import build_update_actor_payload
 
     # `processing` stays inside the payload: client.fwd_bwd folds a `processing=`
     # kwarg into the body anyway, so leaving it in yields the identical wire body
-    # and lets the backend share the same `client.fwd_bwd(batch)` call.
+    # and lets every backend share the same `client.fwd_bwd(batch)` call.
     return build_update_actor_payload(tokens, False, ROLLOUT_N, PROMPT_LEN, RESPONSE_LEN)
 
 
 # ── unified across all backends ──────────────────────────────────────────────
 def _report(step: int, out: dict, step_out: dict) -> str:
-    """One report for every backend, via graceful key lookups on the responses."""
+    """One report for every backend, via graceful key lookups on the responses.
+
+    Response shapes still diverge (Cortex: loss only; on-prem: avg_loss +
+    grad_norm in step metrics) — see ArcticRLClient.step's TODO. Until those
+    converge, we cope here rather than branch on backend.
+    """
     loss = _metric(out.get("avg_loss", out.get("loss")))
     line = f"step {step + 1}/{STEPS} loss={loss:.4g}"
     grad_norm = (step_out or {}).get("metrics", {}).get("grad_norm")
@@ -151,6 +216,7 @@ class Profile:
 
 
 BACKENDS: dict[str, Profile] = {
+    "cortex": Profile(_cortex_config, _cortex_batch),
     "onprem-http": Profile(_onprem_config("http", True), _onprem_batch),
     "onprem-ray": Profile(_onprem_config("ray", False), _onprem_batch),
 }
@@ -171,6 +237,8 @@ def main() -> None:
             for step in range(STEPS):
                 # RL note: a full loop would create a sampling job, generate() a
                 # rollout, score it into advantages, then feed that here.
+                # One fwd_bwd call for every backend -- only `batch`'s wire shape
+                # differs (see note on ArcticRLClient.fwd_bwd).
                 out = client.fwd_bwd(batch)
                 step_out = client.step()
                 print(_report(step, out, step_out))

--- a/arctic_platform/client/transports/cortex.py
+++ b/arctic_platform/client/transports/cortex.py
@@ -1,0 +1,548 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cortex (cortex-training) transport over the SnowAPI GS REST surface.
+
+The transport *owns* the Cortex wire mechanics: it builds the SnowAPI session,
+submits each op over HTTP, and polls the async request to completion. There is
+no separately-held client object — `call` is an op->handler table, the only
+place Cortex specifics live. Unlisted ops (fwd-no-grad, log-probs, save-weights)
+raise NotImplementedError.
+
+The types and codec needed to talk to Cortex live in the client package:
+`JobType`/`SubJobConfig`/`TrainingConfig`/`InferenceConfig` (the CreateJob wire
+schema) below, and the DSSST1 safetensors codec in `arctic_platform.client.wire`.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import time
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+from typing import Any
+from typing import Callable
+
+import requests
+
+from arctic_platform.client import wire
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.transport import JOB_TYPES
+from arctic_platform.client.transport import JobHandles
+from arctic_platform.client.transport import Request
+from arctic_platform.client.transport import Transport
+
+# Ask the server for a chunked DSSST1 (safetensors) response for tensor-bearing ops.
+_CHUNKED_DSSST1 = {"response_options": {"format": "dssst1", "delivery": "chunked"}}
+
+
+# ─── CreateJob wire schema ────────────────────────────────────────────────
+
+
+class JobType(str, Enum):
+    TRAINING = "training"
+    SAMPLING = "sampling"
+    LOG_PROBABILITY = "log_probability"
+
+
+@dataclass
+class TrainingConfig:
+    optimizer: dict
+    max_seq_len: int
+    train_batch_size: int
+    n_gpus: int
+    gradient_clipping: float | None = None
+    load_optimizer_states: bool | None = None
+    extra: dict = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not isinstance(self.optimizer, dict) or not self.optimizer:
+            raise ValueError("training.optimizer is required and must be a non-empty dict")
+        if self.max_seq_len <= 0:
+            raise ValueError("training.max_seq_len must be > 0")
+        if self.train_batch_size <= 0:
+            raise ValueError("training.train_batch_size must be > 0")
+        if self.n_gpus <= 0:
+            raise ValueError("training.n_gpus must be > 0")
+
+    def to_wire(self) -> dict:
+        out: dict = {
+            "optimizer": self.optimizer,
+            "max_seq_len": self.max_seq_len,
+            "train_batch_size": self.train_batch_size,
+            "n_gpus": self.n_gpus,
+        }
+        if self.gradient_clipping is not None:
+            out["gradient_clipping"] = self.gradient_clipping
+        if self.load_optimizer_states is not None:
+            out["load_optimizer_states"] = self.load_optimizer_states
+        for k, v in self.extra.items():
+            out.setdefault(k, v)
+        return out
+
+
+@dataclass
+class InferenceConfig:
+    max_seq_len: int
+    n_gpus: int
+    extra: dict = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if self.max_seq_len <= 0:
+            raise ValueError("sampling.max_seq_len must be > 0")
+        if self.n_gpus <= 0:
+            raise ValueError("sampling.n_gpus must be > 0")
+
+    def to_wire(self) -> dict:
+        out: dict = {"max_seq_len": self.max_seq_len, "n_gpus": self.n_gpus}
+        for k, v in self.extra.items():
+            out.setdefault(k, v)
+        return out
+
+
+@dataclass
+class SubJobConfig:
+    job_type: JobType
+    model_name: str
+    training: TrainingConfig | None = None
+    sampling: InferenceConfig | None = None
+    dtype: str | None = None
+    seed: int | None = None
+
+    @classmethod
+    def training_job(
+        cls,
+        model_name: str,
+        *,
+        optimizer: dict,
+        max_seq_len: int,
+        train_batch_size: int,
+        n_gpus: int,
+        extra_training: dict | None = None,
+        dtype: str | None = None,
+        seed: int | None = None,
+    ) -> SubJobConfig:
+        return cls(
+            job_type=JobType.TRAINING,
+            model_name=model_name,
+            training=TrainingConfig(
+                optimizer=optimizer,
+                max_seq_len=max_seq_len,
+                train_batch_size=train_batch_size,
+                n_gpus=n_gpus,
+                extra=dict(extra_training) if extra_training else {},
+            ),
+            dtype=dtype,
+            seed=seed,
+        )
+
+    @classmethod
+    def sampling_job(
+        cls,
+        model_name: str,
+        *,
+        max_seq_len: int,
+        n_gpus: int,
+        extra_sampling: dict | None = None,
+        job_type: JobType = JobType.SAMPLING,
+        dtype: str | None = None,
+        seed: int | None = None,
+    ) -> SubJobConfig:
+        if job_type not in (JobType.SAMPLING, JobType.LOG_PROBABILITY):
+            raise ValueError(f"sampling_job() only accepts SAMPLING or LOG_PROBABILITY, got {job_type!r}")
+        return cls(
+            job_type=job_type,
+            model_name=model_name,
+            sampling=InferenceConfig(
+                max_seq_len=max_seq_len,
+                n_gpus=n_gpus,
+                extra=dict(extra_sampling) if extra_sampling else {},
+            ),
+            dtype=dtype,
+            seed=seed,
+        )
+
+    def validate(self) -> None:
+        if not self.model_name:
+            raise ValueError("sub_job.model_name is required")
+        if self.job_type == JobType.TRAINING:
+            if self.training is None:
+                raise ValueError("training sub-job requires a `training` block")
+            self.training.validate()
+        else:
+            if self.sampling is None:
+                raise ValueError(f"{self.job_type.value} sub-job requires a `sampling` block")
+            self.sampling.validate()
+
+    def to_wire(self) -> dict:
+        out: dict = {"job_type": self.job_type.value, "model_name": self.model_name}
+        if self.dtype is not None:
+            out["dtype"] = self.dtype
+        if self.seed is not None:
+            out["seed"] = self.seed
+        if self.training is not None:
+            out["training_config"] = self.training.to_wire()
+        if self.sampling is not None:
+            out["inference_config"] = self.sampling.to_wire()
+        return out
+
+
+# ─── Result decoding ──────────────────────────────────────────────────────
+
+
+def _load_torch():
+    import torch
+
+    return torch
+
+
+def _restore_generate_result_lists(value: Any, torch_module: Any = None) -> Any:
+    torch_module = _load_torch() if torch_module is None else torch_module
+    if torch_module.is_tensor(value):
+        return value.cpu().tolist()
+    if isinstance(value, dict):
+        return {key: _restore_generate_result_lists(item, torch_module) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_restore_generate_result_lists(item, torch_module) for item in value)
+    return value
+
+
+def _decode_result_payload(result: dict) -> dict | None:
+    if not isinstance(result, dict) or result.get("wire_format") != wire.WIRE_FORMAT_VERSION:
+        return None
+    if result.get("encoding") != "base64":
+        raise RuntimeError("DSSST1 result payload must use base64 encoding")
+    raw = result.get("payload_b64")
+    if not isinstance(raw, str) or not raw:
+        raise RuntimeError("DSSST1 result payload missing payload_b64")
+    decoded = wire.loads(base64.b64decode(raw))
+    if not isinstance(decoded, dict):
+        raise RuntimeError("DSSST1 result payload did not decode to a dict")
+    return decoded
+
+
+def _decode_result_chunk_event(event: dict) -> bytes | None:
+    if not isinstance(event, dict) or event.get("type") != "result_chunk":
+        return None
+    raw = event.get("payload_b64")
+    if not isinstance(raw, str) or not raw:
+        raise RuntimeError("result_chunk event missing payload_b64")
+    payload = base64.b64decode(raw)
+    expected = event.get("payload_sha256")
+    if expected is not None and hashlib.sha256(payload).hexdigest() != expected:
+        raise RuntimeError("result_chunk payload_sha256 mismatch")
+    return payload
+
+
+# ─── Transport ─────────────────────────────────────────────────────────────
+
+
+class CortexTransport(Transport):
+    _MAX_FWD_BWD_BYTES = 60 * 1024 * 1024
+    _MAX_GENERATE_BYTES = 60 * 1024 * 1024
+
+    poll_interval = 0.5
+    poll_timeout = 1800.0
+    poll_backoff_multiplier = 1.25
+    poll_max_interval = 6.0
+
+    def __init__(self, config: ArcticRLClientConfig) -> None:
+        self.config = config
+        self.jobs = JobHandles()
+        self.job_id: str | None = None
+        self.sub_jobs: dict[str, str] = {}
+        self._generate_request_ids: set[str] = set()
+        self._session = self._build_session()
+        self._handlers: dict[str, Callable[[dict], dict]] = {
+            "fwd-bwd": self._fwd_bwd,
+            "step": self._step,
+            "save-checkpoint": self._save_checkpoint,
+            "generate": self._generate,
+            "sync-weights": self._sync_weights,
+            "reset-prefix-cache": self._reset_prefix_cache,
+        }
+
+    def initialize(self) -> JobHandles:
+        cfg = self.config
+        if cfg.training_job_id is not None:  # reconnect
+            self.job_id = str(cfg.training_job_id)
+            self.jobs = JobHandles.from_config(cfg)
+            self.sub_jobs = {jt: f"{self.job_id}:{jt}" for jt in ("training", "sampling", "log_probability")}
+            return self.jobs
+        self.job_id = self._create_job(self._build_sub_jobs())
+        self._capture_sub_jobs(self._wait_for_job(self.job_id))
+        for job_type in JOB_TYPES:
+            if cfg.gpus_for(job_type) > 0:
+                self.jobs.set(job_type, self.job_id)
+        return self.jobs
+
+    def call(self, request: Request) -> dict:
+        handler = self._handlers.get(request.op)
+        if handler is None:
+            raise NotImplementedError(f"cortex has no {request.op}")
+        return handler(request.body)
+
+    def shutdown(self) -> None:
+        if self.job_id is not None:
+            try:
+                self._send("POST", f"{self._prefix}/{self.job_id}:cancel")
+            except Exception:
+                pass
+
+    # ── op handlers: canonical body -> SnowAPI call -> canonical dict ──────
+    def _fwd_bwd(self, body: dict) -> dict:
+        payload = wire.dumps(body, metadata=_CHUNKED_DSSST1)
+        request_id = self._post_octet_request_chunks(
+            path_suffix="forward-backward",
+            operation="fwd-bwd",
+            frame=payload,
+            max_bytes=self._MAX_FWD_BWD_BYTES,
+        )["request_id"]
+        return self._poll(request_id)
+
+    def _step(self, body: dict) -> dict:
+        req_body = {} if body["learning_rate"] is None else {"learning_rate": body["learning_rate"]}
+        request_id = self._send("POST", f"{self._prefix}/{self.job_id}/step", json=req_body).json()["request_id"]
+        return self._poll(request_id)
+
+    def _save_checkpoint(self, body: dict) -> dict:
+        request_id = self._send(
+            "POST",
+            f"{self._prefix}/{self.job_id}/save",
+            json={"checkpoint_type": "resumable"},
+        ).json()["request_id"]
+        return self._poll(request_id)
+
+    def _generate(self, body: dict) -> dict:
+        payload: dict = {"prompts": body["prompts"]}
+        if body["sampling_params"] is not None:
+            payload["sampling_params"] = body["sampling_params"]
+        if body["routing_key"] is not None:
+            payload["routing_key"] = body["routing_key"]
+        frame = wire.dumps(payload, metadata=_CHUNKED_DSSST1)
+        request_id = self._post_octet_request_chunks(
+            path_suffix="generate",
+            operation="generate",
+            frame=frame,
+            max_bytes=self._MAX_GENERATE_BYTES,
+        )["request_id"]
+        self._generate_request_ids.add(request_id)
+        return {"results": self._poll(request_id).get("results", [])}
+
+    def _sync_weights(self, body: dict) -> dict:
+        source = self.sub_jobs["training"]
+        request_id = self._operation(
+            "weight-sync",
+            payload={"source_sub_job_id": source, "target_sub_job_ids": [self.sub_jobs["sampling"]]},
+            sub_job_id=source,
+            sub_job_type="training",
+        )["request_id"]
+        return self._poll(request_id)
+
+    def _reset_prefix_cache(self, body: dict) -> dict:
+        result = self._operation(
+            "reset-prefix-cache",
+            payload={"drain": body["drain"], "timeout_s": body["timeout_s"], "retry_interval_s": 0.1},
+            sub_job_type="sampling",
+        )
+        request_id = result.get("request_id") if isinstance(result, dict) else None
+        return self._poll(request_id) if request_id else result
+
+    # ── SnowAPI HTTP layer ─────────────────────────────────────────────────
+    def _build_session(self) -> requests.Session:
+        cfg = self.config
+        session = requests.Session()
+        if cfg.cortex_base_url is not None:
+            self.base_url = cfg.cortex_base_url.rstrip("/")
+            return session
+        self.base_url = f"https://{cfg.cortex_host}"
+        session.headers["Authorization"] = f"Bearer {os.environ[cfg.cortex_pat_env_var]}"
+        session.headers["X-Snowflake-Authorization-Token-Type"] = "PROGRAMMATIC_ACCESS_TOKEN"
+        return session
+
+    @property
+    def _prefix(self) -> str:
+        cfg = self.config
+        return (
+            f"{self.base_url}/api/v2/databases/{cfg.cortex_database}/schemas/{cfg.cortex_schema}/{cfg.cortex_endpoint}"
+        )
+
+    def _send(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        resp = getattr(self._session, method.lower())(url, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def _create_job(self, sub_jobs: list[SubJobConfig]) -> str:
+        if not sub_jobs:
+            raise ValueError("create_job requires a non-empty sub_jobs list")
+        for sj in sub_jobs:
+            sj.validate()
+        body = {"sub_job_configs": [sj.to_wire() for sj in sub_jobs]}
+        return self._send("POST", self._prefix, json=body).json()["job_id"]
+
+    def _wait_for_job(self, job_id: str) -> dict:
+        deadline = time.monotonic() + self.poll_timeout
+        delay = self.poll_interval
+        while time.monotonic() < deadline:
+            job = self._send("GET", f"{self._prefix}/{job_id}").json()
+            status = str(job.get("status", "")).lower().removeprefix("job_state_")
+            if status == "running":
+                return job
+            if status in ("failed", "done", "cancelled", "canceled"):
+                raise RuntimeError(f"Job {job_id} reached terminal state '{status}': {job.get('reason', '')}")
+            delay = self._sleep_with_backoff(delay, deadline)
+        raise TimeoutError(f"Job {job_id} did not become running within {self.poll_timeout}s")
+
+    def _post_octet_request_chunks(self, *, path_suffix: str, operation: str, frame: bytes, max_bytes: int) -> dict:
+        chunks = wire.encode_byte_chunks(frame, kind="request", operation=operation, max_bytes=max_bytes)
+        final_body: dict | None = None
+        for idx, chunk in enumerate(chunks):
+            body = self._send(
+                "POST",
+                f"{self._prefix}/{self.job_id}/{path_suffix}",
+                data=chunk,
+                headers={"Content-Type": "application/octet-stream"},
+            ).json()
+            if idx < len(chunks) - 1:
+                if isinstance(body, dict) and body.get("request_id"):
+                    raise RuntimeError(f"{operation} chunk {idx} unexpectedly returned request_id")
+                continue
+            final_body = body
+        if final_body is None:
+            raise RuntimeError(f"{operation} produced no request body")
+        return final_body
+
+    def _operation(
+        self,
+        operation_type: str,
+        *,
+        payload: dict,
+        sub_job_id: str | None = None,
+        sub_job_type: str | None = None,
+    ) -> dict:
+        body: dict = {"operation_type": operation_type, "payload": payload}
+        if sub_job_id is not None:
+            body["sub_job_id"] = sub_job_id
+        if sub_job_type is not None:
+            body["sub_job_type"] = sub_job_type
+        return self._send("POST", f"{self._prefix}/{self.job_id}/operation", json=body).json()
+
+    def _poll(self, request_id: str) -> dict:
+        deadline = time.monotonic() + self.poll_timeout
+        delay = self.poll_interval
+        result_chunks: list[bytes] = []
+        cursor: str | None = None
+        while time.monotonic() < deadline:
+            status = self._get_request_status(request_id, cursor)
+            state = str(status.get("status", "")).lower().removeprefix("request_state_")
+            received_chunk = False
+            for event in status.get("events") or []:
+                chunk = _decode_result_chunk_event(event)
+                if chunk is not None:
+                    result_chunks.append(chunk)
+                    received_chunk = True
+            next_cursor = status.get("next_cursor")
+            if isinstance(next_cursor, str) and next_cursor:
+                cursor = next_cursor
+                continue
+            if state in ("completed", "done", "succeeded"):
+                return self._finalize_result(request_id, status, result_chunks)
+            if state in ("failed", "cancelled", "canceled"):
+                self._generate_request_ids.discard(request_id)
+                raise RuntimeError(f"Request {request_id} ended with state '{state}': {status.get('error', '')}")
+            if received_chunk:
+                continue
+            delay = self._sleep_with_backoff(delay, deadline)
+        self._generate_request_ids.discard(request_id)
+        raise TimeoutError(f"Request {request_id} did not complete within {self.poll_timeout}s")
+
+    def _get_request_status(self, request_id: str, cursor: str | None) -> dict:
+        params = {"cursor": cursor} if cursor else None
+        return self._send("GET", f"{self._prefix}/{self.job_id}/requests/{request_id}", params=params).json()
+
+    def _finalize_result(self, request_id: str, status: dict, result_chunks: list[bytes]) -> dict:
+        if result_chunks:
+            result = wire.decode_result_chunks(result_chunks)
+        else:
+            result = status.get("result") or {}
+            decoded = _decode_result_payload(result)
+            if decoded is not None:
+                result = decoded
+        is_generate = request_id in self._generate_request_ids
+        self._generate_request_ids.discard(request_id)
+        if is_generate and isinstance(result, dict) and "results" in result:
+            result = {**result, "results": _restore_generate_result_lists(result["results"])}
+        return result
+
+    def _sleep_with_backoff(self, delay: float, deadline: float) -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return delay
+        time.sleep(min(delay, remaining))
+        return min(delay * self.poll_backoff_multiplier, self.poll_max_interval)
+
+    # ── sub-job wiring ─────────────────────────────────────────────────────
+    def _build_sub_jobs(self) -> list[SubJobConfig]:
+        cfg = self.config
+        tc = cfg.training_config or {}
+        subs: list[SubJobConfig] = []
+        if cfg.sampling_gpus > 0:
+            subs.append(
+                SubJobConfig.sampling_job(
+                    model_name=cfg.model_name,
+                    max_seq_len=cfg.max_seq_len,
+                    n_gpus=cfg.sampling_gpus,
+                    extra_sampling=cfg.vllm_config or {},
+                    job_type=JobType.SAMPLING,
+                    dtype=cfg.dtype,
+                    seed=cfg.seed,
+                )
+            )
+        if cfg.log_prob_gpus > 0:
+            subs.append(
+                SubJobConfig.sampling_job(
+                    model_name=cfg.model_name,
+                    max_seq_len=cfg.max_seq_len,
+                    n_gpus=cfg.log_prob_gpus,
+                    extra_sampling=cfg.vllm_config or {},
+                    job_type=JobType.LOG_PROBABILITY,
+                    dtype=cfg.dtype,
+                    seed=cfg.seed,
+                )
+            )
+        if cfg.training_gpus > 0:
+            subs.append(
+                SubJobConfig.training_job(
+                    model_name=cfg.model_name,
+                    optimizer=tc.get("optimizer", {"type": "adamw", "lr": 1e-5}),
+                    max_seq_len=cfg.max_seq_len,
+                    train_batch_size=tc.get("train_batch_size", 1),
+                    n_gpus=cfg.training_gpus,
+                    extra_training=tc,
+                    dtype=cfg.dtype,
+                    seed=cfg.seed,
+                )
+            )
+        return subs
+
+    def _capture_sub_jobs(self, job_info: dict) -> None:
+        job = job_info.get("job", job_info)
+        for sub in job.get("sub_jobs", []) or []:
+            job_type = str(sub.get("job_type", "")).lower().removeprefix("job_type_")
+            self.sub_jobs[job_type] = str(sub["sub_job_id"])
+        self.sub_jobs.setdefault("training", f"{self.job_id}:training")
+        self.sub_jobs.setdefault("sampling", f"{self.job_id}:sampling")

--- a/arctic_platform/client/wire.py
+++ b/arctic_platform/client/wire.py
@@ -1,0 +1,396 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DSS binary wire protocol (DSSST1).
+
+This is the single source of truth for how dss serializes binary training
+payloads. ``dss-platform`` and ``ArcticRL`` depend on ``dss-client`` and import
+this module, so all three sides share one implementation.
+
+It owns three concerns behind one small surface:
+
+1. Codec -- ``dumps`` / ``loads`` serialize a nested dict/list/tuple of tensors
+   and JSON-able data as a single **safetensors** blob. Pickle is never used, so
+   nothing can execute during decode (unlike ``torch.load``).
+
+2. Operation metadata -- ``dumps(obj, metadata=...)`` stores small control-plane
+   metadata (router replay, chunk descriptors) inside the safetensors
+   ``__metadata__`` header. ``read_metadata`` reads it back **without**
+   deserializing tensors. This replaces the old hand-rolled ``DSSMETA1`` byte
+   envelope -- there is now exactly one framing.
+
+3. Byte chunking -- ``encode_byte_chunks`` splits an oversized DSSST1 frame into
+   self-describing byte-range frames. ``decode_byte_chunks`` reassembles them.
+   The split/merge contract lives in one place so client and server cannot
+   drift.
+
+Wire layout of one frame is just a safetensors blob::
+
+    [ u64 header_len | JSON header (__metadata__: {dss: <structure>, op: <metadata>}) | tensor bytes ]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import torch
+from safetensors.torch import load as st_load
+from safetensors.torch import save as st_save
+
+WIRE_FORMAT_VERSION = "DSSST1"
+
+_STRUCT_KEY = "dss"  # structure skeleton (internal)
+_OP_KEY = "op"  # operation metadata (router_replay, request/result chunks, ...)
+_REQUEST_CHUNK_KEY = "request_chunk"
+_RESULT_CHUNK_KEY = "result_chunk"
+_PLACEHOLDER_KEY = "__dss_empty__"
+_ROOT_KEY = "__root__"
+_MAX_HEADER_BYTES = 64 * 1024 * 1024
+_CHUNK_PAYLOAD_KEY = "payload"
+_DEFAULT_CHUNK_OVERHEAD_BYTES = 8192
+
+_PICKLE_SIGNATURES = (b"\x80\x02", b"\x80\x03", b"\x80\x04", b"\x80\x05")
+_ZIP_SIGNATURE = b"PK\x03\x04"
+
+
+class WireError(ValueError):
+    """Raised for malformed or incompatible wire payloads."""
+
+
+def _is_tensor(obj: Any) -> bool:
+    return torch.is_tensor(obj)
+
+
+# ---------------------------------------------------------------------------
+# Codec
+# ---------------------------------------------------------------------------
+
+
+def _subtree_has_tensor(obj: Any) -> bool:
+    if _is_tensor(obj):
+        return True
+    if isinstance(obj, dict):
+        return any(_subtree_has_tensor(v) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return any(_subtree_has_tensor(v) for v in obj)
+    return False
+
+
+def _encode(obj: Any, tensors: dict, seen: set, path: str) -> list:
+    if _is_tensor(obj):
+        key = path or _ROOT_KEY
+        tensor = obj.detach().cpu().contiguous()
+        node: list = ["t", key]
+        if tensor.dim() == 0:
+            tensor = tensor.reshape(1)
+            node = ["t", key, {"scalar": True}]
+        # safetensors rejects tensors that share storage; clone on collision.
+        if tensor.data_ptr() in seen and tensor.numel() > 0:
+            tensor = tensor.clone()
+        seen.add(tensor.data_ptr())
+        tensors[key] = tensor
+        return node
+    if isinstance(obj, dict):
+        if not _subtree_has_tensor(obj):
+            return ["j", obj]
+        items = []
+        for raw_key, value in obj.items():
+            if not isinstance(raw_key, str):
+                raise WireError(f"DSSST1 dict keys must be strings, got {type(raw_key)!r}")
+            child_path = f"{path}.{raw_key}" if path else raw_key
+            items.append([raw_key, _encode(value, tensors, seen, child_path)])
+        return ["d", items]
+    if isinstance(obj, tuple):
+        return ["u", [_encode(v, tensors, seen, f"{path}.{i}" if path else str(i)) for i, v in enumerate(obj)]]
+    if isinstance(obj, list):
+        if not _subtree_has_tensor(obj):
+            return ["j", obj]
+        return ["l", [_encode(v, tensors, seen, f"{path}.{i}" if path else str(i)) for i, v in enumerate(obj)]]
+    return ["j", obj]
+
+
+def dumps(obj: Any, *, metadata: dict | None = None) -> bytes:
+    """Serialize ``obj`` to one safetensors frame, with optional op ``metadata``."""
+    tensors: dict = {}
+    tree = _encode(obj, tensors, set(), "")
+    if not tensors:
+        tensors[_PLACEHOLDER_KEY] = torch.zeros(1, dtype=torch.uint8)
+    header = {_STRUCT_KEY: json.dumps({"v": WIRE_FORMAT_VERSION, "tree": tree})}
+    if metadata:
+        header[_OP_KEY] = json.dumps(metadata)
+    return st_save(tensors, metadata=header)
+
+
+def _decode(node: list, tensors: dict) -> Any:
+    tag = node[0]
+    if tag == "t":
+        tensor = tensors[node[1]]
+        if len(node) > 2 and isinstance(node[2], dict) and node[2].get("scalar"):
+            return tensor.reshape(())
+        return tensor
+    if tag == "j":
+        return node[1]
+    if tag == "d":
+        return {key: _decode(child, tensors) for key, child in node[1]}
+    if tag == "l":
+        return [_decode(child, tensors) for child in node[1]]
+    if tag == "u":
+        return tuple(_decode(child, tensors) for child in node[1])
+    raise WireError(f"unknown DSSST1 node tag {tag!r}")
+
+
+def _read_header(data: bytes) -> dict:
+    if len(data) < 8:
+        raise WireError("payload too short to be a DSSST1 safetensors blob")
+    header_len = int.from_bytes(data[:8], "little")
+    if header_len <= 0 or 8 + header_len > len(data) or header_len > _MAX_HEADER_BYTES:
+        raise WireError("invalid DSSST1 safetensors header length")
+    header = json.loads(data[8 : 8 + header_len].decode("utf-8"))
+    return header.get("__metadata__", {}) or {}
+
+
+def loads(data: Any) -> Any:
+    """Deserialize a frame produced by :func:`dumps`.
+
+    Never invokes pickle/``torch.load``; a legacy pickle or ``torch.save``
+    payload is rejected with a clear error instead of being executed.
+    """
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise WireError("DSSST1 loads expects bytes")
+    data = bytes(data)
+    try:
+        tensors = st_load(data)
+        header = _read_header(data)
+    except Exception as exc:  # not safetensors -> never feed it to pickle
+        if data[:2] in _PICKLE_SIGNATURES or data[:4] == _ZIP_SIGNATURE:
+            raise WireError(
+                "refusing to deserialize a legacy pickle/torch.save payload; "
+                "the peer must use the DSSST1 safetensors wire protocol"
+            ) from exc
+        raise WireError(f"not a valid DSSST1 safetensors payload: {exc}") from exc
+
+    raw = header.get(_STRUCT_KEY)
+    if raw is None:
+        raise WireError("DSSST1 structure missing from safetensors header")
+    info = json.loads(raw)
+    if info.get("v") != WIRE_FORMAT_VERSION:
+        raise WireError(f"unsupported DSSST1 wire version {info.get('v')!r}")
+    tensors.pop(_PLACEHOLDER_KEY, None)
+    return _decode(info["tree"], tensors)
+
+
+def read_metadata(data: Any) -> dict:
+    """Return the operation metadata from a frame header without loading tensors.
+
+    This is a lenient peek: bytes that aren't a valid DSSST1 frame simply have no
+    operation metadata, so ``{}`` is returned. The authoritative (pickle-safe)
+    decode happens in :func:`loads`.
+    """
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise WireError("DSSST1 read_metadata expects bytes")
+    try:
+        raw = _read_header(bytes(data)).get(_OP_KEY)
+    except (WireError, ValueError):
+        return {}
+    return json.loads(raw) if raw else {}
+
+
+# ---------------------------------------------------------------------------
+# Byte chunking -- split and reassemble DSSST1 frames
+# ---------------------------------------------------------------------------
+
+
+def _chunk_key(kind: str) -> str:
+    if kind == "request":
+        return _REQUEST_CHUNK_KEY
+    if kind == "result":
+        return _RESULT_CHUNK_KEY
+    raise WireError(f"unknown byte chunk kind {kind!r}")
+
+
+def _bytes_to_tensor(data: bytes) -> torch.Tensor:
+    # bytearray makes the buffer writable; clone detaches from the temporary.
+    return torch.frombuffer(bytearray(data), dtype=torch.uint8).clone()
+
+
+def _tensor_to_bytes(tensor: Any) -> bytes:
+    if not torch.is_tensor(tensor):
+        raise WireError("byte chunk payload must be a tensor")
+    if tensor.dtype != torch.uint8:
+        raise WireError(f"byte chunk payload tensor must be uint8, got {tensor.dtype}")
+    if tensor.ndim != 1:
+        raise WireError(f"byte chunk payload tensor must be 1-D, got shape {tuple(tensor.shape)}")
+    return tensor.cpu().contiguous().numpy().tobytes()
+
+
+def _make_byte_chunk_frame(
+    frame: bytes,
+    *,
+    kind: str,
+    operation: str | None,
+    group_id: str | None,
+    chunk_idx: int,
+    total_chunks: int,
+    start: int,
+    end: int,
+) -> bytes:
+    key = _chunk_key(kind)
+    desc: dict[str, Any] = {
+        "chunk_idx": chunk_idx,
+        "total_chunks": total_chunks,
+        "frame_sha256": hashlib.sha256(frame).hexdigest(),
+        "frame_size_bytes": len(frame),
+    }
+    if group_id is not None:
+        desc["chunk_group_id"] = group_id
+    if operation is not None:
+        desc["operation"] = operation
+    return dumps({_CHUNK_PAYLOAD_KEY: _bytes_to_tensor(frame[start:end])}, metadata={key: desc})
+
+
+def encode_byte_chunks(
+    frame: bytes,
+    *,
+    kind: str,
+    operation: str | None = None,
+    max_bytes: int = 0,
+    chunk_group_id: str | None = None,
+) -> list[bytes]:
+    """Split a DSSST1 frame into byte-range DSSST1 chunk frames.
+
+    Returns ``[frame]`` when no chunking is needed. When chunking is needed,
+    every returned frame contains a 1-D uint8 ``payload`` tensor plus metadata
+    under ``request_chunk`` or ``result_chunk``.
+    """
+    if not isinstance(frame, (bytes, bytearray, memoryview)):
+        raise WireError("encode_byte_chunks expects frame bytes")
+    frame = bytes(frame)
+    if max_bytes <= 0 or len(frame) <= max_bytes:
+        return [frame]
+
+    group_id = chunk_group_id if kind == "request" else None
+    if kind == "request" and not group_id:
+        import uuid
+
+        group_id = str(uuid.uuid4())
+
+    payload_size = max(1, max_bytes - _DEFAULT_CHUNK_OVERHEAD_BYTES)
+    while True:
+        ranges = [(start, min(start + payload_size, len(frame))) for start in range(0, len(frame), payload_size)]
+        total = len(ranges)
+        chunks = [
+            _make_byte_chunk_frame(
+                frame,
+                kind=kind,
+                operation=operation,
+                group_id=group_id,
+                chunk_idx=idx,
+                total_chunks=total,
+                start=start,
+                end=end,
+            )
+            for idx, (start, end) in enumerate(ranges)
+        ]
+        if all(len(chunk) <= max_bytes for chunk in chunks):
+            return chunks
+        if payload_size == 1:
+            raise WireError("max_bytes is too small to hold one DSSST1 byte chunk frame")
+        payload_size = max(1, payload_size // 2)
+
+
+def read_byte_chunk_metadata(frame: Any) -> dict | None:
+    """Return byte chunk metadata with ``kind`` included, or ``None``."""
+    metadata = read_metadata(frame)
+    if _REQUEST_CHUNK_KEY in metadata:
+        desc = dict(metadata[_REQUEST_CHUNK_KEY])
+        desc["kind"] = "request"
+        return desc
+    if _RESULT_CHUNK_KEY in metadata:
+        desc = dict(metadata[_RESULT_CHUNK_KEY])
+        desc["kind"] = "result"
+        return desc
+    return None
+
+
+def decode_byte_chunks(chunks: list[bytes], *, kind: str | None = None) -> bytes:
+    """Reassemble byte-range DSSST1 chunks into the original DSSST1 frame."""
+    if not chunks:
+        raise WireError("decode_byte_chunks requires at least one frame")
+    if len(chunks) == 1 and read_byte_chunk_metadata(chunks[0]) is None:
+        return bytes(chunks[0])
+
+    descriptors = [read_byte_chunk_metadata(chunk) for chunk in chunks]
+    if any(desc is None for desc in descriptors):
+        raise WireError("decode_byte_chunks received a frame without byte chunk metadata")
+    descriptors = [desc for desc in descriptors if desc is not None]
+    actual_kind = descriptors[0]["kind"]
+    if kind is not None and actual_kind != kind:
+        raise WireError(f"expected {kind} chunks, got {actual_kind} chunks")
+
+    total = int(descriptors[0].get("total_chunks"))
+    frame_sha256 = descriptors[0].get("frame_sha256")
+    frame_size_bytes = int(descriptors[0].get("frame_size_bytes"))
+    group_id = descriptors[0].get("chunk_group_id")
+    operation = descriptors[0].get("operation")
+
+    if len(chunks) != total:
+        raise WireError(f"expected {total} byte chunks, got {len(chunks)}")
+
+    seen: set[int] = set()
+    ordered: list[tuple[int, bytes]] = []
+    for chunk, desc in zip(chunks, descriptors):
+        if desc["kind"] != actual_kind:
+            raise WireError("mixed byte chunk kinds")
+        if int(desc.get("total_chunks")) != total:
+            raise WireError("byte chunk total_chunks differs across frames")
+        if desc.get("frame_sha256") != frame_sha256:
+            raise WireError("byte chunk frame_sha256 differs across frames")
+        if int(desc.get("frame_size_bytes")) != frame_size_bytes:
+            raise WireError("byte chunk frame_size_bytes differs across frames")
+        if desc.get("chunk_group_id") != group_id:
+            raise WireError("byte chunk chunk_group_id differs across frames")
+        if desc.get("operation") != operation:
+            raise WireError("byte chunk operation differs across frames")
+        idx = int(desc.get("chunk_idx"))
+        if idx < 0 or idx >= total:
+            raise WireError("byte chunk_idx out of range")
+        if idx in seen:
+            raise WireError("duplicate byte chunk_idx")
+        seen.add(idx)
+        payload = loads(chunk).get(_CHUNK_PAYLOAD_KEY)
+        ordered.append((idx, _tensor_to_bytes(payload)))
+
+    if seen != set(range(total)):
+        missing = sorted(set(range(total)) - seen)
+        raise WireError(f"missing byte chunks: {missing}")
+
+    frame = b"".join(payload for _, payload in sorted(ordered))
+    if len(frame) != frame_size_bytes:
+        raise WireError("reassembled frame size mismatch")
+    if hashlib.sha256(frame).hexdigest() != frame_sha256:
+        raise WireError("reassembled frame sha256 mismatch")
+    return frame
+
+
+def encode_result_chunks(result: Any, *, max_bytes: int = 0) -> list[bytes]:
+    """Serialize and optionally byte-chunk a result object."""
+    return encode_byte_chunks(dumps(result), kind="result", max_bytes=max_bytes)
+
+
+def decode_result_chunks(chunks: list[bytes]) -> Any:
+    """Decode a result object returned by :func:`encode_result_chunks`."""
+    return loads(decode_byte_chunks(chunks, kind="result"))

--- a/tests/client/test_cortex.py
+++ b/tests/client/test_cortex.py
@@ -1,0 +1,154 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cortex transport translation-layer tests (pure logic, no network).
+
+Covers the CreateJob wire schema builders, GPU-gated sub-job assembly, and the
+result decoders. The HTTP submit/poll layer needs a live server and is not
+exercised here.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+import torch
+
+from arctic_platform.client import wire
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.transports import cortex
+from arctic_platform.client.transports.cortex import CortexTransport
+from arctic_platform.client.transports.cortex import InferenceConfig
+from arctic_platform.client.transports.cortex import JobType
+from arctic_platform.client.transports.cortex import SubJobConfig
+from arctic_platform.client.transports.cortex import TrainingConfig
+
+
+class TestWireSchema:
+    def test_training_sub_job_to_wire(self):
+        """A training sub-job serializes model + training_config to the wire schema."""
+        sub = SubJobConfig.training_job(
+            "Qwen/Qwen3-0.6B",
+            optimizer={"name": "AdamW", "lr": 1e-5},
+            max_seq_len=128,
+            train_batch_size=8,
+            n_gpus=4,
+            dtype="bfloat16",
+        )
+        sub.validate()
+        wired = sub.to_wire()
+        assert wired["job_type"] == "training"
+        assert wired["model_name"] == "Qwen/Qwen3-0.6B"
+        assert wired["dtype"] == "bfloat16"
+        assert wired["training_config"] == {
+            "optimizer": {"name": "AdamW", "lr": 1e-5},
+            "max_seq_len": 128,
+            "train_batch_size": 8,
+            "n_gpus": 4,
+        }
+
+    def test_sampling_sub_job_to_wire(self):
+        """A sampling sub-job serializes an inference_config block."""
+        sub = SubJobConfig.sampling_job("m", max_seq_len=64, n_gpus=2)
+        sub.validate()
+        wired = sub.to_wire()
+        assert wired["job_type"] == "sampling"
+        assert wired["inference_config"] == {"max_seq_len": 64, "n_gpus": 2}
+
+    def test_sampling_job_rejects_training_type(self):
+        """sampling_job() only accepts SAMPLING or LOG_PROBABILITY."""
+        with pytest.raises(ValueError, match="SAMPLING or LOG_PROBABILITY"):
+            SubJobConfig.sampling_job("m", max_seq_len=8, n_gpus=1, job_type=JobType.TRAINING)
+
+    def test_training_config_validate_requires_optimizer(self):
+        """An empty optimizer is rejected."""
+        with pytest.raises(ValueError, match="optimizer"):
+            TrainingConfig(optimizer={}, max_seq_len=8, train_batch_size=1, n_gpus=1).validate()
+
+    def test_inference_config_validate_positive_gpus(self):
+        """n_gpus must be > 0."""
+        with pytest.raises(ValueError, match="n_gpus"):
+            InferenceConfig(max_seq_len=8, n_gpus=0).validate()
+
+
+class TestBuildSubJobs:
+    def _transport(self, **gpus) -> CortexTransport:
+        cfg = ArcticRLClientConfig(
+            backend="cortex",
+            model_name="m",
+            cortex_base_url="http://mock",
+            max_seq_len=128,
+            training_config={"optimizer": {"lr": 1e-5}, "train_batch_size": 8},
+            **gpus,
+        )
+        return CortexTransport(cfg)
+
+    def test_gpu_gating_omits_zero_count_jobs(self):
+        """A sub-job is created only when its GPU count is > 0."""
+        subs = self._transport(training_gpus=4)._build_sub_jobs()
+        assert [s.job_type for s in subs] == [JobType.TRAINING]
+
+    def test_creation_order_inference_before_training(self):
+        """Order is sampling, log_probability, then training (NCCL root last)."""
+        subs = self._transport(training_gpus=4, sampling_gpus=2, log_prob_gpus=1)._build_sub_jobs()
+        assert [s.job_type for s in subs] == [JobType.SAMPLING, JobType.LOG_PROBABILITY, JobType.TRAINING]
+
+
+class TestResultDecoders:
+    def test_decode_result_payload_roundtrip(self):
+        """A base64 DSSST1 result payload decodes back to its dict."""
+        result = {
+            "wire_format": wire.WIRE_FORMAT_VERSION,
+            "encoding": "base64",
+            "payload_b64": base64.b64encode(wire.dumps({"loss": 1.5})).decode(),
+        }
+        assert cortex._decode_result_payload(result) == {"loss": 1.5}
+
+    def test_decode_result_payload_passthrough_when_not_wire(self):
+        """A plain result (no wire_format) returns None so the caller keeps it."""
+        assert cortex._decode_result_payload({"loss": 0.1}) is None
+
+    def test_decode_result_payload_rejects_non_base64(self):
+        """A non-base64 encoding is an error."""
+        with pytest.raises(RuntimeError, match="base64"):
+            cortex._decode_result_payload(
+                {"wire_format": wire.WIRE_FORMAT_VERSION, "encoding": "gzip", "payload_b64": "x"}
+            )
+
+    def test_restore_generate_result_lists(self):
+        """Tensors in a nested generate result become plain Python lists."""
+        out = cortex._restore_generate_result_lists({"a": torch.tensor([1, 2]), "b": [torch.tensor([3])]})
+        assert out == {"a": [1, 2], "b": [[3]]}
+
+    def test_result_chunk_event_sha256_mismatch(self):
+        """A result_chunk event whose payload sha256 disagrees is rejected."""
+        event = {"type": "result_chunk", "payload_b64": base64.b64encode(b"hello").decode(), "payload_sha256": "bad"}
+        with pytest.raises(RuntimeError, match="sha256"):
+            cortex._decode_result_chunk_event(event)
+
+    def test_result_chunk_event_valid(self):
+        """A well-formed result_chunk event returns its raw bytes."""
+        payload = b"hello"
+        event = {
+            "type": "result_chunk",
+            "payload_b64": base64.b64encode(payload).decode(),
+            "payload_sha256": hashlib.sha256(payload).hexdigest(),
+        }
+        assert cortex._decode_result_chunk_event(event) == payload
+
+    def test_non_result_chunk_event_ignored(self):
+        """Non result_chunk events yield None."""
+        assert cortex._decode_result_chunk_event({"type": "status"}) is None

--- a/tests/client/test_wire.py
+++ b/tests/client/test_wire.py
@@ -1,0 +1,149 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DSSST1 wire codec tests.
+
+`wire.py` is the single source of truth for the binary wire format shared across
+dss-platform, ArcticRL, and this client, so silent codec bugs corrupt every
+payload. These tests are pure (CPU torch + safetensors), no GPU or network.
+"""
+
+from __future__ import annotations
+
+import io
+import pickle
+
+import pytest
+import torch
+
+from arctic_platform.client import wire
+
+
+class TestCodec:
+    def test_roundtrip_nested_mixed(self):
+        """Nested dict/list/tuple mixing tensors and JSON survive a roundtrip."""
+        obj = {
+            "weights": torch.arange(6).reshape(2, 3),
+            "meta": {"lr": 0.1, "name": "x"},
+            "list": [torch.ones(2), 5, "s"],
+            "tup": (torch.zeros(1), 2),
+        }
+        back = wire.loads(wire.dumps(obj))
+        assert torch.equal(back["weights"], obj["weights"])
+        assert back["meta"] == {"lr": 0.1, "name": "x"}
+        assert torch.equal(back["list"][0], torch.ones(2))
+        assert back["list"][1:] == [5, "s"]
+        assert torch.equal(back["tup"][0], torch.zeros(1))
+        assert back["tup"][1] == 2
+
+    def test_scalar_tensor_dim_preserved(self):
+        """A 0-dim tensor comes back 0-dim (not reshaped to [1])."""
+        back = wire.loads(wire.dumps({"s": torch.tensor(3.5)}))
+        assert back["s"].shape == torch.Size([])
+        assert float(back["s"]) == pytest.approx(3.5)
+
+    def test_tuple_vs_list_distinction_preserved(self):
+        """tuple stays tuple, list stays list."""
+        back = wire.loads(wire.dumps({"t": (torch.ones(1),), "l": [torch.ones(1)]}))
+        assert isinstance(back["t"], tuple)
+        assert isinstance(back["l"], list)
+
+    def test_no_tensor_payload(self):
+        """A tensor-free object roundtrips via the placeholder path."""
+        obj = {"only": "json", "nums": [1, 2, 3]}
+        assert wire.loads(wire.dumps(obj)) == obj
+
+    def test_metadata_read_without_loading_tensors(self):
+        """read_metadata returns op metadata without decoding tensors."""
+        frame = wire.dumps({"x": torch.ones(3)}, metadata={"router_replay": [1, 2], "op": "fwd-bwd"})
+        assert wire.read_metadata(frame) == {"router_replay": [1, 2], "op": "fwd-bwd"}
+
+    def test_read_metadata_lenient_on_garbage(self):
+        """Non-frame bytes have no metadata rather than raising."""
+        assert wire.read_metadata(b"not a frame") == {}
+
+
+class TestByteChunks:
+    def _big_frame(self) -> bytes:
+        return wire.dumps({"big": torch.arange(100_000, dtype=torch.int64)})
+
+    def test_single_frame_passthrough(self):
+        """No chunking needed -> the frame is returned as-is and decodes back."""
+        frame = self._big_frame()
+        chunks = wire.encode_byte_chunks(frame, kind="request")
+        assert chunks == [frame]
+        assert wire.decode_byte_chunks(chunks) == frame
+
+    def test_multichunk_roundtrip(self):
+        """A frame larger than max_bytes splits and reassembles losslessly."""
+        frame = self._big_frame()
+        chunks = wire.encode_byte_chunks(frame, kind="request", operation="fwd-bwd", max_bytes=16_384)
+        assert len(chunks) > 1
+        assert wire.decode_byte_chunks(chunks, kind="request") == frame
+
+    def test_missing_chunk_detected(self):
+        """Dropping a chunk is caught by the count check."""
+        chunks = wire.encode_byte_chunks(self._big_frame(), kind="request", max_bytes=16_384)
+        with pytest.raises(wire.WireError, match="byte chunks"):
+            wire.decode_byte_chunks(chunks[:-1], kind="request")
+
+    def test_duplicate_chunk_detected(self):
+        """A repeated chunk index is rejected."""
+        chunks = wire.encode_byte_chunks(self._big_frame(), kind="request", max_bytes=16_384)
+        tampered = chunks[:-1] + [chunks[0]]
+        with pytest.raises(wire.WireError, match="duplicate"):
+            wire.decode_byte_chunks(tampered, kind="request")
+
+    def test_wrong_kind_rejected(self):
+        """Asking for result chunks when given request chunks fails."""
+        chunks = wire.encode_byte_chunks(self._big_frame(), kind="request", max_bytes=16_384)
+        with pytest.raises(wire.WireError, match="expected result"):
+            wire.decode_byte_chunks(chunks, kind="result")
+
+    def test_cross_frame_chunks_detected(self):
+        """Chunks from two different frames (same group) fail the sha256 cross-check."""
+        frame_a = wire.dumps({"x": torch.arange(50_000, dtype=torch.int64)})
+        frame_b = wire.dumps({"y": torch.arange(50_000, dtype=torch.int64) + 1})
+        ca = wire.encode_byte_chunks(frame_a, kind="request", max_bytes=16_384, chunk_group_id="g")
+        cb = wire.encode_byte_chunks(frame_b, kind="request", max_bytes=16_384, chunk_group_id="g")
+        assert len(ca) == len(cb) > 1
+        with pytest.raises(wire.WireError, match="frame_sha256 differs"):
+            wire.decode_byte_chunks([ca[0]] + cb[1:], kind="request")
+
+    def test_result_chunks_roundtrip(self):
+        """encode_result_chunks/decode_result_chunks roundtrip a tensor result."""
+        result = {"results": [torch.arange(100_000, dtype=torch.int64)]}
+        chunks = wire.encode_result_chunks(result, max_bytes=16_384)
+        assert len(chunks) > 1
+        back = wire.decode_result_chunks(chunks)
+        assert torch.equal(back["results"][0], result["results"][0])
+
+
+class TestSafety:
+    def test_pickle_payload_rejected(self):
+        """A pickle payload is refused, never fed to pickle."""
+        with pytest.raises(wire.WireError, match="refusing to deserialize"):
+            wire.loads(pickle.dumps({"a": 1}))
+
+    def test_torch_save_payload_rejected(self):
+        """A torch.save payload is refused (zip signature)."""
+        buf = io.BytesIO()
+        torch.save({"a": torch.ones(1)}, buf)
+        with pytest.raises(wire.WireError, match="refusing to deserialize"):
+            wire.loads(buf.getvalue())
+
+    def test_garbage_payload_rejected(self):
+        """Random bytes are rejected as not-a-frame."""
+        with pytest.raises(wire.WireError, match="not a valid DSSST1"):
+            wire.loads(b"\x00\x01\x02\x03not safetensors")


### PR DESCRIPTION
Add the Cortex (cortex-training) transport over the SnowAPI GS REST surface: an op->handler table that builds the CreateJob wire schema, submits each op, and polls the async request to completion. Add the DSSST1 safetensors wire codec (wire.py) it depends on -- the single serialization source of truth (codec + op metadata + byte chunking), pickle-free on decode. Wire cortex into the config (cortex backend + cortex_* fields), make_transport, and the example.

Tests: tests/client/test_wire.py (roundtrip, chunking, pickle rejection) and tests/client/test_cortex.py (wire schema, sub-job gating/order, result decoders).