### PR TITLE
RFC: TRL backend for Arctic RL

### DIFF
--- a/arctic_platform/integrations/trl/README.md
+++ b/arctic_platform/integrations/trl/README.md
@@ -5,33 +5,36 @@ layout helpers in `client.py` are stubs and nothing here has run against a live 
 
 ## The interface
 
-TRL's `TrainingClientProtocol` is two methods:
+TRL's `TrainingClientProtocol` is a single fused call:
 
 ```python
-forward_no_grad(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
-forward_backward(grad_log_probs) -> None
+forward_backward(model, input_ids, position_ids, completion_mask, loss_fn, aux_loss_coef) -> ForwardBackwardOutput
 ```
 
-They map one to one onto `fwd_no_grad` and `fwd_bwd`. The server forwards the batch twice, once to score it
-and once to backpropagate, because the graph from the first pass cannot cross the wire.
+`loss_fn` is a Python callable mapping per-token log probs to a scalar. It closes over the advantages, old log
+probs, mask and clipping bounds, so nothing algorithm-shaped reaches this repo.
 
-The trainer computes its loss on the log probs returned by the first call and hands back
-`d(loss)/d(log_probs)`.
-The server backpropagates `sum(w * logprobs)`, a first-order surrogate whose gradient with respect to every
-parameter equals the gradient of the real loss. The loss itself never crosses the wire.
+The adapter runs in the trainer's process even though the model does not, so `loss_fn` is evaluated here, on
+the tensors the server returned. Only tensors cross the wire. The adapter takes `d(loss)/d(log_probs)` locally
+and ships that, and the server backpropagates `sum(w * logprobs)`, a first-order surrogate whose gradient with
+respect to every parameter equals the gradient of the real loss.
 
-Verified bit-exact against the in-process path on TRL's GRPO loss: zero difference across all 27 parameter
-tensors, for both the co-located variant and the two-forward variant a remote backend would use.
+Verified bit-exact against the in-process path on TRL's GRPO loss: zero difference across every parameter
+tensor, for both the co-located variant and the two-forward variant a remote backend would use.
 
-## Why not a fused `forward_backward(..., "grpo_loss")`
+## On the fused call and the extra forward
 
-That was the suggestion on the PR thread, and `forward_backward` here does issue the fused `fwd_bwd`. The split is in
-TRL's interface, not in what the backend does. Two round trips are inherent either way, because the weights
-are a function of the log probs and cannot be known before the first forward. Tinker's
-`forward` + `forward_backward_custom` has the same shape.
+Folding the forward and backward into one call was the request on the PR thread, and this is that call. Naming
+the *loss* in it is the part worth avoiding, and passing a callable instead of a string key gets the fused
+shape without it.
 
-The part worth avoiding is naming the *loss* across the wire. The cost of that is already measurable in this
-repo:
+On cost: a co-located deployment runs one forward, calls `loss_fn` in-process, and returns a loss still
+attached to the graph, so there is no surrogate and no second pass at all. A remote deployment issues
+`fwd_no_grad` then `fwd_bwd`, which is two forwards unless the server retains the graph between them. That
+choice is server-side and invisible to TRL: the extra forward buys not having to pin activations across a
+round trip.
+
+The cost of the alternative, naming the loss across the wire, is already measurable in this repo:
 
 | | loss lives on | consequence |
 |---|---|---|
