### PR TITLE
Async unified client

### DIFF
--- a/arctic_platform/client/__init__.py
+++ b/arctic_platform/client/__init__.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from arctic_platform.client.client import ArcticRLClient
-from arctic_platform.client.client import AsyncArcticRLClient
+from arctic_platform.client.client import SyncArcticRLClient
 from arctic_platform.client.client import create_arctic_rl_client
-from arctic_platform.client.client import create_async_arctic_rl_client
 from arctic_platform.client.client import make_transport
 from arctic_platform.client.config import ArcticRLClientConfig
 from arctic_platform.client.transport import OPS
@@ -28,12 +27,11 @@ __all__ = [
     "OPS",
     "ArcticRLClient",
     "ArcticRLClientConfig",
-    "AsyncArcticRLClient",
     "JobHandles",
     "Request",
+    "SyncArcticRLClient",
     "Transport",
     "create_arctic_rl_client",
-    "create_async_arctic_rl_client",
     "make_transport",
     "unresolved_ops",
 ]

--- a/arctic_platform/client/__init__.py
+++ b/arctic_platform/client/__init__.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from arctic_platform.client.client import ArcticRLClient
+from arctic_platform.client.client import AsyncArcticRLClient
 from arctic_platform.client.client import create_arctic_rl_client
+from arctic_platform.client.client import create_async_arctic_rl_client
 from arctic_platform.client.client import make_transport
 from arctic_platform.client.config import ArcticRLClientConfig
 from arctic_platform.client.transport import OPS
@@ -26,10 +28,12 @@ __all__ = [
     "OPS",
     "ArcticRLClient",
     "ArcticRLClientConfig",
+    "AsyncArcticRLClient",
     "JobHandles",
     "Request",
     "Transport",
     "create_arctic_rl_client",
+    "create_async_arctic_rl_client",
     "make_transport",
     "unresolved_ops",
 ]

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -17,7 +17,8 @@
 Every op lives here exactly once: friendly signature -> canonical `Request`
 (op name, target job, user-data body). Job ids and wire mechanics belong to the
 transport, so the client never mentions them. Switching deployment == changing
-`config.backend`.
+`config.backend`. Sync and async frontends share the Request builders; they
+differ only at `transport.call` vs `transport.acall`.
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.transport import JobHandles
 from arctic_platform.client.transport import Request
 from arctic_platform.client.transport import Transport
 
@@ -38,6 +40,105 @@ def make_transport(config: ArcticRLClientConfig) -> Transport:
     return HttpTransport(config)  # onprem (HTTP)
 
 
