### PR TITLE
[SFT] loss function sameness

### DIFF
--- a/arctic_platform/common/utils/tiled_logits.py
+++ b/arctic_platform/common/utils/tiled_logits.py
@@ -112,7 +112,10 @@ def logprobs_entropy_from_flat_logits(flat_logits, flat_labels, calculate_entrop
     reshape back to the original batch dims.
     """
     entropy = None
-    if FLASH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE:
+    # The flash-attn CE kernel is Triton and only runs on CUDA tensors; fall back
+    # to the logsumexp/gather path on CPU so callers (e.g. sft_ce's ``none`` path)
+    # stay valid off-GPU. GPU behavior is unchanged.
+    if FLASH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE and flat_logits.is_cuda:
         inplace_backward = flat_logits.requires_grad
         output = cross_entropy_loss(flat_logits, flat_labels, inplace_backward=inplace_backward)
         logprobs = -output[0]

--- a/arctic_platform/sft/processor.py
+++ b/arctic_platform/sft/processor.py
@@ -30,7 +30,6 @@ from functools import partial
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 
 from arctic_platform.common.registry import LOSS_FNS
 from arctic_platform.common.registry import _resolve_fn
@@ -41,6 +40,7 @@ from arctic_platform.common.utils.debug import see_memory_usage
 from arctic_platform.common.utils.tiled_logits import TiledLogProbEntropy
 from arctic_platform.common.utils.tiled_logits import chunked_logprobs_entropy_from_hidden
 from arctic_platform.common.utils.tiled_logits import logits_chunk_rows
+from arctic_platform.common.utils.tiled_logits import logprobs_entropy_from_flat_logits
 from arctic_platform.common.utils.tiled_logits import tiled_logprobs_entropy_from_hidden
 
 # Valid ``logits_optimization`` modes for sft_ce. ``none`` keeps the classic
@@ -136,13 +136,19 @@ def sft_ce_loss(
     shift_labels = labels[:, 1:].contiguous()
     vocab = shift_logits.size(-1)
 
-    ce_sum = F.cross_entropy(
-        shift_logits.view(-1, vocab).float(),
-        shift_labels.view(-1),
-        ignore_index=-100,
-        reduction="sum",
-    )
-    n_valid = int((shift_labels != -100).sum().item())
+    # Compute CE through the shared logprobs core rather than F.cross_entropy so
+    # the full-logits ``none`` path is numerically identical to the ``compute`` /
+    # ``memory`` hidden-state paths (which also go through this core). The two
+    # kernels agree on the forward loss but their *backward* diverges at large
+    # vocab (~1.5% on the lm-head grad), which otherwise desyncs the three modes'
+    # training curves after the first step. Mirror sft_ce_sum_from_hidden's -100
+    # masking: clamp ignored targets to a safe gather index, then zero them out.
+    valid = shift_labels != -100
+    safe_labels = shift_labels.clamp_min(0)
+    flat_logits = shift_logits.reshape(-1, vocab).float()
+    logprobs, _ = logprobs_entropy_from_flat_logits(flat_logits, safe_labels.reshape(-1), False)
+    ce_sum = -(logprobs * valid.reshape(-1).to(logprobs.dtype)).sum()
+    n_valid = int(valid.sum().item())
 
     loss = _scale_ce_sum(ce_sum, n_valid, meta)
     return loss, _paired_loss_metrics(float(ce_sum.detach().float().item()), n_valid)


### PR DESCRIPTION
## Summary

`sft_ce` with `logits_optimization=none` diverged from `compute`/`memory` during training: `tests/sft/test_sft_ce_gpu.py::TestSftCeHttpE2EModesGPU::test_modes_match_loss_and_grad_norm_curves` failed because the three modes produced different loss/grad-norm curves after the first step. This unifies the CE kernel across all three modes so they are numerically identical.

The modes used two different cross-entropy kernels:

- `none` → `sft_ce_loss` used `torch.nn.functional.cross_entropy`.
- `compute` / `memory` → `sft_ce_sum_from_hidden` used the shared `logprobs_entropy_from_flat_logits` core (flash-attn Triton CE when available).

On the real demo model (`NousResearch/Llama-3.2-1B`, vocab 128256, bf16) the two kernels agree on the **forward** loss bit-for-bit, but their **backward** passes diverge at large vocab: `lm_head.weight.grad` differs by ~1.5% (max rel), and the total grad-norm differs (`7056.10` vs `7057.28`). `compute` vs `memory` were identical (0.0). That is exactly why step-1 loss and grad-norm printed equal across modes but step-2 diverged (`0.704` vs `0.7023`): identical forward, different gradient → different optimizer step.

- `arctic_platform/sft/processor.py`: `sft_ce_loss` now computes CE via the shared `logprobs_entropy_from_flat_logits` core (with the same `-100` masking as `sft_ce_sum_from_hidden`) instead of `F.cross_entropy`, so `none` matches `compute`/`memory`. Drops the now-unused `torch.nn.functional` import.
- `arctic_platform/common/utils/tiled_logits.py`: guard the flash-attn CE kernel with `flat_logits.is_cuda` so it's only used on CUDA tensors (the Triton kernel is CUDA-only). CPU callers fall back to the existing logsumexp/gather path. GPU behavior is unchanged, so RL and the `compute`/`memory` paths are unaffected.

No test/tolerance changes — the exact-equality assertion is fixed at the source.

## Testing

8×H200, imports from this checkout (`arctic-platform-1`, branch `stas/fix-sft-ce`):

- `tests/sft/test_sft_ce_gpu.py` → **7 passed**, including the 3-mode e2e (`test_modes_match_loss_and_grad_norm_curves`) and the small-vocab parity unit tests (`test_value_parity_with_masking`, `test_grad_parity_wrt_hidden`).
- CPU `tests/sft/test_sft_losses.py` + `tests/sft/test_sft_edge_cases.py` → **44 passed**.