@@ -70,8 +73,8 @@ Nothing. `training_client=` already exists on `AsyncGRPOTrainer` alongside the `
    `self.model.named_parameters()` on every rank (`async_grpo_trainer.py:1149`). Meta device crashes there
    and an empty CUDA model wastes full model memory. A stub module carrying names and shapes is the likely
    answer. TRL-side work.
-2. **Microbatch scaling.** TRL scales its loss for gradient accumulation before the gradient reaches
-   `forward_backward`, so the weights arrive pre-scaled. If `run_pipeline` applies its own per-microbatch
+2. **Microbatch scaling.** The adapter folds the trainer's gradient-accumulation scaling into the weights
+   before sending them, so they arrive pre-scaled. If `run_pipeline` applies its own per-microbatch
    normalization on top, one of the two has to be disabled.
 3. **Batch layout.** The padding-free row to padded rows conversion is stubbed out. Mechanical, but it is
    where a first integration spends its time.

--- a/arctic_platform/integrations/trl/README.md
+++ b/arctic_platform/integrations/trl/README.md
@@ -1,0 +1,76 @@
+# Arctic RL backend for TRL
+
+Draft, for discussion on [huggingface/trl#6676](https://github.com/huggingface/trl/pull/6676). The batch
+layout helpers in `client.py` are stubs and nothing here has run against a live server.
+
+## The interface
+
+TRL's `TrainingClientProtocol` is two methods:
+
+```python
+forward(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
+backward(grad_log_probs) -> None
+```
+
+The trainer computes its loss on the log probs returned by `forward` and hands back `d(loss)/d(log_probs)`.
+The server backpropagates `sum(w * logprobs)`, a first-order surrogate whose gradient with respect to every
+parameter equals the gradient of the real loss. The loss itself never crosses the wire.
+
+Verified bit-exact against the in-process path on TRL's GRPO loss: zero difference across all 27 parameter
+tensors, for both the co-located variant and the two-forward variant a remote backend would use.
+
+## Why not a fused `forward_backward(..., "grpo_loss")`
+
+That was the suggestion on the PR thread, and `backward` here does issue the fused `fwd_bwd`. The split is in
+TRL's interface, not in what the backend does. Two round trips are inherent either way, because the weights
+are a function of the log probs and cannot be known before the first forward. Tinker's
+`forward` + `forward_backward_custom` has the same shape.
+
+The part worth avoiding is naming the *loss* across the wire. The cost of that is already measurable in this
+repo:
+
+| | loss lives on | consequence |
+|---|---|---|
+| `integrations/verl/grpo_loss.py` | server | 523 lines reimplementing verl's `masked_mean`, `agg_loss`, `compute_policy_loss_vanilla`, `kl_penalty` on this side, supporting `loss_mode="vanilla"` only, out of the 12 entries in verl's `POLICY_LOSS_REGISTRY` |
+| `integrations/trl/loss.py` | client | 1 function, ~6 lines, covers every TRL loss including ones not written yet |
+
+TRL has 8 `loss_type` values today and adds them regularly. Mirroring a registry means an Arctic PR per
+variant, per framework.
+
+This is also the position ArcticTraining already takes in-process: `Trainer.loss` is an abstract method that
+users implement in Python. Same idea, across a process boundary.
+
+## Server-side addition
+
+One loss function, registered as `weighted_logprob_sum`. It is loss-agnostic and never needs revisiting.
+
+`pipeline._resolve_fn` falls back to a dotted-path import for names not in `LOSS_FNS`, so
+`loss_fn="arctic_platform.integrations.trl.loss.weighted_logprob_sum"` resolves without the registry entry
+when the module is importable in the server process. Two questions for the Arctic side:
+
+1. Is that fallback a supported extension point or an implementation detail?
+2. For managed deployments, would a generic registry entry be acceptable? Weighted cross-entropy is the same
+   thing: server CE is `sum(-logprobs * weights)`, so `weights = -d(loss)/d(logprobs)` gives the surrogate.
+   Tinker maps its custom-loss path onto plain `cross_entropy` and adds no loss at all.
+
+## What TRL changes
+
+Nothing. `training_client=` already exists on `AsyncGRPOTrainer` alongside the `rollout_worker` and
+`weight_transfer` hooks, and `transformers.Trainer` already accepts `optimizers=`, which is why there is no
+`optim_step` or `clip_grad_norm` in the protocol.
+
+## Open items
+
+1. **No local model.** The real blocker. Arctic owns the weights, but transformers and accelerate still want
+   a local module to `prepare()`, and `AsyncGRPOTrainer._sync_weight` streams from
+   `self.model.named_parameters()` on every rank (`async_grpo_trainer.py:1149`). Meta device crashes there
+   and an empty CUDA model wastes full model memory. A stub module carrying names and shapes is the likely
+   answer. TRL-side work.
+2. **Microbatch scaling.** TRL scales its loss for gradient accumulation before the gradient reaches
+   `backward`, so the weights arrive pre-scaled. If `run_pipeline` applies its own per-microbatch
+   normalization on top, one of the two has to be disabled.
+3. **Batch layout.** The padding-free row to padded rows conversion is stubbed out. Mechanical, but it is
+   where a first integration spends its time.
+4. **Weight sync.** `WeightTransferProtocol` is already pluggable on the TRL side and Arctic has
+   `save_weights_for_sampler`. Open question is whether that path exists for managed deployments or only
+   self-hosted.

--- a/arctic_platform/integrations/trl/README.md
+++ b/arctic_platform/integrations/trl/README.md
@@ -8,11 +8,15 @@ layout helpers in `client.py` are stubs and nothing here has run against a live 
 TRL's `TrainingClientProtocol` is two methods:
 
 ```python
-forward(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
-backward(grad_log_probs) -> None
+forward_no_grad(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
+forward_backward(grad_log_probs) -> None
 ```
 
-The trainer computes its loss on the log probs returned by `forward` and hands back `d(loss)/d(log_probs)`.
+They map one to one onto `fwd_no_grad` and `fwd_bwd`. The server forwards the batch twice, once to score it
+and once to backpropagate, because the graph from the first pass cannot cross the wire.
+
+The trainer computes its loss on the log probs returned by the first call and hands back
+`d(loss)/d(log_probs)`.
 The server backpropagates `sum(w * logprobs)`, a first-order surrogate whose gradient with respect to every
 parameter equals the gradient of the real loss. The loss itself never crosses the wire.
 
@@ -21,7 +25,7 @@ tensors, for both the co-located variant and the two-forward variant a remote ba
 
 ## Why not a fused `forward_backward(..., "grpo_loss")`
 
-That was the suggestion on the PR thread, and `backward` here does issue the fused `fwd_bwd`. The split is in
+That was the suggestion on the PR thread, and `forward_backward` here does issue the fused `fwd_bwd`. The split is in
 TRL's interface, not in what the backend does. Two round trips are inherent either way, because the weights
 are a function of the log probs and cannot be known before the first forward. Tinker's
 `forward` + `forward_backward_custom` has the same shape.
@@ -67,7 +71,7 @@ Nothing. `training_client=` already exists on `AsyncGRPOTrainer` alongside the `
    and an empty CUDA model wastes full model memory. A stub module carrying names and shapes is the likely
    answer. TRL-side work.
 2. **Microbatch scaling.** TRL scales its loss for gradient accumulation before the gradient reaches
-   `backward`, so the weights arrive pre-scaled. If `run_pipeline` applies its own per-microbatch
+   `forward_backward`, so the weights arrive pre-scaled. If `run_pipeline` applies its own per-microbatch
    normalization on top, one of the two has to be disabled.
 3. **Batch layout.** The padding-free row to padded rows conversion is stubbed out. Mechanical, but it is
    where a first integration spends its time.

--- a/arctic_platform/integrations/trl/__init__.py
+++ b/arctic_platform/integrations/trl/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Arctic RL backend for TRL.
+
+Unlike the verl integration there is no plugin entry point and no registry to hook. TRL takes the backend as
+a constructor argument::
+
+    from arctic_platform.client.client import SyncArcticRLClient
+    from arctic_platform.integrations.trl import ArcticOptimizer
+    from arctic_platform.integrations.trl import ArcticTrainingClient
+
+    client = SyncArcticRLClient(config)
+    trainer = AsyncGRPOTrainer(
+        model=model,
+        ...,
+        training_client=ArcticTrainingClient(client),
+        optimizers=(ArcticOptimizer(client, model.parameters()), scheduler),
+    )
+
+Importing this package registers ``weighted_logprob_sum`` in ``LOSS_FNS``, which is the only server-side
+addition the integration needs.
+
+See ``README.md`` for the design rationale and the open items.
+"""
+
+from arctic_platform.integrations.trl.client import ArcticOptimizer
+from arctic_platform.integrations.trl.client import ArcticTrainingClient
+from arctic_platform.integrations.trl.loss import weighted_logprob_sum
+
+__all__ = ["ArcticOptimizer", "ArcticTrainingClient", "weighted_logprob_sum"]

--- a/arctic_platform/integrations/trl/client.py
+++ b/arctic_platform/integrations/trl/client.py
@@ -1,0 +1,161 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Arctic Platform backend for TRL's ``TrainingClientProtocol``.
+
+TRL's protocol (``trl/experimental/api/training_client.py``) is two methods::
+
+    forward(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
+    backward(grad_log_probs) -> None
+
+The trainer computes its loss between the two calls and hands back ``d(loss)/d(log_probs)``. Everything
+algorithm-shaped stays on the TRL side, so this file has no notion of GRPO, advantages, or clipping ratios,
+and it does not grow when TRL adds a loss variant.
+
+The split into two methods is a split in TRL's interface, not a requirement on the backend: ``backward`` below
+issues the fused ``fwd_bwd`` call. Two round trips are inherent regardless, since the weights are a function of
+the log probs and cannot be known before the first forward.
+"""
+
+from typing import Any
+
+import torch
+from trl.experimental.api import ForwardOutput
+
+
+class ArcticTrainingClient:
+    """Runs the forward and the backward on an Arctic RL server while TRL keeps the loss.
+
+    Configuration lives on this object rather than in TRL's config: the trainer takes the client as a
+    constructed instance, so endpoint, temperature and loss name never become TRL config fields.
+
+    Args:
+        client: A :class:`~arctic_platform.client.client.SyncArcticRLClient`.
+        temperature: Sampling temperature applied by the ``apply_temperature`` post-processor.
+        loss_fn: Name of the surrogate loss. ``pipeline._resolve_fn`` falls back to a dotted-path import, so
+            ``"arctic_platform.integrations.trl.loss.weighted_logprob_sum"`` also resolves when the registry
+            entry is not present.
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        temperature: float = 1.0,
+        loss_fn: str = "weighted_logprob_sum",
+    ) -> None:
+        self.client = client
+        self.temperature = temperature
+        self.loss_fn = loss_fn
+        self._batch: dict | None = None
+
+    def forward(
+        self,
+        model: torch.nn.Module,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        completion_mask: torch.Tensor,
+        aux_loss_coef: float = 0.0,
+    ) -> ForwardOutput:
+        # `model` is the trainer's local module. Arctic owns the weights, so it is unused here.
+        #
+        # AsyncGRPOTrainer packs a rank's samples into one padding-free row and marks sequence boundaries by
+        # position_ids resets. The server wants padded [B, S] rows, so unpack first. This conversion is the
+        # bulk of the adapter and is the main reason it belongs on this side of the wire.
+        batch = _unpack_to_padded_rows(input_ids, position_ids, completion_mask)
+        self._batch = batch
+
+        response = self.client.fwd_no_grad(
+            batch,
+            processing={
+                "post": ["apply_temperature", "compute_entropy_and_logprobs"],
+                "loss_fn": None,
+            },
+        )
+        out = response["batch"]
+
+        # Hand back a leaf tensor: the trainer's `loss.backward()` stops here and deposits
+        # d(loss)/d(log_probs) into `.grad`, which is what arrives at `backward` below.
+        #
+        # The server returns log probs under the roll(-1) convention and TRL expects the [:, 1:] shift, so
+        # the repack aligns them rather than merely reshaping.
+        return ForwardOutput(
+            log_probs=_repack_to_row(out["logprobs"], completion_mask).requires_grad_(True),
+            entropy=_repack_to_row(out["entropy"], completion_mask),
+            aux_loss=None,  # Arctic reports the MoE aux loss as a metric, not as a differentiable tensor
+        )
+
+    def backward(self, grad_log_probs: torch.Tensor) -> None:
+        assert self._batch is not None, "backward() called without a preceding forward()"
+
+        batch = dict(self._batch)
+        # `_shifted` marks the roll(-1) convention, matching the other log-prob tensors in the batch.
+        batch["logprob_weights_shifted"] = _unpack_to_padded(grad_log_probs)
+
+        self.client.fwd_bwd(
+            batch,
+            processing={
+                "post": ["apply_temperature"],
+                "loss_fn": self.loss_fn,
+            },
+        )
+        self._batch = None
+
+
+class ArcticOptimizer(torch.optim.Optimizer):
+    """Drives ``client.step()``. Passed to the trainer as ``optimizers=(ArcticOptimizer(...), scheduler)``.
+
+    TRL needs nothing for this. ``transformers.Trainer`` already accepts a user-supplied optimizer and calls
+    ``.step()`` on it, so the optimizer leg needs no protocol of its own and gradient clipping stays inside
+    ``step()`` where Arctic already does it.
+    """
+
+    def __init__(self, client: Any, params: Any) -> None:
+        super().__init__(params, {})
+        self.client = client
+        self.last_grad_norm: float | None = None
+
+    def step(self, closure: Any = None) -> None:  # type: ignore[override]
+        metrics = self.client.step().get("metrics", {})
+        norm = metrics.get("grad_norm")
+        # grad_norm comes back per DP rank as a flat list. Under ZeRO-3 the value is already globally
+        # reduced, so the first entry is the value.
+        self.last_grad_norm = norm[0] if isinstance(norm, list) else norm
+
+    def zero_grad(self, set_to_none: bool = True) -> None:  # type: ignore[override]
+        pass  # gradients live on the server and are cleared by step()
+
+
+# ------------------------------------------------------------------------------------------------------- #
+# Batch layout helpers
+# ------------------------------------------------------------------------------------------------------- #
+# Stubs. Padding-free row to padded rows and back is mechanical but fiddly, and is where a first integration
+# would actually spend its time. Note what is absent compared with `integrations/verl/adapter.py`: no
+# `old_log_probs`, no `advantages`, no `ref_log_prob`. TRL consumed those before the gradient was formed.
+
+
+def _unpack_to_padded_rows(
+    input_ids: torch.Tensor,
+    position_ids: torch.Tensor,
+    completion_mask: torch.Tensor,
+) -> dict:
+    raise NotImplementedError
+
+
+def _unpack_to_padded(tensor: torch.Tensor) -> torch.Tensor:
+    raise NotImplementedError
+
+
+def _repack_to_row(tensor: torch.Tensor, completion_mask: torch.Tensor) -> torch.Tensor:
+    raise NotImplementedError

--- a/arctic_platform/integrations/trl/client.py
+++ b/arctic_platform/integrations/trl/client.py
@@ -17,16 +17,21 @@
 
 TRL's protocol (``trl/experimental/api/training_client.py``) is two methods::
 
-    forward(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
-    backward(grad_log_probs) -> None
+    forward_no_grad(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
+    forward_backward(grad_log_probs) -> None
 
 The trainer computes its loss between the two calls and hands back ``d(loss)/d(log_probs)``. Everything
 algorithm-shaped stays on the TRL side, so this file has no notion of GRPO, advantages, or clipping ratios,
 and it does not grow when TRL adds a loss variant.
 
-The split into two methods is a split in TRL's interface, not a requirement on the backend: ``backward`` below
-issues the fused ``fwd_bwd`` call. Two round trips are inherent regardless, since the weights are a function of
-the log probs and cannot be known before the first forward.
+The names map one to one onto this wire: ``forward_no_grad`` is ``fwd_no_grad`` and ``forward_backward`` is
+``fwd_bwd``. The server therefore forwards the batch twice, once to score it and once to backpropagate, because
+the graph from the first pass cannot cross the wire. The second pass is what makes the gradient real despite
+the first being no-grad.
+
+Two round trips are inherent rather than a choice about where to put the split: the weights are a function of
+the log probs, so they cannot be known before the first forward. Tinker's ``forward`` plus
+``forward_backward_custom`` has the same shape.
 """
 
 from typing import Any
@@ -60,7 +65,7 @@ class ArcticTrainingClient:
         self.loss_fn = loss_fn
         self._batch: dict | None = None
 
-    def forward(
+    def forward_no_grad(
         self,
         model: torch.nn.Module,
         input_ids: torch.Tensor,
@@ -68,6 +73,7 @@ class ArcticTrainingClient:
         completion_mask: torch.Tensor,
         aux_loss_coef: float = 0.0,
     ) -> ForwardOutput:
+        """Score the batch. No graph is built here, and none is needed: see `forward_backward` below."""
         # `model` is the trainer's local module. Arctic owns the weights, so it is unused here.
         #
         # AsyncGRPOTrainer packs a rank's samples into one padding-free row and marks sequence boundaries by
@@ -76,6 +82,8 @@ class ArcticTrainingClient:
         batch = _unpack_to_padded_rows(input_ids, position_ids, completion_mask)
         self._batch = batch
 
+        # No grad, so nothing on the server survives this call. The batch is kept above because
+        # `forward_backward` has to send it again to rebuild the graph.
         response = self.client.fwd_no_grad(
             batch,
             processing={
@@ -86,7 +94,8 @@ class ArcticTrainingClient:
         out = response["batch"]
 
         # Hand back a leaf tensor: the trainer's `loss.backward()` stops here and deposits
-        # d(loss)/d(log_probs) into `.grad`, which is what arrives at `backward` below.
+        # d(loss)/d(log_probs) into `.grad`, which is what arrives at `forward_backward` below. The tensor is
+        # differentiable on the TRL side even though the call above built no graph on the server.
         #
         # The server returns log probs under the roll(-1) convention and TRL expects the [:, 1:] shift, so
         # the repack aligns them rather than merely reshaping.
@@ -96,8 +105,13 @@ class ArcticTrainingClient:
             aux_loss=None,  # Arctic reports the MoE aux loss as a metric, not as a differentiable tensor
         )
 
-    def backward(self, grad_log_probs: torch.Tensor) -> None:
-        assert self._batch is not None, "backward() called without a preceding forward()"
+    def forward_backward(self, grad_log_probs: torch.Tensor) -> None:
+        """Forward the batch again, this time with a graph, and backpropagate the surrogate through it.
+
+        This is the second of the two forwards. `fwd_bwd` runs the model, applies `weighted_logprob_sum`, and
+        backpropagates it, so the gradient is built here rather than carried over from the scoring pass.
+        """
+        assert self._batch is not None, "forward_backward() called without a preceding forward_no_grad()"
 
         batch = dict(self._batch)
         # `_shifted` marks the roll(-1) convention, matching the other log-prob tensors in the batch.

--- a/arctic_platform/integrations/trl/client.py
+++ b/arctic_platform/integrations/trl/client.py
@@ -15,33 +15,32 @@
 
 """Arctic Platform backend for TRL's ``TrainingClientProtocol``.
 
-TRL's protocol (``trl/experimental/api/training_client.py``) is two methods::
+TRL's protocol is a single fused call::
 
-    forward_no_grad(model, input_ids, position_ids, completion_mask, aux_loss_coef) -> ForwardOutput
-    forward_backward(grad_log_probs) -> None
+    forward_backward(model, input_ids, position_ids, completion_mask, loss_fn, aux_loss_coef) -> ForwardBackwardOutput
 
-The trainer computes its loss between the two calls and hands back ``d(loss)/d(log_probs)``. Everything
-algorithm-shaped stays on the TRL side, so this file has no notion of GRPO, advantages, or clipping ratios,
-and it does not grow when TRL adds a loss variant.
+``loss_fn`` is a Python callable mapping per-token log probs to a scalar. It closes over everything
+algorithm-shaped (advantages, old log probs, the mask, clipping bounds), so nothing algorithm-shaped reaches
+this file and nothing here changes when TRL adds a loss variant.
 
-The names map one to one onto this wire: ``forward_no_grad`` is ``fwd_no_grad`` and ``forward_backward`` is
-``fwd_bwd``. The server therefore forwards the batch twice, once to score it and once to backpropagate, because
-the graph from the first pass cannot cross the wire. The second pass is what makes the gradient real despite
-the first being no-grad.
+The adapter runs in the trainer's process even though the model does not, so ``loss_fn`` is called here, on
+tensors the server returned. Only tensors cross the wire. That is what lets a TRL user write a new objective
+as a plain Python function and run it against Arctic on day one, with no change on this side.
 
-Two round trips are inherent rather than a choice about where to put the split: the weights are a function of
-the log probs, so they cannot be known before the first forward. Tinker's ``forward`` plus
-``forward_backward_custom`` has the same shape.
+Two wire calls, ``fwd_no_grad`` then ``fwd_bwd``, because the per-token weights are a function of the log
+probs and cannot be known before the first pass. Whether that costs a second forward is a server-side choice:
+retaining the graph between the two calls trades the extra forward for activation memory held across one round
+trip. A co-located deployment pays neither, since the graph never leaves the process.
 """
 
 from typing import Any
 
 import torch
-from trl.experimental.api import ForwardOutput
+from trl.experimental.api import ForwardBackwardOutput
 
 
 class ArcticTrainingClient:
-    """Runs the forward and the backward on an Arctic RL server while TRL keeps the loss.
+    """Runs the model on an Arctic RL server while TRL keeps the loss.
 
     Configuration lives on this object rather than in TRL's config: the trainer takes the client as a
     constructed instance, so endpoint, temperature and loss name never become TRL config fields.
@@ -49,9 +48,10 @@ class ArcticTrainingClient:
     Args:
         client: A :class:`~arctic_platform.client.client.SyncArcticRLClient`.
         temperature: Sampling temperature applied by the ``apply_temperature`` post-processor.
-        loss_fn: Name of the surrogate loss. ``pipeline._resolve_fn`` falls back to a dotted-path import, so
-            ``"arctic_platform.integrations.trl.loss.weighted_logprob_sum"`` also resolves when the registry
-            entry is not present.
+        loss_fn: Name of the server-side surrogate. ``pipeline._resolve_fn`` falls back to a dotted-path
+            import, so ``"arctic_platform.integrations.trl.loss.weighted_logprob_sum"`` also resolves when the
+            registry entry is not present. Unrelated to TRL's ``loss_fn`` argument, which is a callable and
+            never leaves this process.
     """
 
     def __init__(
@@ -63,27 +63,23 @@ class ArcticTrainingClient:
         self.client = client
         self.temperature = temperature
         self.loss_fn = loss_fn
-        self._batch: dict | None = None
 
-    def forward_no_grad(
+    def forward_backward(
         self,
         model: torch.nn.Module,
         input_ids: torch.Tensor,
         position_ids: torch.Tensor,
         completion_mask: torch.Tensor,
+        loss_fn: Any,
         aux_loss_coef: float = 0.0,
-    ) -> ForwardOutput:
-        """Score the batch. No graph is built here, and none is needed: see `forward_backward` below."""
+    ) -> ForwardBackwardOutput:
         # `model` is the trainer's local module. Arctic owns the weights, so it is unused here.
         #
         # AsyncGRPOTrainer packs a rank's samples into one padding-free row and marks sequence boundaries by
         # position_ids resets. The server wants padded [B, S] rows, so unpack first. This conversion is the
         # bulk of the adapter and is the main reason it belongs on this side of the wire.
         batch = _unpack_to_padded_rows(input_ids, position_ids, completion_mask)
-        self._batch = batch
 
-        # No grad, so nothing on the server survives this call. The batch is kept above because
-        # `forward_backward` has to send it again to rebuild the graph.
         response = self.client.fwd_no_grad(
             batch,
             processing={
@@ -93,38 +89,39 @@ class ArcticTrainingClient:
         )
         out = response["batch"]
 
-        # Hand back a leaf tensor: the trainer's `loss.backward()` stops here and deposits
-        # d(loss)/d(log_probs) into `.grad`, which is what arrives at `forward_backward` below. The tensor is
-        # differentiable on the TRL side even though the call above built no graph on the server.
-        #
-        # The server returns log probs under the roll(-1) convention and TRL expects the [:, 1:] shift, so
-        # the repack aligns them rather than merely reshaping.
-        return ForwardOutput(
-            log_probs=_repack_to_row(out["logprobs"], completion_mask).requires_grad_(True),
-            entropy=_repack_to_row(out["entropy"], completion_mask),
+        # The server returns log probs under the roll(-1) convention and TRL expects the [:, 1:] shift, so the
+        # repack aligns them rather than merely reshaping.
+        log_probs = _repack_to_row(out["logprobs"], completion_mask)
+        entropy = _repack_to_row(out["entropy"], completion_mask)
+
+        # Evaluate the trainer's loss here, locally, on a leaf. This is the whole trick: the loss is a Python
+        # callable in this process, so it never has to exist on the server or be named on the wire.
+        leaf = log_probs.detach().requires_grad_(True)
+        loss = loss_fn(leaf)
+        (grad_log_probs,) = torch.autograd.grad(loss, leaf)
+
+        def send_backward(grad_loss: torch.Tensor) -> None:
+            # Fires from the trainer's `accelerator.backward`. `grad_loss` carries whatever scaling that
+            # backward applies, so folding it in here keeps gradient accumulation correct.
+            weights = _unpack_to_padded(grad_log_probs * grad_loss)
+            payload = dict(batch)
+            # `_shifted` marks the roll(-1) convention, matching the other log-prob tensors in the batch.
+            payload["logprob_weights_shifted"] = weights
+            self.client.fwd_bwd(
+                payload,
+                processing={"post": ["apply_temperature"], "loss_fn": self.loss_fn},
+            )
+
+        # Detached, because nothing on this side is connected to the model. The hook is what reaches it.
+        reported_loss = loss.detach().requires_grad_(True)
+        reported_loss.register_hook(send_backward)
+
+        return ForwardBackwardOutput(
+            loss=reported_loss,
+            log_probs=log_probs.detach(),
+            entropy=entropy,
             aux_loss=None,  # Arctic reports the MoE aux loss as a metric, not as a differentiable tensor
         )
-
-    def forward_backward(self, grad_log_probs: torch.Tensor) -> None:
-        """Forward the batch again, this time with a graph, and backpropagate the surrogate through it.
-
-        This is the second of the two forwards. `fwd_bwd` runs the model, applies `weighted_logprob_sum`, and
-        backpropagates it, so the gradient is built here rather than carried over from the scoring pass.
-        """
-        assert self._batch is not None, "forward_backward() called without a preceding forward_no_grad()"
-
-        batch = dict(self._batch)
-        # `_shifted` marks the roll(-1) convention, matching the other log-prob tensors in the batch.
-        batch["logprob_weights_shifted"] = _unpack_to_padded(grad_log_probs)
-
-        self.client.fwd_bwd(
-            batch,
-            processing={
-                "post": ["apply_temperature"],
-                "loss_fn": self.loss_fn,
-            },
-        )
-        self._batch = None
 
 
 class ArcticOptimizer(torch.optim.Optimizer):
@@ -156,7 +153,8 @@ class ArcticOptimizer(torch.optim.Optimizer):
 # ------------------------------------------------------------------------------------------------------- #
 # Stubs. Padding-free row to padded rows and back is mechanical but fiddly, and is where a first integration
 # would actually spend its time. Note what is absent compared with `integrations/verl/adapter.py`: no
-# `old_log_probs`, no `advantages`, no `ref_log_prob`. TRL consumed those before the gradient was formed.
+# `old_log_probs`, no `advantages`, no `ref_log_prob`. TRL's `loss_fn` consumed those before the gradient was
+# formed, so they never reach the wire.
 
 
 def _unpack_to_padded_rows(

--- a/arctic_platform/integrations/trl/loss.py
+++ b/arctic_platform/integrations/trl/loss.py
@@ -1,0 +1,64 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The single loss function the TRL integration needs.
+
+TRL computes its own loss on the client and sends back ``d(loss)/d(logprobs)``. The server backpropagates
+``sum(w * logprobs)``, a first-order surrogate whose gradient with respect to every parameter equals the
+gradient of the real loss. So the loss itself never crosses the wire.
+
+This is what lets one entry cover every TRL loss variant. Compare ``integrations/verl/grpo_loss.py``, which is
+523 lines reimplementing verl's ``masked_mean`` / ``agg_loss`` / ``compute_policy_loss_vanilla`` on this side
+and still supports only ``loss_mode="vanilla"`` out of the twelve entries in verl's ``POLICY_LOSS_REGISTRY``.
+Nothing here needs revisiting when TRL adds a loss.
+
+Equivalent framing: a weighted cross-entropy ``sum(-logprobs * weights)`` is the same surrogate under
+``weights = -d(loss)/d(logprobs)``. Tinker takes that route and maps its custom-loss path onto plain
+``cross_entropy`` without adding a loss at all.
+"""
+
+from typing import Any
+
+import torch
+
+from arctic_platform.rl.processors.pipeline import register_loss_fn
+
+
+@register_loss_fn("weighted_logprob_sum")
+def weighted_logprob_sum(
+    model_outputs: dict,
+    batch: dict,
+    meta: dict,
+    config: dict,
+    device: str,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """``sum(w * logprobs)`` over the loss mask.
+
+    ``logprob_weights_shifted`` follows the same roll(-1) convention as every other log-prob tensor in the
+    batch, so it lines up with ``model_outputs["logprobs"]`` without a shift here.
+
+    The weights arrive already scaled for gradient accumulation: TRL divides by its accumulation step count
+    before the gradient reaches the client. The sum below must therefore stay unnormalized, or the two
+    scalings compose.
+    """
+    logprobs = model_outputs["logprobs"]
+    weights = batch["logprob_weights_shifted"]
+
+    loss_mask = batch.get("loss_mask")
+    if loss_mask is not None:
+        weights = weights * loss_mask
+
+    loss = (logprobs * weights).sum()
+    return loss, {"loss": loss.detach()}


### PR DESCRIPTION
Sketch of a TRL backend for Arctic RL, opened as an RFC alongside huggingface/trl#6676. Not ready to merge: the batch layout helpers are stubs and none of this has run against a live server.

The idea is that TRL keeps the loss. `forward` returns per token logprobs, TRL builds its loss on them, and `backward` sends back `d(loss)/d(logprobs)`. The server backprops `sum(w * logprobs)`, which gives the same parameter gradients as the real loss. Verified bit exact against the in process path on TRL's GRPO loss.

So one server side loss function instead of one per algorithm. For comparison, `integrations/verl/grpo_loss.py` is 523 lines and still covers `vanilla` only, out of the 12 in verl's `POLICY_LOSS_REGISTRY`. `integrations/trl/loss.py` is about 6 lines and would not need touching when TRL adds a loss variant.

Two things I could not settle from the code:

1. `pipeline._resolve_fn` falls back to a dotted path import, so on a self hosted server the loss resolves without a registry entry at all. Is that a supported extension point or an implementation detail?
2. For managed deployments, would a generic registry entry be ok? Weighted cross entropy is the same surrogate under `weights = -d(loss)/d(logprobs)`, which is how Tinker avoids adding a loss.

Remaining open items are in the README. The main one is TRL side: it still wants a local model to prepare and to stream weights from.