+# ── Request builders (op vocabulary defined once) ───────────────────────────
+
+
+def _fwd_bwd_request(
+    jobs: JobHandles, batch: dict, processing: dict | None = None, router_replay: Any = None
+) -> Request:
+    # NOTE: the call *signature* is unified across backends, but `batch`'s
+    # *content* is not: Cortex expects an RPC-style
+    # {"args": [...], "kwargs": {...}} that the server tokenizes, while on-prem
+    # expects a pre-tokenized verl-GRPO {"batch", "meta", "processing"}. The
+    # client forwards `batch` verbatim, so today the caller must still match
+    # the target backend's data contract.
+    # TODO(unify-backends): converge the server-side fwd_bwd on ONE batch
+    # contract (ideally Cortex's) so this frontend is truly backend-agnostic
+    # and callers stop branching on backend. Until then `processing` is folded
+    # into the body here, which is why callers can leave it inside `batch`.
+    body = dict(batch)
+    body.update({k: v for k, v in (("processing", processing), ("router_replay", router_replay)) if v is not None})
+    return Request("forward-backward", jobs.require("training"), body, binary=True)
+
+
+def _fwd_no_grad_request(jobs: JobHandles, batch: dict) -> Request:
+    return Request("forward", jobs.require("training"), dict(batch), binary=True)
+
+
+def _step_request(jobs: JobHandles, learning_rate: float | None = None) -> Request:
+    # NOTE: response *shapes* also diverge across backends -- on-prem returns
+    # {"metrics": {"grad_norm", ...}, ...} (scalars can be per-DP-rank lists),
+    # while Cortex returns just the loss with no metrics dict. Callers cope
+    # via graceful key lookups today.
+    # TODO(unify-backends): converge the server-side fwd_bwd/step *responses*
+    # on ONE schema (loss + metrics) so callers never key on backend.
+    return Request("step", jobs.require("training"), {"learning_rate": learning_rate})
+
+
+def _save_checkpoint_request(
+    jobs: JobHandles, checkpoint_id: str | None = None, checkpoint_type: str = "resumable"
+) -> Request:
+    # Matches Cortex's `save(job_id, checkpoint_id=None, checkpoint_type=None)`.
+    body = {"checkpoint_id": checkpoint_id, "checkpoint_type": checkpoint_type}
+    return Request("save", jobs.require("training"), body)
+
+
+def _generate_request(
+    jobs: JobHandles,
+    prompts: list,
+    sampling_params: dict | None = None,
+    routing_key: Any = None,
+    strict: bool = False,
+) -> Request:
+    body = {"prompts": prompts, "sampling_params": sampling_params, "routing_key": routing_key, "strict": strict}
+    return Request("generate", jobs.require("sampling"), body)
+
+
+def _log_probs_request(
+    jobs: JobHandles, prompts: list, completions: list | None = None, top_k: int = 1
+) -> Request:
+    body = {"prompts": prompts, "completions": completions, "top_k": top_k}
+    return Request("log-probs", jobs.require("log_prob"), body)
+
+
+def _sync_weights_request(jobs: JobHandles) -> Request:
+    # The client assembles the full Cortex `/operation` envelope here so transports
+    # just forward it: SnowAPI reads the `sub_job_*` routing hints, on-prem accepts
+    # the same shape and ignores them (it addresses jobs by job id). On-prem treats a
+    # sub_job_id as its plain job id, so source/target ids double as its job ids.
+    tid, sid = jobs.require("training"), jobs.require("sampling")
+    body = {
+        "operation_type": "weight-sync",
+        "sub_job_id": tid,
+        "sub_job_type": "training",
+        "payload": {"source_sub_job_id": tid, "target_sub_job_ids": [sid]},
+    }
+    return Request("operation", tid, body)
+
+
+def _reset_prefix_cache_request(
+    jobs: JobHandles, drain: bool = True, timeout_s: float = 60.0, retry_interval_s: float = 0.1
+) -> Request:
+    sid = jobs.require("sampling")
+    body = {
+        "operation_type": "reset-prefix-cache",
+        "sub_job_type": "sampling",
+        "payload": {"drain": drain, "timeout_s": timeout_s, "retry_interval_s": retry_interval_s},
+    }
+    return Request("operation", sid, body)
+
+
+def _reconnect_config(config: ArcticRLClientConfig, jobs: JobHandles) -> ArcticRLClientConfig:
+    """A serializable config that reattaches to these jobs in another process."""
+    return config.model_copy(
+        update={
+            "training_job_id": jobs.training,
+            "sampling_job_id": jobs.sampling,
+            "log_prob_job_id": jobs.log_prob,
+        }
+    )
+
+
 class ArcticRLClient:
     def __init__(self, config: ArcticRLClientConfig) -> None:
         self.config = config
@@ -46,82 +147,38 @@ class ArcticRLClient:
 
     # ── training ─────────────────────────────────────────────────────────
     def fwd_bwd(self, batch: dict, processing: dict | None = None, router_replay: Any = None) -> dict:
-        # NOTE: the call *signature* is unified across backends, but `batch`'s
-        # *content* is not: Cortex expects an RPC-style
-        # {"args": [...], "kwargs": {...}} that the server tokenizes, while on-prem
-        # expects a pre-tokenized verl-GRPO {"batch", "meta", "processing"}. The
-        # client forwards `batch` verbatim, so today the caller must still match
-        # the target backend's data contract.
-        # TODO(unify-backends): converge the server-side fwd_bwd on ONE batch
-        # contract (ideally Cortex's) so this frontend is truly backend-agnostic
-        # and callers stop branching on backend. Until then `processing` is folded
-        # into the body here, which is why callers can leave it inside `batch`.
-        body = dict(batch)
-        body.update({k: v for k, v in (("processing", processing), ("router_replay", router_replay)) if v is not None})
-        return self.transport.call(Request("forward-backward", self.jobs.require("training"), body, binary=True))
+        return self.transport.call(_fwd_bwd_request(self.jobs, batch, processing, router_replay))
 
     def fwd_no_grad(self, batch: dict) -> dict:
-        return self.transport.call(Request("forward", self.jobs.require("training"), dict(batch), binary=True))
+        return self.transport.call(_fwd_no_grad_request(self.jobs, batch))
 
     def step(self, learning_rate: float | None = None) -> dict:
-        # NOTE: response *shapes* also diverge across backends -- on-prem returns
-        # {"metrics": {"grad_norm", ...}, ...} (scalars can be per-DP-rank lists),
-        # while Cortex returns just the loss with no metrics dict. Callers cope
-        # via graceful key lookups today.
-        # TODO(unify-backends): converge the server-side fwd_bwd/step *responses*
-        # on ONE schema (loss + metrics) so callers never key on backend.
-        return self.transport.call(Request("step", self.jobs.require("training"), {"learning_rate": learning_rate}))
+        return self.transport.call(_step_request(self.jobs, learning_rate))
 
     def save_checkpoint(self, checkpoint_id: str | None = None, checkpoint_type: str = "resumable") -> dict:
-        # Matches Cortex's `save(job_id, checkpoint_id=None, checkpoint_type=None)`.
-        body = {"checkpoint_id": checkpoint_id, "checkpoint_type": checkpoint_type}
-        return self.transport.call(Request("save", self.jobs.require("training"), body))
+        return self.transport.call(_save_checkpoint_request(self.jobs, checkpoint_id, checkpoint_type))
 
     # ── sampling / log-prob ──────────────────────────────────────────────
     def generate(
         self, prompts: list, sampling_params: dict | None = None, routing_key: Any = None, strict: bool = False
     ) -> list:
-        body = {"prompts": prompts, "sampling_params": sampling_params, "routing_key": routing_key, "strict": strict}
-        return self.transport.call(Request("generate", self.jobs.require("sampling"), body))["results"]
+        return self.transport.call(_generate_request(self.jobs, prompts, sampling_params, routing_key, strict))[
+            "results"
+        ]
 
     def log_probs(self, prompts: list, completions: list | None = None, top_k: int = 1) -> dict:
-        body = {"prompts": prompts, "completions": completions, "top_k": top_k}
-        return self.transport.call(Request("log-probs", self.jobs.require("log_prob"), body))
+        return self.transport.call(_log_probs_request(self.jobs, prompts, completions, top_k))
 
-    # ── weight sync + cache (control-plane ops -> the /operation envelope) ──
-    # The client assembles the full Cortex `/operation` envelope here so transports
-    # just forward it: SnowAPI reads the `sub_job_*` routing hints, on-prem accepts
-    # the same shape and ignores them (it addresses jobs by job id). On-prem treats a
-    # sub_job_id as its plain job id, so source/target ids double as its job ids.
+    # ── weight sync + cache ──────────────────────────────────────────────
     def sync_weights(self) -> dict:
-        tid, sid = self.jobs.require("training"), self.jobs.require("sampling")
-        body = {
-            "operation_type": "weight-sync",
-            "sub_job_id": tid,
-            "sub_job_type": "training",
-            "payload": {"source_sub_job_id": tid, "target_sub_job_ids": [sid]},
-        }
-        return self.transport.call(Request("operation", tid, body))
+        return self.transport.call(_sync_weights_request(self.jobs))
 
     def reset_prefix_cache(self, drain: bool = True, timeout_s: float = 60.0, retry_interval_s: float = 0.1) -> dict:
-        sid = self.jobs.require("sampling")
-        body = {
-            "operation_type": "reset-prefix-cache",
-            "sub_job_type": "sampling",
-            "payload": {"drain": drain, "timeout_s": timeout_s, "retry_interval_s": retry_interval_s},
-        }
-        return self.transport.call(Request("operation", sid, body))
+        return self.transport.call(_reset_prefix_cache_request(self.jobs, drain, timeout_s, retry_interval_s))
 
     # ── lifecycle ────────────────────────────────────────────────────────
     def reconnect_config(self) -> ArcticRLClientConfig:
-        """A serializable config that reattaches to these jobs in another process."""
-        return self.config.model_copy(
-            update={
-                "training_job_id": self.jobs.training,
-                "sampling_job_id": self.jobs.sampling,
-                "log_prob_job_id": self.jobs.log_prob,
-            }
-        )
+        return _reconnect_config(self.config, self.jobs)
 
     def shutdown(self) -> None:
         self.transport.shutdown()
@@ -133,6 +190,70 @@ class ArcticRLClient:
         self.shutdown()
 
 
