### PR TITLE
Align on-prem APIs with SnowAPI payload shapes

### DIFF
--- a/arctic_platform/client/UNIFICATION_NOTES.md
+++ b/arctic_platform/client/UNIFICATION_NOTES.md
@@ -27,9 +27,11 @@ forwards `(job_id, body)` unchanged, matching the server's uniform
 
 ## On-prem HTTP transport
 `HttpTransport` shares the same `OnPremTransport` control plane and only supplies
-the delivery primitives: it POSTs each op to `/{op}?job_id=...`. Tensor-bearing
-ops (`fwd_bwd`/`fwd_no_grad`) send an octet `torch.save` payload and decode octet
-responses; everything else is JSON. It also optionally launches a local server
+the delivery primitives: it POSTs each op to `/{op}?job_id=...`. The canonical op
+names + arg/response shapes mirror Cortex (`forward-backward`, `forward`, `step`,
+`save`, `generate`, `weight-sync`, `reset-prefix-cache`, plus on-prem-only
+`log-probs`). Tensor-bearing ops (`forward-backward`/`forward`) send an octet
+`torch.save` payload and decode octet responses; everything else is JSON. It also optionally launches a local server
 (`launch_local_server`) and polls `/health` + `/job/{id}` to wait for readiness.
 The Ray path forwards `(job_id, body)` to the same uniform server surface, so the
 two transports differ only in `_start`/`_rpc`/`_destroy`.

--- a/arctic_platform/client/UNIFICATION_NOTES.md
+++ b/arctic_platform/client/UNIFICATION_NOTES.md
@@ -31,14 +31,39 @@ names + arg/response shapes mirror Cortex (`forward-backward`, `forward`, `step`
 `save`, `generate`, plus on-prem-only `log-probs`). Control-plane ops (weight-sync,
 reset-prefix-cache) share one canonical `operation` op carrying Cortex's
 `{operation_type, payload}` envelope, delivered to `/operation`. Tensor-bearing
-ops (`forward-backward`/`forward`) send an octet **DSSST1** payload and decode
-octet DSSST1 responses; everything else is JSON. DSSST1 is the same
+ops (`forward-backward`/`forward`) plus `generate` send an octet **DSSST1** payload
+and decode octet DSSST1 responses (generate carries no tensors, but the endpoint
+speaks the binary wire to match Cortex); everything else is JSON. DSSST1 is the same
 `arctic_platform.wire` codec Cortex speaks to SnowAPI, so both transports (and the
 on-prem server) share one binary wire and never touch pickle/`torch.load`. It also
 optionally launches a local server
 (`launch_local_server`) and polls `/health` + `/job/{id}` to wait for readiness.
 The Ray path forwards `(job_id, body)` to the same uniform server surface, so the
 two transports differ only in `_start`/`call`/`_destroy`.
+
+## Known divergences from SnowAPI (deferred on purpose)
+The unified client aligns the **request bodies + op vocabulary** with Cortex/SnowAPI
+(the `/operation` envelope, `weight-sync` source/target sub-job ids, DSSST1 tensor
+bodies). The on-prem **server** intentionally does *not* reproduce the rest of
+SnowAPI's shape — the transport layer is the adapter, so the server stays simple.
+
+- **Sync vs async.** SnowAPI is submit→`{request_id}`→poll
+  `GET /{job_id}/requests/{request_id}` (status enums, `result_chunk` events,
+  `next_cursor`). The on-prem server returns results **inline** (octet DSSST1 for
+  tensor ops, JSON otherwise). The Cortex transport owns the submit+poll loop;
+  on-prem has no `request_id`/poll surface. Deferred.
+- **Data-plane ops stay dedicated.** `/operation` is reserved for control-plane
+  ops (`weight-sync`, `reset-prefix-cache`). We deliberately do **not** mirror
+  SnowAPI's `operation_type:"forward"` routing — `forward-backward`/`forward`/
+  `generate`/`log-probs` remain dedicated endpoints (this also matches how the
+  neutrino client posts `forward-backward`/`generate`). Any parity is the
+  transport's job.
+- **Job creation.** On-prem `/initialize` takes one `JobConfig` per call;
+  SnowAPI takes a single `sub_job_configs[]` (parent + sub-jobs,
+  `training_config`/`inference_config`). Not unified. Deferred.
+- **Addressing / id types.** On-prem uses `job_id` as a query param with `int`
+  ids; SnowAPI uses path routing with string sub-job tokens
+  (`"{job_id}:role:idx"`). The transport maps between them. Deferred.
 
 ## Not yet in unified client (future work)
 Ops present in `arctic_platform/rl/*_client.py` but not yet on `ArcticRLClient`.

--- a/arctic_platform/client/UNIFICATION_NOTES.md
+++ b/arctic_platform/client/UNIFICATION_NOTES.md
@@ -10,10 +10,9 @@ body, which job each op targets, response contract) is defined once in
 
 ## Design in place (this package)
 - `Transport` ABC + `JobHandles` + `Request` (single op vocabulary in `client.py`).
-- `OnPremTransport` base: job creation, ordering, payload building, and a uniform
-  `call` that posts/dispatches the op against its target job. Concrete transports
-  implement only the delivery primitives (`_start`, `_rpc`, `_destroy`,
-  `_wait_running`).
+- `OnPremTransport` base: job creation, ordering, payload building. Concrete
+  transports implement only the delivery primitives (`_start`, `call`, `_destroy`,
+  `_wait_running`); `call` posts/dispatches the op against its target job.
 - `JOB_CREATE_ORDER` + `ArcticRLClientConfig.gpus_for()` centralize GPU-gating and
   creation order so transports no longer hand-roll them.
 
@@ -21,7 +20,7 @@ body, which job each op targets, response contract) is defined once in
 `RayTransport` makes in-process Ray actor calls — no HTTP, no serialization. The
 server splits into a `state` actor (job creation) and an `ArcticRLRayServer`
 wrapper (typed async ops) that snapshots workers at construction, so the wrapper
-is built lazily after jobs are initialized. `_rpc` resolves `op -> method` and
+is built lazily after jobs are initialized. `call` resolves `op -> method` and
 forwards `(job_id, body)` unchanged, matching the server's uniform
 `op(job_id, body) -> dict` surface.
 
@@ -29,12 +28,17 @@ forwards `(job_id, body)` unchanged, matching the server's uniform
 `HttpTransport` shares the same `OnPremTransport` control plane and only supplies
 the delivery primitives: it POSTs each op to `/{op}?job_id=...`. The canonical op
 names + arg/response shapes mirror Cortex (`forward-backward`, `forward`, `step`,
-`save`, `generate`, `weight-sync`, `reset-prefix-cache`, plus on-prem-only
-`log-probs`). Tensor-bearing ops (`forward-backward`/`forward`) send an octet
-`torch.save` payload and decode octet responses; everything else is JSON. It also optionally launches a local server
+`save`, `generate`, plus on-prem-only `log-probs`). Control-plane ops (weight-sync,
+reset-prefix-cache) share one canonical `operation` op carrying Cortex's
+`{operation_type, payload}` envelope, delivered to `/operation`. Tensor-bearing
+ops (`forward-backward`/`forward`) send an octet **DSSST1** payload and decode
+octet DSSST1 responses; everything else is JSON. DSSST1 is the same
+`arctic_platform.wire` codec Cortex speaks to SnowAPI, so both transports (and the
+on-prem server) share one binary wire and never touch pickle/`torch.load`. It also
+optionally launches a local server
 (`launch_local_server`) and polls `/health` + `/job/{id}` to wait for readiness.
 The Ray path forwards `(job_id, body)` to the same uniform server surface, so the
-two transports differ only in `_start`/`_rpc`/`_destroy`.
+two transports differ only in `_start`/`call`/`_destroy`.
 
 ## Not yet in unified client (future work)
 Ops present in `arctic_platform/rl/*_client.py` but not yet on `ArcticRLClient`.

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -88,17 +88,29 @@ class ArcticRLClient:
         body = {"prompts": prompts, "completions": completions, "top_k": top_k}
         return self.transport.call(Request("log-probs", self.jobs.require("log_prob"), body))
 
-    # ── weight sync + cache ──────────────────────────────────────────────
+    # ── weight sync + cache (control-plane ops -> the /operation envelope) ──
+    # The client assembles the full Cortex `/operation` envelope here so transports
+    # just forward it: SnowAPI reads the `sub_job_*` routing hints, on-prem accepts
+    # the same shape and ignores them (it addresses jobs by job id). On-prem treats a
+    # sub_job_id as its plain job id, so source/target ids double as its job ids.
     def sync_weights(self) -> dict:
-        # Matches Cortex's `weight_sync(job_id, source_sub_job_id, target_sub_job_ids)`.
-        # On-prem treats a sub_job_id as its plain job id: source == training, targets == [sampling].
         tid, sid = self.jobs.require("training"), self.jobs.require("sampling")
-        body = {"source_sub_job_id": tid, "target_sub_job_ids": [sid]}
-        return self.transport.call(Request("weight-sync", tid, body))
+        body = {
+            "operation_type": "weight-sync",
+            "sub_job_id": tid,
+            "sub_job_type": "training",
+            "payload": {"source_sub_job_id": tid, "target_sub_job_ids": [sid]},
+        }
+        return self.transport.call(Request("operation", tid, body))
 
     def reset_prefix_cache(self, drain: bool = True, timeout_s: float = 60.0, retry_interval_s: float = 0.1) -> dict:
-        body = {"drain": drain, "timeout_s": timeout_s, "retry_interval_s": retry_interval_s}
-        return self.transport.call(Request("reset-prefix-cache", self.jobs.require("sampling"), body))
+        sid = self.jobs.require("sampling")
+        body = {
+            "operation_type": "reset-prefix-cache",
+            "sub_job_type": "sampling",
+            "payload": {"drain": drain, "timeout_s": timeout_s, "retry_interval_s": retry_interval_s},
+        }
+        return self.transport.call(Request("operation", sid, body))
 
     # ── lifecycle ────────────────────────────────────────────────────────
     def reconnect_config(self) -> ArcticRLClientConfig:

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -58,10 +58,10 @@ class ArcticRLClient:
         # into the body here, which is why callers can leave it inside `batch`.
         body = dict(batch)
         body.update({k: v for k, v in (("processing", processing), ("router_replay", router_replay)) if v is not None})