+class AsyncArcticRLClient:
+    def __init__(self, config: ArcticRLClientConfig) -> None:
+        self.config = config
+        self.transport = make_transport(config)
+        self.jobs = self.transport.initialize()
+
+    # ── training ─────────────────────────────────────────────────────────
+    async def fwd_bwd(self, batch: dict, processing: dict | None = None, router_replay: Any = None) -> dict:
+        return await self.transport.acall(_fwd_bwd_request(self.jobs, batch, processing, router_replay))
+
+    async def fwd_no_grad(self, batch: dict) -> dict:
+        return await self.transport.acall(_fwd_no_grad_request(self.jobs, batch))
+
+    async def step(self, learning_rate: float | None = None) -> dict:
+        return await self.transport.acall(_step_request(self.jobs, learning_rate))
+
+    async def save_checkpoint(self, checkpoint_id: str | None = None, checkpoint_type: str = "resumable") -> dict:
+        return await self.transport.acall(_save_checkpoint_request(self.jobs, checkpoint_id, checkpoint_type))
+
+    # ── sampling / log-prob ──────────────────────────────────────────────
+    async def generate(
+        self, prompts: list, sampling_params: dict | None = None, routing_key: Any = None, strict: bool = False
+    ) -> list:
+        return (
+            await self.transport.acall(_generate_request(self.jobs, prompts, sampling_params, routing_key, strict))
+        )["results"]
+
+    async def log_probs(self, prompts: list, completions: list | None = None, top_k: int = 1) -> dict:
+        return await self.transport.acall(_log_probs_request(self.jobs, prompts, completions, top_k))
+
+    # ── weight sync + cache ──────────────────────────────────────────────
+    async def sync_weights(self) -> dict:
+        return await self.transport.acall(_sync_weights_request(self.jobs))
+
+    async def reset_prefix_cache(
+        self, drain: bool = True, timeout_s: float = 60.0, retry_interval_s: float = 0.1
+    ) -> dict:
+        return await self.transport.acall(
+            _reset_prefix_cache_request(self.jobs, drain, timeout_s, retry_interval_s)
+        )
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+    def reconnect_config(self) -> ArcticRLClientConfig:
+        return _reconnect_config(self.config, self.jobs)
+
+    async def shutdown(self) -> None:
+        # HttpTransport's aiohttp session must be closed with await; sync
+        # transport.shutdown() can't do that from a running event loop.
+        aclose = getattr(self.transport, "aclose", None)
+        if aclose is not None:
+            await aclose()
+        self.transport.shutdown()
+
+    async def __aenter__(self) -> AsyncArcticRLClient:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.shutdown()
+
+
 def create_arctic_rl_client(config: ArcticRLClientConfig) -> ArcticRLClient:
     """Factory matching the current OSS entrypoint shape."""
     return ArcticRLClient(config)
+
+
+def create_async_arctic_rl_client(config: ArcticRLClientConfig) -> AsyncArcticRLClient:
+    return AsyncArcticRLClient(config)

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -240,11 +240,9 @@ class ArcticRLClient:
         return _reconnect_config(self.config, self.jobs)
 
     async def shutdown(self) -> None:
-        # HttpTransport's aiohttp session must be closed with await; sync
-        # transport.shutdown() can't do that from a running event loop.
-        aclose = getattr(self.transport, "aclose", None)
-        if aclose is not None:
-            await aclose()
+        # aiohttp's session must be closed with await; the sync shutdown() that
+        # tears down jobs can't do that from inside a running event loop.
+        await self.transport.aclose()
         self.transport.shutdown()
 
     async def __aenter__(self) -> ArcticRLClient:

--- a/arctic_platform/client/client.py
+++ b/arctic_platform/client/client.py
@@ -24,6 +24,8 @@ differ only at `transport.call` vs `transport.acall`.
 from __future__ import annotations
 
 from typing import Any
+from typing import Literal
+from typing import overload
 
 from arctic_platform.client.config import ArcticRLClientConfig
 from arctic_platform.client.transport import JobHandles
@@ -139,7 +141,7 @@ def _reconnect_config(config: ArcticRLClientConfig, jobs: JobHandles) -> ArcticR
     )
 
 
-class ArcticRLClient:
+class SyncArcticRLClient:
     def __init__(self, config: ArcticRLClientConfig) -> None:
         self.config = config
         self.transport = make_transport(config)
@@ -183,14 +185,16 @@ class ArcticRLClient:
     def shutdown(self) -> None:
         self.transport.shutdown()
 
-    def __enter__(self) -> ArcticRLClient:
+    def __enter__(self) -> SyncArcticRLClient:
         return self
 
     def __exit__(self, *exc: object) -> None:
         self.shutdown()
 
 
-class AsyncArcticRLClient:
+class ArcticRLClient:
+    """The async client. Use `SyncArcticRLClient` for blocking calls."""
+
     def __init__(self, config: ArcticRLClientConfig) -> None:
         self.config = config
         self.transport = make_transport(config)
@@ -243,17 +247,25 @@ class AsyncArcticRLClient:
             await aclose()
         self.transport.shutdown()
 
-    async def __aenter__(self) -> AsyncArcticRLClient:
+    async def __aenter__(self) -> ArcticRLClient:
         return self
 
     async def __aexit__(self, *exc: object) -> None:
         await self.shutdown()
 
 
-def create_arctic_rl_client(config: ArcticRLClientConfig) -> ArcticRLClient:
-    """Factory matching the current OSS entrypoint shape."""
-    return ArcticRLClient(config)
+@overload
+def create_arctic_rl_client(
+    config: ArcticRLClientConfig, *, blocking_calls: Literal[False] = ...
+) -> ArcticRLClient: ...
 
 
-def create_async_arctic_rl_client(config: ArcticRLClientConfig) -> AsyncArcticRLClient:
-    return AsyncArcticRLClient(config)
+@overload
+def create_arctic_rl_client(config: ArcticRLClientConfig, *, blocking_calls: Literal[True]) -> SyncArcticRLClient: ...
+
+
+def create_arctic_rl_client(
+    config: ArcticRLClientConfig, *, blocking_calls: bool = False
+) -> ArcticRLClient | SyncArcticRLClient:
+    """Async client by default; pass blocking_calls=True for the sync client."""
+    return SyncArcticRLClient(config) if blocking_calls else ArcticRLClient(config)

--- a/arctic_platform/client/examples/sft_example.py
+++ b/arctic_platform/client/examples/sft_example.py
@@ -39,8 +39,8 @@ ARCTIC = Path(__file__).resolve().parents[3]  # Arctic-Platform/
 sys.path.insert(0, str(ARCTIC))
 sys.path.insert(0, str(ARCTIC / "tests" / "rl"))
 
-from arctic_platform.client import ArcticRLClient  # noqa: E402
 from arctic_platform.client import ArcticRLClientConfig  # noqa: E402
+from arctic_platform.client import SyncArcticRLClient  # noqa: E402
 
 STEPS = 20
 SEED = 42
@@ -165,7 +165,7 @@ def main() -> None:
         config = profile.config(stack)
         batch = profile.batch(_tokens())  # same tokens, backend-specific wire shape
 
-        client = ArcticRLClient(config)
+        client = SyncArcticRLClient(config)
         print(f"training job: {client.jobs.training}")
         try:
             for step in range(STEPS):

--- a/arctic_platform/client/transport.py
+++ b/arctic_platform/client/transport.py
@@ -119,6 +119,9 @@ class Transport(ABC):
     async def acall(self, request: Request) -> dict:
         """Async delivery of one op; return a canonical response dict."""
 
+    async def aclose(self) -> None:
+        """Release async resources (e.g. an aiohttp session); no-op by default."""
+
     @abstractmethod
     def shutdown(self) -> None:
         """Tear down jobs / connections."""

--- a/arctic_platform/client/transport.py
+++ b/arctic_platform/client/transport.py
@@ -116,5 +116,9 @@ class Transport(ABC):
         """Deliver one op to this deployment; return a canonical response dict."""
 
     @abstractmethod