-        return self.transport.call(Request("fwd-bwd", self.jobs.require("training"), body, binary=True))
+        return self.transport.call(Request("forward-backward", self.jobs.require("training"), body, binary=True))
 
     def fwd_no_grad(self, batch: dict) -> dict:
-        return self.transport.call(Request("fwd-no-grad", self.jobs.require("training"), dict(batch), binary=True))
+        return self.transport.call(Request("forward", self.jobs.require("training"), dict(batch), binary=True))
 
     def step(self, learning_rate: float | None = None) -> dict:
         # NOTE: response *shapes* also diverge across backends -- on-prem returns
@@ -72,15 +72,16 @@ class ArcticRLClient:
         # on ONE schema (loss + metrics) so callers never key on backend.
         return self.transport.call(Request("step", self.jobs.require("training"), {"learning_rate": learning_rate}))
 
-    def save_checkpoint(self, stage_info: dict | None = None, path: str | None = None) -> dict:
-        # `path` is this call's destination; when None the server uses the job's
-        # config.checkpoint_path. An explicit `path` here wins over the config.
-        body = {"stage_info": stage_info, "path": path}
-        return self.transport.call(Request("save-checkpoint", self.jobs.require("training"), body))
+    def save_checkpoint(self, checkpoint_id: str | None = None, checkpoint_type: str = "resumable") -> dict:
+        # Matches Cortex's `save(job_id, checkpoint_id=None, checkpoint_type=None)`.
+        body = {"checkpoint_id": checkpoint_id, "checkpoint_type": checkpoint_type}
+        return self.transport.call(Request("save", self.jobs.require("training"), body))
 
     # ── sampling / log-prob ──────────────────────────────────────────────
-    def generate(self, prompts: list, sampling_params: dict | None = None, routing_key: Any = None) -> list:
-        body = {"prompts": prompts, "sampling_params": sampling_params, "routing_key": routing_key}
+    def generate(
+        self, prompts: list, sampling_params: dict | None = None, routing_key: Any = None, strict: bool = False
+    ) -> list:
+        body = {"prompts": prompts, "sampling_params": sampling_params, "routing_key": routing_key, "strict": strict}
         return self.transport.call(Request("generate", self.jobs.require("sampling"), body))["results"]
 
     def log_probs(self, prompts: list, completions: list | None = None, top_k: int = 1) -> dict:
@@ -89,12 +90,14 @@ class ArcticRLClient:
 
     # ── weight sync + cache ──────────────────────────────────────────────
     def sync_weights(self) -> dict:
-        # sync-weights has no primary job id; both ids travel in the body.
+        # Matches Cortex's `weight_sync(job_id, source_sub_job_id, target_sub_job_ids)`.
+        # On-prem treats a sub_job_id as its plain job id: source == training, targets == [sampling].
         tid, sid = self.jobs.require("training"), self.jobs.require("sampling")
-        return self.transport.call(Request("sync-weights", None, {"training_job_id": tid, "sampling_job_id": sid}))
+        body = {"source_sub_job_id": tid, "target_sub_job_ids": [sid]}
+        return self.transport.call(Request("weight-sync", tid, body))
 
-    def reset_prefix_cache(self, drain: bool = True, timeout_s: float = 60.0) -> dict:
-        body = {"drain": drain, "timeout_s": timeout_s}
+    def reset_prefix_cache(self, drain: bool = True, timeout_s: float = 60.0, retry_interval_s: float = 0.1) -> dict:
+        body = {"drain": drain, "timeout_s": timeout_s, "retry_interval_s": retry_interval_s}
         return self.transport.call(Request("reset-prefix-cache", self.jobs.require("sampling"), body))
 
     # ── lifecycle ────────────────────────────────────────────────────────

--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -58,8 +58,7 @@ class ArcticRLClientConfig(BaseModel):
         None,
         description=(
             "onprem: training job's base checkpoint dir, set at init (resume-from + weight sync). "
-            "This is the default destination; a per-call save_checkpoint(path=...) overrides it for "
-            "that call and falls back to this dir when path is None."
+            "This is the default destination used by save_checkpoint()."
         ),
     )
 

--- a/arctic_platform/client/transport.py
+++ b/arctic_platform/client/transport.py
@@ -41,13 +41,13 @@ JOB_CREATE_ORDER = ("sampling", "log_prob", "training")
 # its own coverage up front instead of failing with an AttributeError mid-run.
 OPS = frozenset(
     {
-        "fwd-bwd",
-        "fwd-no-grad",
+        "forward-backward",
+        "forward",
         "step",
-        "save-checkpoint",
+        "save",
         "generate",
         "log-probs",
-        "sync-weights",
+        "weight-sync",
         "reset-prefix-cache",
     }
 )
@@ -97,7 +97,7 @@ class Request:
     the server, `binary` just picks the body codec (octet tensors vs JSON).
     """
 
-    op: str  # canonical op name, e.g. "fwd-bwd"
+    op: str  # canonical op name, e.g. "forward-backward"
     job_id: JobId | None = None  # primary target id (client-resolved); None -> omit
     body: dict[str, Any] = field(default_factory=dict)
     binary: bool = False  # body carries tensors -> octet, else JSON

--- a/arctic_platform/client/transport.py
+++ b/arctic_platform/client/transport.py
@@ -47,8 +47,9 @@ OPS = frozenset(
         "save",
         "generate",
         "log-probs",
-        "weight-sync",
-        "reset-prefix-cache",
+        # Control-plane ops share one canonical envelope (op_type + payload),
+        # matching Cortex's /operation; the transport routes them to /operation.
+        "operation",
     }
 )
 

--- a/arctic_platform/client/transports/onprem.py
+++ b/arctic_platform/client/transports/onprem.py
@@ -15,10 +15,10 @@
 """On-prem transport base for the Arctic-Platform server.
 
 HTTP and in-process Ray share one control plane (`OnPremTransport`:
-job creation, ordering, payload building, `call`); they differ only in three
-primitives (`_start`, `_rpc`, `_destroy`). `call` is uniform — post/dispatch the
-op against its target job — because the server exposes a uniform
-`op(job_id, body) -> dict` surface.
+job creation, ordering, payload building); they differ only in the delivery
+primitives (`_start`, `call`, `_destroy`, `_wait_running`). The client already
+resolved the job id onto each Request, so `call` just delivers it against the
+server's uniform `op(job_id, body) -> dict` surface.
 
 Concrete transports live alongside this base: `HttpTransport` in
 `onprem_http.py` and `RayTransport` in `onprem_ray.py`.
@@ -35,7 +35,6 @@ from arctic_platform.client.config import JobId
 from arctic_platform.client.transport import JOB_CREATE_ORDER
 from arctic_platform.client.transport import JOB_TYPES
 from arctic_platform.client.transport import JobHandles
-from arctic_platform.client.transport import Request
 from arctic_platform.client.transport import Transport
 from arctic_platform.client.transport import unresolved_ops
 
@@ -58,10 +57,6 @@ class OnPremTransport(Transport):
                 self.jobs.set(job_type, self._start(self._init_payload(job_type)))
         self._wait_running()
         return self.jobs
-
-    def call(self, request: Request) -> dict:
-        # The client already resolved the job id onto the request; just deliver it.
-        return self._rpc(request)
 
     def shutdown(self) -> None:
         for job_type in JOB_TYPES:
@@ -91,13 +86,10 @@ class OnPremTransport(Transport):
         return payload
 
     # delivery primitives — the only things a concrete transport implements
+    # (plus `call` from the Transport ABC, which delivers one op end to end).
     @abstractmethod
     def _start(self, payload: dict) -> JobId:
         """Create one job and return its id."""
-
-    @abstractmethod
-    def _rpc(self, request: Request) -> dict:
-        """Deliver one op and return its response dict."""
 
     @abstractmethod
     def _destroy(self, job_id: JobId, job_type: str) -> None:

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -26,6 +26,11 @@ from arctic_platform.client.transport import Request
 from arctic_platform.client.transports.onprem import OnPremTransport
 
 
+# Ops the server wants as DSSST1 octet even without tensors in the body: a wire
+# requirement of the endpoint (matching Cortex/SnowAPI), not payload binary-ness.
+_OCTET_OPS = frozenset({"generate"})
+
+
 class HttpTransport(OnPremTransport):
     """Blocking HTTP over the shared DSSST1 wire. Serves onprem (local/remote)."""
 
@@ -46,10 +51,11 @@ class HttpTransport(OnPremTransport):
         return resp.json()["job_id"]
 
     def call(self, request: Request) -> dict:
-        # Tensor-bearing ops send a DSSST1 octet body; the rest send JSON.
+        # Tensor-bearing ops (and generate) send a DSSST1 octet body; rest send JSON.
+        octet = request.binary or request.op in _OCTET_OPS
         payload = (
             {"data": wire.dumps(request.body), "headers": {"Content-Type": "application/octet-stream"}}
-            if request.binary
+            if octet
             else {"json": request.body}
         )
         params = {} if request.job_id is None else {"job_id": request.job_id}

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -12,13 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Blocking HTTP transport (on-prem) + tensor codec."""
+"""Blocking HTTP transport (on-prem). Tensor bodies use the shared DSSST1 codec."""
 
 from __future__ import annotations
 
 import time
-from typing import Any
 
+from arctic_platform import wire
 from arctic_platform.client.config import ArcticRLClientConfig
 from arctic_platform.client.config import JobId
 from arctic_platform.client.transport import JOB_TYPES
@@ -26,26 +26,8 @@ from arctic_platform.client.transport import Request
 from arctic_platform.client.transports.onprem import OnPremTransport
 
 
-def _dumps(obj: Any) -> bytes:
-    import io
-
-    import torch
-
-    buf = io.BytesIO()
-    torch.save(obj, buf)
-    return buf.getvalue()
-
-
-def _loads(data: bytes) -> Any:
-    import io
-
-    import torch
-
-    return torch.load(io.BytesIO(data), map_location="cpu", weights_only=False)
-
-
 class HttpTransport(OnPremTransport):
-    """Blocking HTTP + tensor codec. Serves onprem (local/remote)."""
+    """Blocking HTTP over the shared DSSST1 wire. Serves onprem (local/remote)."""
 
     def __init__(self, config: ArcticRLClientConfig) -> None:
         super().__init__(config)
@@ -63,19 +45,19 @@ class HttpTransport(OnPremTransport):
         resp.raise_for_status()
         return resp.json()["job_id"]
 
-    def _rpc(self, request: Request) -> dict:
-        # Tensor-bearing ops send an octet torch payload; the rest send JSON.
+    def call(self, request: Request) -> dict:
+        # Tensor-bearing ops send a DSSST1 octet body; the rest send JSON.
         payload = (
-            {"data": _dumps(request.body), "headers": {"Content-Type": "application/octet-stream"}}
+            {"data": wire.dumps(request.body), "headers": {"Content-Type": "application/octet-stream"}}
             if request.binary
             else {"json": request.body}
         )
         params = {} if request.job_id is None else {"job_id": request.job_id}
         resp = self.session.post(f"{self.base_url}/{request.op}", params=params, timeout=self.timeout, **payload)
         resp.raise_for_status()
-        # Tensor-bearing responses come back as octet; everything else is JSON.
+        # Tensor-bearing responses come back as DSSST1 octet; everything else is JSON.
         if "application/octet-stream" in resp.headers.get("Content-Type", ""):
-            return _loads(resp.content)
+            return wire.loads(resp.content)
         return resp.json()
 
     def _destroy(self, job_id: JobId, job_type: str) -> None:

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -25,7 +25,6 @@ from arctic_platform.client.transport import JOB_TYPES
 from arctic_platform.client.transport import Request
 from arctic_platform.client.transports.onprem import OnPremTransport
 
-
 # Ops the server wants as DSSST1 octet even without tensors in the body: a wire
 # requirement of the endpoint (matching Cortex/SnowAPI), not payload binary-ness.
 _OCTET_OPS = frozenset({"generate"})

--- a/arctic_platform/client/transports/onprem_ray.py
+++ b/arctic_platform/client/transports/onprem_ray.py
@@ -32,7 +32,7 @@ class RayTransport(OnPremTransport):
     ``ArcticRLRayServer`` wrapper (typed async ops) that snapshots workers at
     construction, so the wrapper is built lazily after jobs are initialized.
 
-    `_rpc` resolves ``op -> method`` and forwards the request unchanged.
+    `call` resolves ``op -> method`` and forwards the request unchanged.
     """
 
     def __init__(self, config: ArcticRLClientConfig) -> None:
@@ -62,7 +62,7 @@ class RayTransport(OnPremTransport):
         self._server = ArcticRLRayServer(self._state)
         self._check_op_coverage(self._server)
 
-    def _rpc(self, request: Request) -> dict:
+    def call(self, request: Request) -> dict:
         # Pass job_id only when set (ops omitting it call method(body)), then the body.
         method = getattr(self._server, method_name(request.op))
         args = (request.body,) if request.job_id is None else (request.job_id, request.body)

--- a/arctic_platform/client/transports/onprem_ray.py
+++ b/arctic_platform/client/transports/onprem_ray.py
@@ -63,7 +63,7 @@ class RayTransport(OnPremTransport):
         self._check_op_coverage(self._server)
 
     def _rpc(self, request: Request) -> dict:
-        # Pass job_id only when set (some ops, e.g. sync-weights, omit it), then the body.
+        # Pass job_id only when set (ops omitting it call method(body)), then the body.
         method = getattr(self._server, method_name(request.op))
         args = (request.body,) if request.job_id is None else (request.job_id, request.body)
         return self._loop.run_until_complete(method(*args))

--- a/arctic_platform/rl/deepspeed_worker.py
+++ b/arctic_platform/rl/deepspeed_worker.py
@@ -447,7 +447,7 @@ class DeepSpeedWorker:
                 # ``{name}.sum`` / ``{name}.tokens`` scalars (plus a few
                 # passthrough numerics like ``kl_coef``). Sum them across
                 # this rank's microbatches so each rank returns one scalar
-                # per metric; ``ray_server.fwd_bwd`` / ``http_server.fwd_bwd``
+                # per metric; ``ray_server.forward_backward`` / ``http_server.forward_backward``
                 # then sums across DP ranks and collapses the paired keys
                 # into a single global token-mean per metric per mini-batch.
                 pipeline_outputs[k] = combine_metric_microbatches([r[k] for r in pipeline_micro_batch_outputs])

--- a/arctic_platform/rl/http_client.py
+++ b/arctic_platform/rl/http_client.py
@@ -26,7 +26,6 @@ construction time.
 from __future__ import annotations
 
 import atexit
-import io
 import logging
 import signal
 import subprocess
@@ -36,8 +35,8 @@ from typing import Any
 
 import aiohttp
 import requests
-import torch
 
+from arctic_platform import wire
 from arctic_platform.rl.config import ArcticRLClientConfig
 from arctic_platform.rl.http_server import ArcticRLHTTPServerState
 from arctic_platform.rl.utils.debug import pr0
@@ -387,14 +386,11 @@ class ArcticRLHTTPClient:
         tname = timers.start("xyz arctic_rl.client incoming processing 1")
         if processing is not None:
             batch = {**batch, "processing": processing}
-        buffer = io.BytesIO()
         timers.stop_and_print_elapsed(tname)
 
         tname = timers.start("xyz arctic_rl.client incoming processing 2")
-        torch.save(batch, buffer)
+        request_body = wire.dumps(batch)
         timers.stop_and_print_elapsed(tname)
-
-        request_body = buffer.getvalue()
         # import zlib
         # tname = timers.start("xyz arctic_rl.client compress")
         # request_body = zlib.compress(request_body)
@@ -414,7 +410,7 @@ class ArcticRLHTTPClient:
 
         tname = timers.start("xyz arctic_rl.client outgoing processing 1")
         resp.raise_for_status()
-        response = torch.load(io.BytesIO(resp.content), map_location="cpu", weights_only=False)
+        response = wire.loads(resp.content)
         timers.stop_and_print_elapsed(tname)
         pr0(f"[ArcticRLClient] fwd_bwd OUTPUT: {response.keys()=}")
         timers.stop_and_print_elapsed(tname_e2e)
@@ -424,13 +420,10 @@ class ArcticRLHTTPClient:
     async def fwd_no_grad(self, batch: dict, reference_model: bool) -> dict[str, Any]:
         """Forward-only pass (no gradient) on the training engine.
 
-        Returns a binary (torch.save) response containing ``{"logprobs": Tensor}``.
+        Returns a binary (DSSST1) response containing ``{"logprobs": Tensor}``.
         Matches the ``/forward`` endpoint.
         """
-        buffer = io.BytesIO()
-        torch.save(batch, buffer)
-
-        request_body = buffer.getvalue()
+        request_body = wire.dumps(batch)
 
         # import zlib
         # request_body = zlib.compress(buffer.getvalue())
@@ -451,7 +444,7 @@ class ArcticRLHTTPClient:
             },
         )
         resp.raise_for_status()
-        response = torch.load(io.BytesIO(resp.content), map_location="cpu", weights_only=False)
+        response = wire.loads(resp.content)
         pr0(f"[ArcticRLClient] fwd_no_grad OUTPUT: {response.keys()=}")
         return response
 
@@ -707,7 +700,7 @@ class ArcticRLHTTPClient:
             json={"prompts": prompts, "completions": completions, "top_k": top_k},
         )
         resp.raise_for_status()
-        return torch.load(io.BytesIO(resp.content), map_location="cpu", weights_only=False)
+        return wire.loads(resp.content)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/arctic_platform/rl/http_client.py
+++ b/arctic_platform/rl/http_client.py
@@ -521,10 +521,11 @@ class ArcticRLHTTPClient:
             async with session.post(
                 f"{self._base_url}/generate",
                 params={"job_id": self.sampling_job_id},
-                json={"prompts": prompts, "sampling_params": sampling_params},
+                data=wire.dumps({"prompts": prompts, "sampling_params": sampling_params}),
+                headers={"Content-Type": "application/octet-stream"},
             ) as resp:
                 resp.raise_for_status()
-                data = await resp.json()
+                data = wire.loads(await resp.read())
         return data["results"]
 
     # ------------------------------------------------------------------