+    async def acall(self, request: Request) -> dict:
+        """Async delivery of one op; return a canonical response dict."""
+
+    @abstractmethod
     def shutdown(self) -> None:
         """Tear down jobs / connections."""

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -12,11 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Blocking HTTP transport (on-prem). Tensor bodies use the shared DSSST1 codec."""
+"""HTTP transport (on-prem). Sync via ``requests``; async via ``aiohttp``. Tensor bodies use DSSST1."""
 
 from __future__ import annotations
 
 import time
+from typing import Any
 
 from arctic_platform import wire
 from arctic_platform.client.config import ArcticRLClientConfig
@@ -31,7 +32,7 @@ _OCTET_OPS = frozenset({"generate"})
 
 
 class HttpTransport(OnPremTransport):
-    """Blocking HTTP over the shared DSSST1 wire. Serves onprem (local/remote)."""
+    """HTTP over the shared DSSST1 wire. Serves onprem (local/remote)."""
 
     def __init__(self, config: ArcticRLClientConfig) -> None:
         super().__init__(config)
@@ -40,6 +41,7 @@ class HttpTransport(OnPremTransport):
         self.base_url = f"http://{config.host}:{config.port}"
         self.timeout = config.request_timeout
         self.session = requests.Session()
+        self._asession = None  # aiohttp.ClientSession, lazy on first acall
         self.proc = None
         if config.launch_local_server:
             self._launch_server()
@@ -49,21 +51,49 @@ class HttpTransport(OnPremTransport):
         resp.raise_for_status()
         return resp.json()["job_id"]
 
-    def call(self, request: Request) -> dict:
-        # Tensor-bearing ops (and generate) send a DSSST1 octet body; rest send JSON.
-        octet = request.binary or request.op in _OCTET_OPS
-        payload = (
-            {"data": wire.dumps(request.body), "headers": {"Content-Type": "application/octet-stream"}}
-            if octet
-            else {"json": request.body}
-        )
+    def _http_args(self, request: Request) -> tuple[str, dict[str, Any]]:
+        """URL + post kwargs shared by ``requests`` and ``aiohttp``."""
+        url = f"{self.base_url}/{request.op}"
         params = {} if request.job_id is None else {"job_id": request.job_id}
-        resp = self.session.post(f"{self.base_url}/{request.op}", params=params, timeout=self.timeout, **payload)
+        if request.binary or request.op in _OCTET_OPS:
+            return url, {
+                "params": params,
+                "data": wire.dumps(request.body),
+                "headers": {"Content-Type": "application/octet-stream"},
+            }
+        return url, {"params": params, "json": request.body}
+
+    def call(self, request: Request) -> dict:
+        url, kwargs = self._http_args(request)
+        resp = self.session.post(url, timeout=self.timeout, **kwargs)
         resp.raise_for_status()
-        # Tensor-bearing responses come back as DSSST1 octet; everything else is JSON.
         if "application/octet-stream" in resp.headers.get("Content-Type", ""):
             return wire.loads(resp.content)
         return resp.json()
+
+    async def _ensure_asession(self):
+        if self._asession is None or self._asession.closed:
+            import aiohttp
+
+            self._asession = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=self.timeout),
+                connector=aiohttp.TCPConnector(limit=0),
+            )
+        return self._asession
+
+    async def acall(self, request: Request) -> dict:
+        session = await self._ensure_asession()
+        url, kwargs = self._http_args(request)
+        async with session.post(url, **kwargs) as resp:
+            resp.raise_for_status()
+            if "application/octet-stream" in resp.headers.get("Content-Type", ""):
+                return wire.loads(await resp.read())
+            return await resp.json()
+
+    async def aclose(self) -> None:
+        if self._asession is not None and not self._asession.closed:
+            await self._asession.close()
+            self._asession = None
 
     def _destroy(self, job_id: JobId, job_type: str) -> None:
         self.session.post(

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -42,6 +43,7 @@ class HttpTransport(OnPremTransport):
         self.timeout = config.request_timeout
         self.session = requests.Session()
         self._asession = None  # aiohttp.ClientSession, lazy on first acall
+        self._asession_loop = None  # the event loop that session is bound to
         self.proc = None
         if config.launch_local_server:
             self._launch_server()
@@ -72,13 +74,18 @@ class HttpTransport(OnPremTransport):
         return resp.json()
 
     async def _ensure_asession(self):
-        if self._asession is None or self._asession.closed:
+        # A ClientSession is bound to the loop it's built on; reuse it only on
+        # that same loop. On a new loop (e.g. a fresh asyncio.run) we abandon the
+        # stale one -- it can't be awaited closed from here -- and rebuild.
+        loop = asyncio.get_running_loop()
+        if self._asession is None or self._asession.closed or self._asession_loop is not loop:
             import aiohttp
 
             self._asession = aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=self.timeout),
                 connector=aiohttp.TCPConnector(limit=0),
             )
+            self._asession_loop = loop
         return self._asession
 
     async def acall(self, request: Request) -> dict:
@@ -91,9 +98,13 @@ class HttpTransport(OnPremTransport):
             return await resp.json()
 
     async def aclose(self) -> None:
-        if self._asession is not None and not self._asession.closed:
-            await self._asession.close()
+        # Only the loop that owns the session can close it; on any other loop
+        # (a stale session from a prior loop) just drop the reference.
+        if self._asession is not None:
+            if not self._asession.closed and self._asession_loop is asyncio.get_running_loop():
+                await self._asession.close()
             self._asession = None
+            self._asession_loop = None
 
     def _destroy(self, job_id: JobId, job_type: str) -> None:
         self.session.post(

--- a/arctic_platform/client/transports/onprem_ray.py
+++ b/arctic_platform/client/transports/onprem_ray.py
@@ -62,11 +62,19 @@ class RayTransport(OnPremTransport):
         self._server = ArcticRLRayServer(self._state)
         self._check_op_coverage(self._server)
 
-    def call(self, request: Request) -> dict:
-        # Pass job_id only when set (ops omitting it call method(body)), then the body.
+    def _resolve(self, request: Request):
         method = getattr(self._server, method_name(request.op))
         args = (request.body,) if request.job_id is None else (request.job_id, request.body)
+        return method, args
+
+    def call(self, request: Request) -> dict:
+        # Pass job_id only when set (ops omitting it call method(body)), then the body.
+        method, args = self._resolve(request)
         return self._loop.run_until_complete(method(*args))
+
+    async def acall(self, request: Request) -> dict:
+        method, args = self._resolve(request)
+        return await method(*args)
 
     def _destroy(self, job_id: JobId, job_type: str) -> None:
         self._loop.run_until_complete(self._server.destroy(job_id, job_type))

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -12,13 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The op surface of ArcticRLClient must lower to one canonical Request each.
+"""The op surface of ArcticRLClient / SyncArcticRLClient must lower to one
+canonical Request each.
 
 A FakeTransport records the Request every op produces so we can assert the
 mapping (target job, body, binary flag) with no live backend or GPUs.
 """
 
 from __future__ import annotations
+
+import asyncio
+import inspect
 
 import pytest
 
@@ -27,6 +31,7 @@ from arctic_platform.client import ArcticRLClient
 from arctic_platform.client import ArcticRLClientConfig
 from arctic_platform.client import JobHandles
 from arctic_platform.client import Request
+from arctic_platform.client import SyncArcticRLClient
 from arctic_platform.client import Transport
 from arctic_platform.client import client as client_module
 from arctic_platform.client import unresolved_ops
@@ -49,25 +54,36 @@ class FakeTransport(Transport):
         self.calls.append(request)
         return {"results": ["ok"], "loss": 0.0}
 
+    async def acall(self, request: Request) -> dict:
+        return self.call(request)
+
     def shutdown(self) -> None:
         pass
 
 
-@pytest.fixture
-def client(monkeypatch) -> ArcticRLClient:
+def _call(client, method: str, *args, **kwargs):
+    """Drive a sync or async client method from a sync test."""
+    result = getattr(client, method)(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return asyncio.run(result)
+    return result
+
+
+@pytest.fixture(params=[ArcticRLClient, SyncArcticRLClient], ids=["async", "sync"])
+def client(monkeypatch, request) -> ArcticRLClient | SyncArcticRLClient:
     monkeypatch.setattr(client_module, "make_transport", FakeTransport)
     cfg = ArcticRLClientConfig(model_name="m", training_gpus=1, sampling_gpus=1, log_prob_gpus=1)
-    return ArcticRLClient(cfg)
+    return request.param(cfg)
 
 
-def _last(client: ArcticRLClient) -> Request:
+def _last(client: ArcticRLClient | SyncArcticRLClient) -> Request:
     return client.transport.calls[-1]
 
 
 class TestOpMapping:
     def test_fwd_bwd_targets_training_binary(self, client):
         """fwd_bwd -> training job, binary payload, body carries the batch."""
-        client.fwd_bwd({"input_ids": [1, 2]})
+        _call(client, "fwd_bwd", {"input_ids": [1, 2]})
         req = _last(client)
         assert req.op == "forward-backward"
         assert req.job_id == TRAINING
@@ -76,14 +92,14 @@ class TestOpMapping:
 
     def test_fwd_bwd_folds_processing_and_router_replay(self, client):
         """Non-None processing/router_replay are folded into the body."""
-        client.fwd_bwd({"input_ids": [1]}, processing={"p": 1}, router_replay={"r": 2})
+        _call(client, "fwd_bwd", {"input_ids": [1]}, processing={"p": 1}, router_replay={"r": 2})
         body = _last(client).body
         assert body["processing"] == {"p": 1}
         assert body["router_replay"] == {"r": 2}
 
     def test_fwd_no_grad_targets_training_binary(self, client):
         """fwd_no_grad -> training job, binary payload."""
-        client.fwd_no_grad({"input_ids": [1]})
+        _call(client, "fwd_no_grad", {"input_ids": [1]})
         req = _last(client)
         assert req.op == "forward"
         assert req.job_id == TRAINING
@@ -91,7 +107,7 @@ class TestOpMapping:
 
     def test_step_targets_training(self, client):
         """step -> training job, learning_rate in body."""
-        client.step(learning_rate=0.5)
+        _call(client, "step", learning_rate=0.5)
         req = _last(client)
         assert req.op == "step"
         assert req.job_id == TRAINING
@@ -100,7 +116,7 @@ class TestOpMapping:
 
     def test_save_checkpoint_targets_training(self, client):
         """save_checkpoint -> training job (save op, Cortex-shaped body)."""
-        client.save_checkpoint(checkpoint_id="cp1", checkpoint_type="weights-only")
+        _call(client, "save_checkpoint", checkpoint_id="cp1", checkpoint_type="weights-only")
         req = _last(client)
         assert req.op == "save"
         assert req.job_id == TRAINING
@@ -108,7 +124,7 @@ class TestOpMapping:
 
     def test_generate_targets_sampling_and_unwraps_results(self, client):
         """generate -> sampling job; returns the 'results' list."""
-        out = client.generate(["hi"], sampling_params={"n": 1}, routing_key="k", strict=True)
+        out = _call(client, "generate", ["hi"], sampling_params={"n": 1}, routing_key="k", strict=True)
         req = _last(client)
         assert req.op == "generate"
         assert req.job_id == SAMPLING
@@ -117,7 +133,7 @@ class TestOpMapping:
 
     def test_log_probs_targets_log_prob(self, client):
         """log_probs -> log_prob job."""
-        client.log_probs(["hi"], completions=["there"], top_k=3)
+        _call(client, "log_probs", ["hi"], completions=["there"], top_k=3)
         req = _last(client)
         assert req.op == "log-probs"
         assert req.job_id == LOG_PROB
@@ -125,7 +141,7 @@ class TestOpMapping:
 
     def test_reset_prefix_cache_targets_sampling(self, client):
         """reset_prefix_cache -> sampling job via the operation envelope."""
-        client.reset_prefix_cache(drain=False, timeout_s=5.0, retry_interval_s=0.2)
+        _call(client, "reset_prefix_cache", drain=False, timeout_s=5.0, retry_interval_s=0.2)
         req = _last(client)
         assert req.op == "operation"
         assert req.job_id == SAMPLING
@@ -137,7 +153,7 @@ class TestOpMapping:
 
     def test_sync_weights_targets_training_with_sub_job_ids(self, client):
         """sync_weights -> training job; weight-sync operation with source/target payload."""
-        client.sync_weights()
+        _call(client, "sync_weights")
         req = _last(client)
         assert req.op == "operation"
         assert req.job_id == TRAINING
@@ -169,14 +185,14 @@ class TestOpRegistry:
 
     def test_client_emits_exactly_the_registered_ops(self, client):
         """Driving every client op must produce exactly the canonical OPS set."""
-        client.fwd_bwd({"input_ids": [1]})
-        client.fwd_no_grad({"input_ids": [1]})
-        client.step()
-        client.save_checkpoint()
-        client.generate(["hi"])
-        client.log_probs(["hi"])
-        client.sync_weights()
-        client.reset_prefix_cache()
+        _call(client, "fwd_bwd", {"input_ids": [1]})
+        _call(client, "fwd_no_grad", {"input_ids": [1]})
+        _call(client, "step")
+        _call(client, "save_checkpoint")
+        _call(client, "generate", ["hi"])
+        _call(client, "log_probs", ["hi"])
+        _call(client, "sync_weights")
+        _call(client, "reset_prefix_cache")
         assert {req.op for req in client.transport.calls} == OPS
 
     def test_unresolved_ops_flags_a_missing_method(self):


### PR DESCRIPTION
- Add an async-first `ArcticRLClient` alongside `SyncArcticRLClient`, sharing Request builders so op logic is defined once
- Make `Transport.acall` abstract: HTTP via `aiohttp` (shared session), Ray via native await
- `create_arctic_rl_client(..., blocking_calls=...)` selects sync vs async with typed overloads
  - Extend tests to cover both clients