--- a/arctic_platform/rl/http_client.py
+++ b/arctic_platform/rl/http_client.py
@@ -402,7 +402,7 @@ class ArcticRLHTTPClient:
 
         tname = timers.start("xyz arctic_rl.client http post")
         resp = self._session.post(
-            f"{self._base_url}/fwd-bwd",
+            f"{self._base_url}/forward-backward",
             params={"job_id": self.training_job_id},
             data=request_body,
             headers={
@@ -425,7 +425,7 @@ class ArcticRLHTTPClient:
         """Forward-only pass (no gradient) on the training engine.
 
         Returns a binary (torch.save) response containing ``{"logprobs": Tensor}``.
-        Matches the ``/fwd-no-grad`` endpoint added in dss-platform PR #41.
+        Matches the ``/forward`` endpoint.
         """
         buffer = io.BytesIO()
         torch.save(batch, buffer)
@@ -441,7 +441,7 @@ class ArcticRLHTTPClient:
         job_id = self.log_prob_job_id if reference_model else self.training_job_id
         pr0(f"[ArcticRLClient] fwd_no_grad INPUT: {batch.keys()=} {job_id=}")
         resp = self._session.post(
-            f"{self._base_url}/fwd-no-grad",
+            f"{self._base_url}/forward",
             params={"job_id": job_id},
             data=request_body,
             # data=buffer.getvalue(),
@@ -469,7 +469,7 @@ class ArcticRLHTTPClient:
     async def save_checkpoint(self) -> dict[str, Any]:
         """Save training checkpoint."""
         resp = self._session.post(
-            f"{self._base_url}/save-checkpoint",
+            f"{self._base_url}/save",
             params={"job_id": self.training_job_id},
         )
         resp.raise_for_status()
@@ -484,7 +484,7 @@ class ArcticRLHTTPClient:
         side — this call will warn if the endpoint returns an error.
         """
         resp = self._session.post(
-            f"{self._base_url}/sync-weights",
+            f"{self._base_url}/weight-sync",
             params={"job_id": self.sampling_job_id},
             json={"checkpoint_path": path},
         )
@@ -637,7 +637,7 @@ class ArcticRLHTTPClient:
 
         low_memory only applies to the cuda_ipc path (stream one gathered param
         at a time). Not yet implemented on the HTTP path -- see the server-side
-        guard in /sync-weights; use the ray protocol for low_memory_weight_sync.
+        guard in /weight-sync; use the ray protocol for low_memory_weight_sync.
         """
 
         resp = self._session.post(
@@ -648,10 +648,11 @@ class ArcticRLHTTPClient:
         resp.raise_for_status()
 
         resp = self._session.post(
-            f"{self._base_url}/sync-weights",
+            f"{self._base_url}/weight-sync",
+            params={"job_id": self.training_job_id},
             json={
-                "training_job_id": self.training_job_id,
-                "sampling_job_id": self.sampling_job_id,
+                "source_sub_job_id": self.training_job_id,
+                "target_sub_job_ids": [self.sampling_job_id],
                 "colocate": self.config.colocate,
                 "cuda_ipc": cuda_ipc,
                 "low_memory": low_memory,

--- a/arctic_platform/rl/http_server.py
+++ b/arctic_platform/rl/http_server.py
@@ -62,8 +62,11 @@ from arctic_platform.rl.utils.ray_pg import pg_scheduling_options
 from arctic_platform.rl.utils.server_models import GenerateRequest
 from arctic_platform.rl.utils.server_models import JobConfig
 from arctic_platform.rl.utils.server_models import LogProbsRequest
-from arctic_platform.rl.utils.server_models import SyncWeightsRequest
+from arctic_platform.rl.utils.server_models import ResetPrefixCacheRequest
+from arctic_platform.rl.utils.server_models import SaveRequest
+from arctic_platform.rl.utils.server_models import StepRequest
 from arctic_platform.rl.utils.server_models import WeightNormRequest
+from arctic_platform.rl.utils.server_models import WeightSyncRequest
 from arctic_platform.rl.utils.server_models import build_model_config
 
 logger = logging.getLogger(__name__)
@@ -351,8 +354,8 @@ async def destroy(job_id: int, job_type: str = Body(..., embed=True)):
     return {"job_id": job_id}
 
 
-@app.post("/fwd-bwd")
-async def fwd_bwd(
+@app.post("/forward-backward")
+async def forward_backward(
     job_id: int,
     body: bytes = Body(..., media_type="application/octet-stream"),
 ):
@@ -388,7 +391,7 @@ async def fwd_bwd(
     losses = [r["avg_loss"] for r in results]
     avg_loss = sum(losses)  # / len(losses)
 
-    # See ray_server.fwd_bwd for the rationale: collapse the per-DP-rank
+    # See ray_server.forward_backward for the rationale: collapse the per-DP-rank
     # paired ``.sum`` / ``.tokens`` metric scalars into one global
     # token-mean scalar per metric per mini-batch. ``batch`` is intentionally
     # omitted -- the driver does not consume it (see note above).
@@ -406,8 +409,8 @@ async def fwd_bwd(
     return Response(content=buffer.getvalue(), media_type="application/octet-stream")
 
 
-@app.post("/fwd-no-grad")
-async def fwd_no_grad(
+@app.post("/forward")
+async def forward(
     job_id: int,
     body: bytes = Body(..., media_type="application/octet-stream"),
 ):
@@ -442,7 +445,9 @@ async def fwd_no_grad(
 
 
 @app.post("/step")
-async def step(job_id: int):
+async def step(job_id: int, request: StepRequest = Body(default=StepRequest())):
+    # `learning_rate` is accepted for Cortex parity; on-prem uses the DeepSpeed
+    # scheduler's LR, so it is not applied here.
     _verify_job(job_id, "training")
     results = await asyncio.gather(*[w.step.remote() for w in app.state.training_workers])
     merged = dict(
@@ -465,8 +470,10 @@ async def empty_training_cache(job_id: int):
     return {"job_id": job_id, "workers": results}
 
 
-@app.post("/save-checkpoint")
-async def save_checkpoint(job_id: int):
+@app.post("/save")
+async def save(job_id: int, request: SaveRequest = Body(default=SaveRequest())):
+    # `checkpoint_id`/`checkpoint_type` are accepted for Cortex parity; on-prem
+    # saves to the job's configured checkpoint_path.
     _verify_job(job_id, "training")
     info = app.state.jobs[job_id]
     path = info.get("checkpoint_path", None)
@@ -517,8 +524,11 @@ async def wake_inference(job_id: int, tags: list[str] | None = None):
 
 
 @app.post("/reset-prefix-cache")
-async def reset_prefix_cache(job_id: int):
-    """Reset the prefix cache on the sampling inference engines."""
+async def reset_prefix_cache(job_id: int, request: ResetPrefixCacheRequest = Body(default=ResetPrefixCacheRequest())):
+    """Reset the prefix cache on the sampling inference engines.
+
+    `drain`/`timeout_s`/`retry_interval_s` are accepted for Cortex parity.
+    """
     _verify_job(job_id, "sampling")
     results = {}
     pool: ReplicaPool = app.state.sampling_pool
@@ -601,7 +611,7 @@ async def wake_log_prob(job_id: int):
 async def generate(job_id: int, request: GenerateRequest = Body(...)):
     _verify_job(job_id, "sampling")
     pool: ReplicaPool = app.state.sampling_pool
-    results = await pool.generate(request.prompts, request.sampling_params)
+    results = await pool.generate(request.prompts, request.sampling_params, strict=request.strict)
     return {"job_id": job_id, "results": results}
 
 
@@ -627,16 +637,21 @@ async def weight_norm(request: WeightNormRequest = Body(...)):
     }
 
 
-@app.post("/sync-weights")
-async def sync_weights(request: SyncWeightsRequest = Body(...)):
+@app.post("/weight-sync")
+async def weight_sync(job_id: int, request: WeightSyncRequest = Body(...)):
     """Sync training model weights to the sampling engine.
+
+    Matches Cortex's `weight_sync(job_id, source_sub_job_id, target_sub_job_ids)`;
+    on-prem treats a sub_job_id as its plain job id (source == training, target == sampling).
 
     Uses NCCL for non-colocated mode (separate GPUs).  In colocated mode:
     - cuda_ipc=True: CUDA IPC (zero-copy, requires training weights on GPU)
     - cuda_ipc=False: CPU file path (slower, works when offloaded)
     """
-    _verify_job(request.training_job_id, "training")
-    _verify_job(request.sampling_job_id, "sampling")
+    training_job_id = request.source_sub_job_id
+    sampling_job_id = request.target_sub_job_ids[0]
+    _verify_job(training_job_id, "training")
+    _verify_job(sampling_job_id, "sampling")
 
     workers = app.state.training_workers
     pool: ReplicaPool = app.state.sampling_pool
@@ -653,17 +668,15 @@ async def sync_weights(request: SyncWeightsRequest = Body(...)):
                 results = await _sync_weights_cuda_ipc(workers, pool, lp_pool)
         else:
             print("colo _sync_weights_ipc")
-            training_job_info = app.state.jobs.get(request.training_job_id)
+            training_job_info = app.state.jobs.get(training_job_id)
             sync_path = training_job_info.get("sync_path", None)
-            assert sync_path is not None, f"sync_path is required for training job {request.training_job_id}"
+            assert sync_path is not None, f"sync_path is required for training job {training_job_id}"
             results = await _sync_weights_ipc(sync_path, workers, pool, lp_pool)
     else:
         print("colo _sync_weights_nccl")
         results = await _sync_weights_nccl(workers, pool)
 
-    # await self.arctic_rl_ray_server_state.reset_prefix_cache.remote(request.sampling_job_id)
-
-    return {"job_id": request.training_job_id, **results}
+    return {"job_id": training_job_id, **results}
 
     # if colocate:
     #     lp_pool = app.state.log_prob_pool
@@ -796,7 +809,7 @@ async def _sync_weights_cuda_ipc_low_mem(workers, pool: ReplicaPool, lp_pool: Re
     Selected via ``arctic_rl.low_memory_weight_sync=True``.
 
     The staged wake (weights with restore_weights → kv_cache) is driven by the
-    http_client around the /sync-weights call (same as ``_sync_weights_cuda_ipc``);
+    http_client around the /weight-sync call (same as ``_sync_weights_cuda_ipc``);
     the weights wake restores full-shape vLLM params so the per-param chunk copy
     lands on real storage rather than offloaded [1] stubs.
     """

--- a/arctic_platform/rl/http_server.py
+++ b/arctic_platform/rl/http_server.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import io
 import logging
 import os
 import pathlib
@@ -47,6 +46,7 @@ from fastapi import HTTPException
 from fastapi import Response
 from transformers import AutoTokenizer
 
+from arctic_platform import wire
 from arctic_platform.rl.deepspeed_worker import DeepSpeedWorker
 from arctic_platform.rl.ray_cluster import init_ray_cluster
 from arctic_platform.rl.server import ArcticRLServerState
@@ -62,6 +62,7 @@ from arctic_platform.rl.utils.ray_pg import pg_scheduling_options
 from arctic_platform.rl.utils.server_models import GenerateRequest
 from arctic_platform.rl.utils.server_models import JobConfig
 from arctic_platform.rl.utils.server_models import LogProbsRequest
+from arctic_platform.rl.utils.server_models import OperationRequest
 from arctic_platform.rl.utils.server_models import ResetPrefixCacheRequest
 from arctic_platform.rl.utils.server_models import SaveRequest
 from arctic_platform.rl.utils.server_models import StepRequest
@@ -404,9 +405,7 @@ async def forward_backward(
 
     timers.stop_and_print_elapsed(tname_e2e)
 
-    buffer = io.BytesIO()
-    torch.save(merged, buffer)
-    return Response(content=buffer.getvalue(), media_type="application/octet-stream")
+    return Response(content=wire.dumps(merged), media_type="application/octet-stream")
 
 
 @app.post("/forward")
@@ -439,9 +438,7 @@ async def forward(
         metrics=merge_dict_shards([r["metrics"] for r in results]),
     )
 
-    buffer = io.BytesIO()
-    torch.save(merged, buffer)
-    return Response(content=buffer.getvalue(), media_type="application/octet-stream")
+    return Response(content=wire.dumps(merged), media_type="application/octet-stream")
 
 
 @app.post("/step")
@@ -537,6 +534,20 @@ async def reset_prefix_cache(job_id: int, request: ResetPrefixCacheRequest = Bod
     if lp_pool is not None and lp_pool._config is not None:
         results["log_prob"] = await lp_pool.reset_prefix_cache()
     return {"job_id": job_id, **results}
+
+
+@app.post("/operation")
+async def operation(job_id: int, request: OperationRequest = Body(...)):
+    """Generic data-plane operation, matching Cortex's /{job_id}/operation envelope.
+
+    Dispatches on operation_type so the unified client routes control ops through
+    one payload shape. Reuses the typed handlers below; no logic is duplicated.
+    """
+    if request.operation_type == "weight-sync":
+        return await weight_sync(job_id, WeightSyncRequest(**request.payload))
+    if request.operation_type == "reset-prefix-cache":
+        return await reset_prefix_cache(job_id, ResetPrefixCacheRequest(**request.payload))
+    raise HTTPException(status_code=400, detail=f"unknown operation_type {request.operation_type!r}")
 
 
 @app.post("/sleep-training")
@@ -979,9 +990,8 @@ async def log_probs(job_id: int, request: LogProbsRequest = Body(...)):
         # Wrap the encoded batch as the {"batch","meta","processing"} payload unpack_batch expects (the same shape
         # fwd_no_grad sends), split it across DP workers, and forward each dict shard. Empty meta -> no ZoRRO/
         # position-id rewrites, so chunk order is preserved and a plain cat reassembles the global batch.
-        batch_buf = io.BytesIO()
-        torch.save(dict(batch=dict(encoded), meta={}, processing={}), batch_buf)
-        shards, _ = http_split_batch(batch_buf.getvalue(), len(workers))
+        batch_bytes = wire.dumps(dict(batch=dict(encoded), meta={}, processing={}))
+        shards, _ = http_split_batch(batch_bytes, len(workers))
         raw = await asyncio.gather(*[w.compute_log_probs.remote(s) for w, s in zip(workers, shards)])
         results = torch.cat([r.cpu() for r in raw], dim=0)
     else:
@@ -991,9 +1001,7 @@ async def log_probs(job_id: int, request: LogProbsRequest = Body(...)):
             {"max_tokens": 1, "temperature": 0, "prompt_logprobs": request.top_k},
         )
 
-    buffer = io.BytesIO()
-    torch.save({"job_id": job_id, "results": results}, buffer)
-    return Response(content=buffer.getvalue(), media_type="application/octet-stream")
+    return Response(content=wire.dumps({"job_id": job_id, "results": results}), media_type="application/octet-stream")
 
 
 @app.get("/status")

--- a/arctic_platform/rl/http_server.py
+++ b/arctic_platform/rl/http_server.py
@@ -619,11 +619,14 @@ async def wake_log_prob(job_id: int):
 
 
 @app.post("/generate")
-async def generate(job_id: int, request: GenerateRequest = Body(...)):
+async def generate(job_id: int, body: bytes = Body(..., media_type="application/octet-stream")):
+    # DSSST1 octet in/out, matching Cortex/SnowAPI's generate wire (no tensors in
+    # the request, but the endpoint speaks the shared binary wire either way).
     _verify_job(job_id, "sampling")
+    request = GenerateRequest(**wire.loads(body))
     pool: ReplicaPool = app.state.sampling_pool
     results = await pool.generate(request.prompts, request.sampling_params, strict=request.strict)
-    return {"job_id": job_id, "results": results}
+    return Response(content=wire.dumps({"job_id": job_id, "results": results}), media_type="application/octet-stream")
 
 
 @app.post("/weight-norm")

--- a/arctic_platform/rl/ray_client.py
+++ b/arctic_platform/rl/ray_client.py
@@ -259,7 +259,7 @@ class ArcticRLRayClient:
         if processing is not None:
             batch = {**batch, "processing": processing}
         timers.stop_and_print_elapsed(tname)
-        response = await self._arctic_rl_ray_server.fwd_bwd(self.training_job_id, batch)
+        response = await self._arctic_rl_ray_server.forward_backward(self.training_job_id, batch)
         # tname = timers.start("xyz arctic_rl.ray_client outgoing processing 2")
         # response["batch"] = tensorize(response["batch"])
         # timers.stop_and_print_elapsed(tname)
@@ -271,7 +271,7 @@ class ArcticRLRayClient:
         """Forward-only pass (no gradient) on the training engine."""
         job_id = self.log_prob_job_id if reference_model else self.training_job_id
         pr0(f"[ArcticRLRayClient] fwd_no_grad INPUT: {batch.keys()=} {reference_model=} {job_id=}")
-        response = await self._arctic_rl_ray_server.fwd_no_grad(job_id, batch)
+        response = await self._arctic_rl_ray_server.forward(job_id, batch)
         pr0(f"[ArcticRLRayClient] fwd_no_grad OUTPUT: {response.keys()=}")
         # response["batch"] = tensorize(response["batch"])
         return response
@@ -286,7 +286,7 @@ class ArcticRLRayClient:
 
     async def save_checkpoint(self) -> dict[str, Any]:
         """Save training checkpoint."""
-        response = await self._arctic_rl_ray_server.save_checkpoint(self.training_job_id)
+        response = await self._arctic_rl_ray_server.save(self.training_job_id)
         pr0(f"[ArcticRLClient] save_checkpoint OUTPUT: {response.keys()=}")
         return response
 
@@ -414,13 +414,13 @@ class ArcticRLRayClient:
         the whole model (avoids OOM on big models, at the cost of round-trips).
         """
         request = dict(
-            training_job_id=self.training_job_id,
-            sampling_job_id=self.sampling_job_id,
+            source_sub_job_id=self.training_job_id,
+            target_sub_job_ids=[self.sampling_job_id],
             colocate=self.config.colocate,
             cuda_ipc=cuda_ipc,
             low_memory=low_memory,
         )
-        response = await self._arctic_rl_ray_server.sync_weights(request)
+        response = await self._arctic_rl_ray_server.weight_sync(self.training_job_id, request)
         pr0(f"[ArcticRLClient] sync_weights OUTPUT: {response.keys()=}")
         return response
 

--- a/arctic_platform/rl/ray_server.py
+++ b/arctic_platform/rl/ray_server.py
@@ -59,7 +59,7 @@ from arctic_platform.rl.utils.ray_pg import pg_scheduling_options
 from arctic_platform.rl.utils.server_models import GenerateRequest
 from arctic_platform.rl.utils.server_models import JobConfig
 from arctic_platform.rl.utils.server_models import LogProbsRequest
-from arctic_platform.rl.utils.server_models import SyncWeightsRequest
+from arctic_platform.rl.utils.server_models import WeightSyncRequest
 from arctic_platform.rl.utils.server_models import build_model_config
 
 logger = logging.getLogger(__name__)
@@ -603,7 +603,7 @@ class ArcticRLRayServer:
     async def destroy(self, job_id: int, job_type: str) -> dict[str, Any]:
         return await self.arctic_rl_ray_server_state.destroy.remote(job_id, job_type)
 
-    async def fwd_bwd(self, job_id: int, batch: dict) -> dict[str, Any]:
+    async def forward_backward(self, job_id: int, batch: dict) -> dict[str, Any]:
         tname_e2e = timers.start("xyz fwd_bwd e2e")
 
         tname = timers.start("xyz fwd_bwd: _verify_job")
@@ -679,7 +679,7 @@ class ArcticRLRayServer:
     # )
     # return {"job_id": job_id, "avg_loss": avg_loss, "post_process_outputs": post_process_outputs}
 
-    async def fwd_no_grad(self, job_id: int, batch: dict) -> dict[str, Any]:
+    async def forward(self, job_id: int, batch: dict) -> dict[str, Any]:
         info = self.jobs[job_id]
         self._verify_job(job_id, ["training", "log_prob"])
         job_type = info["job_type"]
@@ -738,8 +738,9 @@ class ArcticRLRayServer:
         logger.info("Empty training cache: %s", results)
         return {"job_id": job_id, "workers": results}
 
-    async def save_checkpoint(self, job_id: int, body: dict[str, Any] | None = None):
-        # `body` is unused; accepted so the client can call with (job_id, body).
+    async def save(self, job_id: int, body: dict[str, Any] | None = None):
+        # `checkpoint_id`/`checkpoint_type` in `body` are accepted for Cortex
+        # parity; on-prem saves to the job's configured checkpoint_path.
         self._verify_job(job_id, "training")
         info = self.jobs[job_id]
         checkpoint_path = info.get("checkpoint_path", None)
@@ -840,21 +841,26 @@ class ArcticRLRayServer:
         results = await pool.generate(
             request.prompts,
             request.sampling_params,
-            strict=True,
+            strict=request.strict,
         )
 
         return {"job_id": job_id, "results": results}
 
-    async def sync_weights(self, request: dict[str, Any]) -> dict[str, Any]:
+    async def weight_sync(self, job_id: int, body: dict[str, Any]) -> dict[str, Any]:
         """Sync training model weights to the sampling engine.
+
+        Matches Cortex's `weight_sync(job_id, source_sub_job_id, target_sub_job_ids)`;
+        on-prem treats a sub_job_id as its plain job id (source == training, target == sampling).
 
         Uses NCCL for non-colocated mode (separate GPUs).  In colocated mode:
         - cuda_ipc=True: CUDA IPC (zero-copy, requires training weights on GPU)
         - cuda_ipc=False: CPU file path (slower, works when offloaded)
         """
-        request = SyncWeightsRequest(**request)
-        self._verify_job(request.training_job_id, "training")
-        self._verify_job(request.sampling_job_id, "sampling")
+        request = WeightSyncRequest(**body)
+        training_job_id = request.source_sub_job_id
+        sampling_job_id = request.target_sub_job_ids[0]
+        self._verify_job(training_job_id, "training")
+        self._verify_job(sampling_job_id, "sampling")
 
         workers = self.training_workers
         pool: ReplicaPool = self.sampling_pool
@@ -871,16 +877,16 @@ class ArcticRLRayServer:
                 else:
                     results = await self._sync_weights_cuda_ipc(workers, pool, lp_pool)
             else:
-                training_job_info = self.jobs[request.training_job_id]
+                training_job_info = self.jobs[training_job_id]
                 sync_path = training_job_info.get("sync_path", None)
-                assert sync_path is not None, f"sync_path is required for training job {request.training_job_id}"
+                assert sync_path is not None, f"sync_path is required for training job {training_job_id}"
                 results = await self._sync_weights_ipc(sync_path, workers, pool, lp_pool)
         else:
             results = await self._sync_weights_nccl(workers, pool)
 
-        await self.arctic_rl_ray_server_state.reset_prefix_cache.remote(request.sampling_job_id)
+        await self.arctic_rl_ray_server_state.reset_prefix_cache.remote(sampling_job_id)
 
-        return {"job_id": request.training_job_id, **results}
+        return {"job_id": training_job_id, **results}
 
         # schedule = TransferSchedule.build(
         #     training_sharding="dp",

--- a/arctic_platform/rl/ray_server.py
+++ b/arctic_platform/rl/ray_server.py
@@ -770,6 +770,19 @@ class ArcticRLRayServer:
         self._verify_job(job_id, "sampling")
         return await self.arctic_rl_ray_server_state.reset_prefix_cache.remote(job_id)
 
+    async def operation(self, job_id: int, body: dict[str, Any]) -> dict[str, Any]:
+        """Generic data-plane operation, matching Cortex's operation envelope.
+
+        Dispatches on operation_type to the typed handlers; no logic duplicated.
+        """
+        op_type = body.get("operation_type")
+        payload = body.get("payload") or {}
+        if op_type == "weight-sync":
+            return await self.weight_sync(job_id, payload)
+        if op_type == "reset-prefix-cache":
+            return await self.reset_prefix_cache(job_id, payload)
+        raise ValueError(f"unknown operation_type {op_type!r}")
+
     async def sleep_training(self, job_id: int, mode: str = "all"):
         """Offload training state to CPU (sleep training workers).
 

--- a/arctic_platform/rl/utils/__init__.py
+++ b/arctic_platform/rl/utils/__init__.py
@@ -29,6 +29,7 @@ from .record_replay import record_replay_generation
 from .server_models import GenerateRequest
 from .server_models import JobConfig
 from .server_models import LogProbsRequest
+from .server_models import OperationRequest
 from .server_models import ResetPrefixCacheRequest
 from .server_models import SaveRequest
 from .server_models import StepRequest
@@ -56,6 +57,7 @@ __all__ = [
     "StepRequest",
     "SaveRequest",
     "ResetPrefixCacheRequest",
+    "OperationRequest",
     "WeightSyncRequest",
     "WeightNormRequest",
     "build_model_config",

--- a/arctic_platform/rl/utils/__init__.py
+++ b/arctic_platform/rl/utils/__init__.py
@@ -29,8 +29,11 @@ from .record_replay import record_replay_generation
 from .server_models import GenerateRequest
 from .server_models import JobConfig
 from .server_models import LogProbsRequest
-from .server_models import SyncWeightsRequest
+from .server_models import ResetPrefixCacheRequest
+from .server_models import SaveRequest
+from .server_models import StepRequest
 from .server_models import WeightNormRequest
+from .server_models import WeightSyncRequest
 from .server_models import build_model_config
 
 __all__ = [
@@ -50,7 +53,10 @@ __all__ = [
     "JobConfig",
     "GenerateRequest",
     "LogProbsRequest",
-    "SyncWeightsRequest",
+    "StepRequest",
+    "SaveRequest",
+    "ResetPrefixCacheRequest",
+    "WeightSyncRequest",
     "WeightNormRequest",
     "build_model_config",
 ]

--- a/arctic_platform/rl/utils/batch.py
+++ b/arctic_platform/rl/utils/batch.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import os
 from typing import Any
 
 # import itertools
 import torch
 
+from arctic_platform import wire
 from arctic_platform.rl.zorro_train.seqlen_balancing import reorg_global_batch
 
 
@@ -158,7 +158,7 @@ def http_split_batch(batch_bytes: bytes, num_workers: int) -> list[bytes]:
     """Deserialize a global batch, split across DP workers, re-serialize each shard."""
     # if num_workers <= 1:
     #     return [batch_bytes]
-    batch = torch.load(io.BytesIO(batch_bytes), map_location="cpu")
+    batch = wire.loads(batch_bytes)
 
     shards, reorder_indices = _split_batch(batch, num_workers)
 

--- a/arctic_platform/rl/utils/server_models.py
+++ b/arctic_platform/rl/utils/server_models.py
@@ -45,6 +45,8 @@ class JobConfig(BaseModel):
 class GenerateRequest(BaseModel):
     prompts: list[str]
     sampling_params: dict[str, Any] | None = None
+    routing_key: Any = None
+    strict: bool = False
 
 
 class LogProbsRequest(BaseModel):
@@ -53,9 +55,28 @@ class LogProbsRequest(BaseModel):
     top_k: int = 1
 
 
-class SyncWeightsRequest(BaseModel):
-    training_job_id: int
-    sampling_job_id: int
+class StepRequest(BaseModel):
+    learning_rate: float | None = None
+
+
+class SaveRequest(BaseModel):
+    # On-prem saves to the job's configured checkpoint_path; these mirror
+    # Cortex's `save(checkpoint_id, checkpoint_type)` and are accepted (unused).
+    checkpoint_id: str | None = None
+    checkpoint_type: str = "resumable"
+
+
+class ResetPrefixCacheRequest(BaseModel):
+    drain: bool = True
+    timeout_s: float = 60.0
+    retry_interval_s: float = 0.1
+
+
+class WeightSyncRequest(BaseModel):
+    # Matches Cortex's `weight_sync(source_sub_job_id, target_sub_job_ids)`.
+    # On-prem treats a sub_job_id as its plain job id.
+    source_sub_job_id: int
+    target_sub_job_ids: list[int]
     colocate: bool = False
     cuda_ipc: bool = False
     low_memory: bool = False

--- a/arctic_platform/rl/utils/server_models.py
+++ b/arctic_platform/rl/utils/server_models.py
@@ -82,6 +82,16 @@ class WeightSyncRequest(BaseModel):
     low_memory: bool = False
 
 
+class OperationRequest(BaseModel):
+    # Generic data-plane envelope, matching Cortex's /{job_id}/operation. On-prem
+    # dispatches on operation_type; sub_job_id/sub_job_type are accepted for
+    # parity (unused, since on-prem addresses jobs by the job_id query param).
+    operation_type: str
+    sub_job_id: str | None = None
+    sub_job_type: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
 class WeightNormRequest(BaseModel):
     training_job_id: int
     sampling_job_id: int

--- a/arctic_platform/wire.py
+++ b/arctic_platform/wire.py
@@ -1,0 +1,392 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DSS binary wire protocol (DSSST1).
+
+The single source of truth for how binary training payloads are serialized. It is
+shared infra: the Cortex transport speaks it to SnowAPI, and the on-prem HTTP
+transport + server use it as their octet codec too. It owns three concerns behind
+one small surface:
+
+1. Codec -- ``dumps`` / ``loads`` serialize a nested dict/list/tuple of tensors
+   and JSON-able data as a single **safetensors** blob. Pickle is never used, so
+   nothing can execute during decode (unlike ``torch.load``).
+
+2. Operation metadata -- ``dumps(obj, metadata=...)`` stores small control-plane
+   metadata (router replay, chunk descriptors) inside the safetensors
+   ``__metadata__`` header. ``read_metadata`` reads it back **without**
+   deserializing tensors.
+
+3. Byte chunking -- ``encode_byte_chunks`` splits an oversized DSSST1 frame into
+   self-describing byte-range frames. ``decode_byte_chunks`` reassembles them.
+
+Wire layout of one frame is just a safetensors blob::
+
+    [ u64 header_len | JSON header (__metadata__: {dss: <structure>, op: <metadata>}) | tensor bytes ]
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from typing import Any
+
+import torch
+from safetensors.torch import load as st_load
+from safetensors.torch import save as st_save
+
+WIRE_FORMAT_VERSION = "DSSST1"
+
+_STRUCT_KEY = "dss"  # structure skeleton (internal)
+_OP_KEY = "op"  # operation metadata (router_replay, request/result chunks, ...)
+_REQUEST_CHUNK_KEY = "request_chunk"
+_RESULT_CHUNK_KEY = "result_chunk"
+_PLACEHOLDER_KEY = "__dss_empty__"
+_ROOT_KEY = "__root__"
+_MAX_HEADER_BYTES = 64 * 1024 * 1024
+_CHUNK_PAYLOAD_KEY = "payload"
+_DEFAULT_CHUNK_OVERHEAD_BYTES = 8192
+
+_PICKLE_SIGNATURES = (b"\x80\x02", b"\x80\x03", b"\x80\x04", b"\x80\x05")
+_ZIP_SIGNATURE = b"PK\x03\x04"
+
+
+class WireError(ValueError):
+    """Raised for malformed or incompatible wire payloads."""
+
+
+def _is_tensor(obj: Any) -> bool:
+    return torch.is_tensor(obj)
+
+
+# ---------------------------------------------------------------------------
+# Codec
+# ---------------------------------------------------------------------------
+
+
+def _subtree_has_tensor(obj: Any) -> bool:
+    if _is_tensor(obj):
+        return True
+    if isinstance(obj, dict):
+        return any(_subtree_has_tensor(v) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return any(_subtree_has_tensor(v) for v in obj)
+    return False
+
+
+def _encode(obj: Any, tensors: dict, seen: set, path: str) -> list:
+    if _is_tensor(obj):
+        key = path or _ROOT_KEY
+        tensor = obj.detach().cpu().contiguous()
+        node: list = ["t", key]
+        if tensor.dim() == 0:
+            tensor = tensor.reshape(1)
+            node = ["t", key, {"scalar": True}]
+        # safetensors rejects tensors that share storage; clone on collision.
+        if tensor.data_ptr() in seen and tensor.numel() > 0:
+            tensor = tensor.clone()
+        seen.add(tensor.data_ptr())
+        tensors[key] = tensor
+        return node
+    if isinstance(obj, dict):
+        if not _subtree_has_tensor(obj):
+            return ["j", obj]
+        items = []
+        for raw_key, value in obj.items():
+            if not isinstance(raw_key, str):
+                raise WireError(f"DSSST1 dict keys must be strings, got {type(raw_key)!r}")
+            child_path = f"{path}.{raw_key}" if path else raw_key
+            items.append([raw_key, _encode(value, tensors, seen, child_path)])
+        return ["d", items]
+    if isinstance(obj, tuple):
+        return ["u", [_encode(v, tensors, seen, f"{path}.{i}" if path else str(i)) for i, v in enumerate(obj)]]
+    if isinstance(obj, list):
+        if not _subtree_has_tensor(obj):
+            return ["j", obj]
+        return ["l", [_encode(v, tensors, seen, f"{path}.{i}" if path else str(i)) for i, v in enumerate(obj)]]
+    return ["j", obj]
+
+
+def dumps(obj: Any, *, metadata: dict | None = None) -> bytes:
+    """Serialize ``obj`` to one safetensors frame, with optional op ``metadata``."""
+    tensors: dict = {}
+    tree = _encode(obj, tensors, set(), "")
+    if not tensors:
+        tensors[_PLACEHOLDER_KEY] = torch.zeros(1, dtype=torch.uint8)
+    header = {_STRUCT_KEY: json.dumps({"v": WIRE_FORMAT_VERSION, "tree": tree})}
+    if metadata:
+        header[_OP_KEY] = json.dumps(metadata)
+    return st_save(tensors, metadata=header)
+
+
+def _decode(node: list, tensors: dict) -> Any:
+    tag = node[0]
+    if tag == "t":
+        tensor = tensors[node[1]]
+        if len(node) > 2 and isinstance(node[2], dict) and node[2].get("scalar"):
+            return tensor.reshape(())
+        return tensor
+    if tag == "j":
+        return node[1]
+    if tag == "d":
+        return {key: _decode(child, tensors) for key, child in node[1]}
+    if tag == "l":
+        return [_decode(child, tensors) for child in node[1]]
+    if tag == "u":
+        return tuple(_decode(child, tensors) for child in node[1])
+    raise WireError(f"unknown DSSST1 node tag {tag!r}")
+
+
+def _read_header(data: bytes) -> dict:
+    if len(data) < 8:
+        raise WireError("payload too short to be a DSSST1 safetensors blob")
+    header_len = int.from_bytes(data[:8], "little")
+    if header_len <= 0 or 8 + header_len > len(data) or header_len > _MAX_HEADER_BYTES:
+        raise WireError("invalid DSSST1 safetensors header length")
+    header = json.loads(data[8 : 8 + header_len].decode("utf-8"))
+    return header.get("__metadata__", {}) or {}
+
+
+def loads(data: Any) -> Any:
+    """Deserialize a frame produced by :func:`dumps`.
+
+    Never invokes pickle/``torch.load``; a legacy pickle or ``torch.save``
+    payload is rejected with a clear error instead of being executed.
+    """
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise WireError("DSSST1 loads expects bytes")
+    data = bytes(data)
+    try:
+        tensors = st_load(data)
+        header = _read_header(data)
+    except Exception as exc:  # not safetensors -> never feed it to pickle
+        if data[:2] in _PICKLE_SIGNATURES or data[:4] == _ZIP_SIGNATURE:
+            raise WireError(
+                "refusing to deserialize a legacy pickle/torch.save payload; "
+                "the peer must use the DSSST1 safetensors wire protocol"
+            ) from exc
+        raise WireError(f"not a valid DSSST1 safetensors payload: {exc}") from exc
+
+    raw = header.get(_STRUCT_KEY)
+    if raw is None:
+        raise WireError("DSSST1 structure missing from safetensors header")
+    info = json.loads(raw)
+    if info.get("v") != WIRE_FORMAT_VERSION:
+        raise WireError(f"unsupported DSSST1 wire version {info.get('v')!r}")
+    tensors.pop(_PLACEHOLDER_KEY, None)
+    return _decode(info["tree"], tensors)
+
+
+def read_metadata(data: Any) -> dict:
+    """Return the operation metadata from a frame header without loading tensors.
+
+    This is a lenient peek: bytes that aren't a valid DSSST1 frame simply have no
+    operation metadata, so ``{}`` is returned. The authoritative (pickle-safe)
+    decode happens in :func:`loads`.
+    """
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise WireError("DSSST1 read_metadata expects bytes")
+    try:
+        raw = _read_header(bytes(data)).get(_OP_KEY)
+    except (WireError, ValueError):
+        return {}
+    return json.loads(raw) if raw else {}
+
+
+# ---------------------------------------------------------------------------
+# Byte chunking -- split and reassemble DSSST1 frames
+# ---------------------------------------------------------------------------
+
+
+def _chunk_key(kind: str) -> str:
+    if kind == "request":
+        return _REQUEST_CHUNK_KEY
+    if kind == "result":
+        return _RESULT_CHUNK_KEY
+    raise WireError(f"unknown byte chunk kind {kind!r}")
+
+
+def _bytes_to_tensor(data: bytes) -> torch.Tensor:
+    # bytearray makes the buffer writable; clone detaches from the temporary.
+    return torch.frombuffer(bytearray(data), dtype=torch.uint8).clone()
+
+
+def _tensor_to_bytes(tensor: Any) -> bytes:
+    if not torch.is_tensor(tensor):
+        raise WireError("byte chunk payload must be a tensor")
+    if tensor.dtype != torch.uint8:
+        raise WireError(f"byte chunk payload tensor must be uint8, got {tensor.dtype}")
+    if tensor.ndim != 1:
+        raise WireError(f"byte chunk payload tensor must be 1-D, got shape {tuple(tensor.shape)}")
+    return tensor.cpu().contiguous().numpy().tobytes()
+
+
+def _make_byte_chunk_frame(
+    frame: bytes,
+    *,
+    kind: str,
+    operation: str | None,
+    group_id: str | None,
+    chunk_idx: int,
+    total_chunks: int,
+    start: int,
+    end: int,
+) -> bytes:
+    key = _chunk_key(kind)
+    desc: dict[str, Any] = {
+        "chunk_idx": chunk_idx,
+        "total_chunks": total_chunks,
+        "frame_sha256": hashlib.sha256(frame).hexdigest(),
+        "frame_size_bytes": len(frame),
+    }
+    if group_id is not None:
+        desc["chunk_group_id"] = group_id
+    if operation is not None:
+        desc["operation"] = operation
+    return dumps({_CHUNK_PAYLOAD_KEY: _bytes_to_tensor(frame[start:end])}, metadata={key: desc})
+
+
+def encode_byte_chunks(
+    frame: bytes,
+    *,
+    kind: str,
+    operation: str | None = None,
+    max_bytes: int = 0,
+    chunk_group_id: str | None = None,
+) -> list[bytes]:
+    """Split a DSSST1 frame into byte-range DSSST1 chunk frames.
+
+    Returns ``[frame]`` when no chunking is needed. When chunking is needed,
+    every returned frame contains a 1-D uint8 ``payload`` tensor plus metadata
+    under ``request_chunk`` or ``result_chunk``.
+    """
+    if not isinstance(frame, (bytes, bytearray, memoryview)):
+        raise WireError("encode_byte_chunks expects frame bytes")
+    frame = bytes(frame)
+    if max_bytes <= 0 or len(frame) <= max_bytes:
+        return [frame]
+
+    group_id = chunk_group_id if kind == "request" else None
+    if kind == "request" and not group_id:
+        import uuid
+
+        group_id = str(uuid.uuid4())
+
+    payload_size = max(1, max_bytes - _DEFAULT_CHUNK_OVERHEAD_BYTES)
+    while True:
+        ranges = [(start, min(start + payload_size, len(frame))) for start in range(0, len(frame), payload_size)]
+        total = len(ranges)
+        chunks = [
+            _make_byte_chunk_frame(
+                frame,
+                kind=kind,
+                operation=operation,
+                group_id=group_id,
+                chunk_idx=idx,
+                total_chunks=total,
+                start=start,
+                end=end,
+            )
+            for idx, (start, end) in enumerate(ranges)
+        ]
+        if all(len(chunk) <= max_bytes for chunk in chunks):
+            return chunks
+        if payload_size == 1:
+            raise WireError("max_bytes is too small to hold one DSSST1 byte chunk frame")
+        payload_size = max(1, payload_size // 2)
+
+
+def read_byte_chunk_metadata(frame: Any) -> dict | None:
+    """Return byte chunk metadata with ``kind`` included, or ``None``."""
+    metadata = read_metadata(frame)
+    if _REQUEST_CHUNK_KEY in metadata:
+        desc = dict(metadata[_REQUEST_CHUNK_KEY])
+        desc["kind"] = "request"
+        return desc
+    if _RESULT_CHUNK_KEY in metadata:
+        desc = dict(metadata[_RESULT_CHUNK_KEY])
+        desc["kind"] = "result"
+        return desc
+    return None
+
+
+def decode_byte_chunks(chunks: list[bytes], *, kind: str | None = None) -> bytes:
+    """Reassemble byte-range DSSST1 chunks into the original DSSST1 frame."""
+    if not chunks:
+        raise WireError("decode_byte_chunks requires at least one frame")
+    if len(chunks) == 1 and read_byte_chunk_metadata(chunks[0]) is None:
+        return bytes(chunks[0])
+
+    descriptors = [read_byte_chunk_metadata(chunk) for chunk in chunks]
+    if any(desc is None for desc in descriptors):
+        raise WireError("decode_byte_chunks received a frame without byte chunk metadata")
+    descriptors = [desc for desc in descriptors if desc is not None]
+    actual_kind = descriptors[0]["kind"]
+    if kind is not None and actual_kind != kind:
+        raise WireError(f"expected {kind} chunks, got {actual_kind} chunks")
+
+    total = int(descriptors[0].get("total_chunks"))
+    frame_sha256 = descriptors[0].get("frame_sha256")
+    frame_size_bytes = int(descriptors[0].get("frame_size_bytes"))
+    group_id = descriptors[0].get("chunk_group_id")
+    operation = descriptors[0].get("operation")
+
+    if len(chunks) != total:
+        raise WireError(f"expected {total} byte chunks, got {len(chunks)}")
+
+    seen: set[int] = set()
+    ordered: list[tuple[int, bytes]] = []
+    for chunk, desc in zip(chunks, descriptors):
+        if desc["kind"] != actual_kind:
+            raise WireError("mixed byte chunk kinds")
+        if int(desc.get("total_chunks")) != total:
+            raise WireError("byte chunk total_chunks differs across frames")
+        if desc.get("frame_sha256") != frame_sha256:
+            raise WireError("byte chunk frame_sha256 differs across frames")
+        if int(desc.get("frame_size_bytes")) != frame_size_bytes:
+            raise WireError("byte chunk frame_size_bytes differs across frames")
+        if desc.get("chunk_group_id") != group_id:
+            raise WireError("byte chunk chunk_group_id differs across frames")
+        if desc.get("operation") != operation:
+            raise WireError("byte chunk operation differs across frames")
+        idx = int(desc.get("chunk_idx"))
+        if idx < 0 or idx >= total:
+            raise WireError("byte chunk_idx out of range")
+        if idx in seen:
+            raise WireError("duplicate byte chunk_idx")
+        seen.add(idx)
+        payload = loads(chunk).get(_CHUNK_PAYLOAD_KEY)
+        ordered.append((idx, _tensor_to_bytes(payload)))
+
+    if seen != set(range(total)):
+        missing = sorted(set(range(total)) - seen)
+        raise WireError(f"missing byte chunks: {missing}")
+
+    frame = b"".join(payload for _, payload in sorted(ordered))
+    if len(frame) != frame_size_bytes:
+        raise WireError("reassembled frame size mismatch")
+    if hashlib.sha256(frame).hexdigest() != frame_sha256:
+        raise WireError("reassembled frame sha256 mismatch")
+    return frame
+
+
+def encode_result_chunks(result: Any, *, max_bytes: int = 0) -> list[bytes]:
+    """Serialize and optionally byte-chunk a result object."""
+    return encode_byte_chunks(dumps(result), kind="result", max_bytes=max_bytes)
+
+
+def decode_result_chunks(chunks: list[bytes]) -> Any:
+    """Decode a result object returned by :func:`encode_result_chunks`."""
+    return loads(decode_byte_chunks(chunks, kind="result"))

--- a/arctic_platform/wire.py
+++ b/arctic_platform/wire.py
@@ -39,8 +39,8 @@ Wire layout of one frame is just a safetensors blob::
 
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 from typing import Any
 
 import torch

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -124,20 +124,29 @@ class TestOpMapping:
         assert req.body == {"prompts": ["hi"], "completions": ["there"], "top_k": 3}
 
     def test_reset_prefix_cache_targets_sampling(self, client):
-        """reset_prefix_cache -> sampling job."""
+        """reset_prefix_cache -> sampling job via the operation envelope."""
         client.reset_prefix_cache(drain=False, timeout_s=5.0, retry_interval_s=0.2)
         req = _last(client)
-        assert req.op == "reset-prefix-cache"
+        assert req.op == "operation"
         assert req.job_id == SAMPLING
-        assert req.body == {"drain": False, "timeout_s": 5.0, "retry_interval_s": 0.2}
+        assert req.body == {
+            "operation_type": "reset-prefix-cache",
+            "sub_job_type": "sampling",
+            "payload": {"drain": False, "timeout_s": 5.0, "retry_interval_s": 0.2},
+        }
 
     def test_sync_weights_targets_training_with_sub_job_ids(self, client):
-        """sync_weights -> training job; Cortex-shaped source/target sub-job ids in body."""
+        """sync_weights -> training job; weight-sync operation with source/target payload."""
         client.sync_weights()
         req = _last(client)
-        assert req.op == "weight-sync"
+        assert req.op == "operation"
         assert req.job_id == TRAINING
-        assert req.body == {"source_sub_job_id": TRAINING, "target_sub_job_ids": [SAMPLING]}
+        assert req.body == {
+            "operation_type": "weight-sync",
+            "sub_job_id": TRAINING,
+            "sub_job_type": "training",
+            "payload": {"source_sub_job_id": TRAINING, "target_sub_job_ids": [SAMPLING]},
+        }
 
 
 class TestLifecycle:

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -69,7 +69,7 @@ class TestOpMapping:
         """fwd_bwd -> training job, binary payload, body carries the batch."""
         client.fwd_bwd({"input_ids": [1, 2]})
         req = _last(client)
-        assert req.op == "fwd-bwd"
+        assert req.op == "forward-backward"
         assert req.job_id == TRAINING
         assert req.binary is True
         assert req.body["input_ids"] == [1, 2]
@@ -85,7 +85,7 @@ class TestOpMapping:
         """fwd_no_grad -> training job, binary payload."""
         client.fwd_no_grad({"input_ids": [1]})
         req = _last(client)
-        assert req.op == "fwd-no-grad"
+        assert req.op == "forward"
         assert req.job_id == TRAINING
         assert req.binary is True
 
@@ -99,20 +99,20 @@ class TestOpMapping:
         assert req.body == {"learning_rate": 0.5}
 
     def test_save_checkpoint_targets_training(self, client):
-        """save_checkpoint -> training job."""
-        client.save_checkpoint(stage_info={"s": 1}, path="/tmp/x")
+        """save_checkpoint -> training job (save op, Cortex-shaped body)."""
+        client.save_checkpoint(checkpoint_id="cp1", checkpoint_type="weights-only")
         req = _last(client)
-        assert req.op == "save-checkpoint"
+        assert req.op == "save"
         assert req.job_id == TRAINING
-        assert req.body == {"stage_info": {"s": 1}, "path": "/tmp/x"}
+        assert req.body == {"checkpoint_id": "cp1", "checkpoint_type": "weights-only"}
 
     def test_generate_targets_sampling_and_unwraps_results(self, client):
         """generate -> sampling job; returns the 'results' list."""
-        out = client.generate(["hi"], sampling_params={"n": 1}, routing_key="k")
+        out = client.generate(["hi"], sampling_params={"n": 1}, routing_key="k", strict=True)
         req = _last(client)
         assert req.op == "generate"
         assert req.job_id == SAMPLING
-        assert req.body == {"prompts": ["hi"], "sampling_params": {"n": 1}, "routing_key": "k"}
+        assert req.body == {"prompts": ["hi"], "sampling_params": {"n": 1}, "routing_key": "k", "strict": True}
         assert out == ["ok"]
 
     def test_log_probs_targets_log_prob(self, client):
@@ -125,19 +125,19 @@ class TestOpMapping:
 
     def test_reset_prefix_cache_targets_sampling(self, client):
         """reset_prefix_cache -> sampling job."""
-        client.reset_prefix_cache(drain=False, timeout_s=5.0)
+        client.reset_prefix_cache(drain=False, timeout_s=5.0, retry_interval_s=0.2)
         req = _last(client)
         assert req.op == "reset-prefix-cache"
         assert req.job_id == SAMPLING
-        assert req.body == {"drain": False, "timeout_s": 5.0}
+        assert req.body == {"drain": False, "timeout_s": 5.0, "retry_interval_s": 0.2}
 
-    def test_sync_weights_has_no_primary_job_id(self, client):
-        """sync_weights -> job_id None; both ids ride in the body."""
+    def test_sync_weights_targets_training_with_sub_job_ids(self, client):
+        """sync_weights -> training job; Cortex-shaped source/target sub-job ids in body."""
         client.sync_weights()
         req = _last(client)
-        assert req.op == "sync-weights"
-        assert req.job_id is None
-        assert req.body == {"training_job_id": TRAINING, "sampling_job_id": SAMPLING}
+        assert req.op == "weight-sync"
+        assert req.job_id == TRAINING
+        assert req.body == {"source_sub_job_id": TRAINING, "target_sub_job_ids": [SAMPLING]}
 
 
 class TestLifecycle:

--- a/tests/rl/test_e2e.py
+++ b/tests/rl/test_e2e.py
@@ -298,7 +298,7 @@ class TestE2E(TestCasePlus):
                 await client.save_weights("/tmp/unused")
         else:
             # The http client implements disk-based save_weights as a graceful warn-on-error stub (server-side
-            # reload is not fully implemented), so it posts to /sync-weights and must return without raising.
+            # reload is not fully implemented), so it posts to /weight-sync and must return without raising.
             await client.save_weights("/tmp/arl_unused_ckpt")
 
     @parameterized.expand(e2e_params, name_func=parameterized_custom_name_func)


### PR DESCRIPTION
Refactors the on-prem HTTP/Ray path so the unified `ArcticRLClient` uses one op vocabulary and request-body shape across both the on-prem and (upcoming) Cortex transports. No Cortex transport is added here.

- **Shared DSSST1 binary wire.** New `arctic_platform.wire` (safetensors-based) replaces `torch.save`/`torch.load` across the client, server, `http_client`, and `batch` utils — one codec for all tensor-bearing payloads, and no more pickle in the deserialization path.
- **Unified `/operation` envelope.** Control-plane ops (`weight-sync`, `reset-prefix-cache`) now flow through a single `operation` op carrying Cortex's `{operation_type, sub_job_id, sub_job_type, payload}` shape, with matching `/operation` endpoints on the HTTP and Ray servers.
- **Body shapes match Cortex:** `weight-sync` (`source_sub_job_id`/`target_sub_job_ids`), `save` (`checkpoint_id`/`checkpoint_type`), `step` (`learning_rate`), and `generate` (`prompts`/`sampling_params`/`routing_key`/`strict`).
- **`generate` over octet DSSST1 (HTTP).** The HTTP `/generate` route now speaks the binary wire in/out like `forward-backward`, matching SnowAPI (Ray is in-process, unchanged).
- **Transport cleanup:** collapsed the `_rpc` delivery primitive into `call`.
- **Docs:** `UNIFICATION_NOTES.md` records the alignment plus the divergences we're intentionally deferring (async submit/poll model, job-creation shape, addressing/id types) — handled by the transport layer since `dss-client` will be deprecated in favor of the Cortex transport on the same wire.
