### PR TITLE
Route DeepSpeed model load through ModelSpec patches

### DIFF
--- a/arctic_platform/common/deepspeed_worker.py
+++ b/arctic_platform/common/deepspeed_worker.py
@@ -39,8 +39,6 @@ import torch.distributed as dist
 from deepspeed.accelerator import get_accelerator
 
 from arctic_platform.common.ray_cluster import primary_ip
-from arctic_platform.model import ModelSpec
-from arctic_platform.model import build_model
 from arctic_platform.common.utils import combine_metric_microbatches
 from arctic_platform.common.utils import log_dp_shard_tokens
 from arctic_platform.common.utils import merge_dict_shards
@@ -49,6 +47,8 @@ from arctic_platform.common.utils import unpack_batch
 from arctic_platform.common.utils.debug import enable_full_determinism
 from arctic_platform.common.utils.debug import pr0
 from arctic_platform.common.utils.debug import see_memory_usage
+from arctic_platform.model import ModelSpec
+from arctic_platform.model import build_model
 
 logger = logging.getLogger(__name__)
 

--- a/arctic_platform/common/deepspeed_worker.py
+++ b/arctic_platform/common/deepspeed_worker.py
@@ -37,9 +37,10 @@ import ray
 import torch
 import torch.distributed as dist
 from deepspeed.accelerator import get_accelerator
-from transformers import AutoModelForCausalLM
 
 from arctic_platform.common.ray_cluster import primary_ip
+from arctic_platform.model import ModelSpec
+from arctic_platform.model import build_model
 from arctic_platform.common.utils import combine_metric_microbatches
 from arctic_platform.common.utils import log_dp_shard_tokens
 from arctic_platform.common.utils import merge_dict_shards
@@ -157,47 +158,13 @@ class DeepSpeedWorker:
 
         pr0(f"ds_worker[after_modify]: {self.job_type=} {ds_config=} {ds_worker_config=}")
 
-        attn_implementation = ds_worker_config.get("attn_implementation", "flash_attention_2")
-
-        model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            attn_implementation=attn_implementation,
-            dtype=torch.bfloat16,
-        )
-
-        if ds_worker_config.get("use_liger", False):
-            pr0(f"Using liger kernel w/ {attn_implementation=}")
-
-            # Apply Liger kernel to the model if use_liger is set to True
-            from liger_kernel.transformers.monkey_patch import _apply_liger_kernel_to_instance
-
-            _apply_liger_kernel_to_instance(
-                model=model,
-                cross_entropy=False,
-                fused_linear_cross_entropy=False,
-                rope=True,
-                rms_norm=True,
-                swiglu=True,
-            )
-        # if ds_worker_config.get("use_liger", False):
-        #     pr0(f"Using liger kernel w/ {attn_implementation=}")
-        #     from liger_kernel.transformers import AutoLigerKernelForCausalLM
-        #     model = AutoLigerKernelForCausalLM.from_pretrained(
-        #         model_name,
-        #         attn_implementation=attn_implementation,
-        #         dtype=torch.bfloat16,
-        #     )
-
-        # else:
-        #     model = AutoModelForCausalLM.from_pretrained(
-        #         model_name,
-        #         attn_implementation=attn_implementation,
-        #         dtype=torch.bfloat16,
-        #     )
+        # HF load + patches via ModelSpec (world_size already injected above).
+        spec = ModelSpec.from_ds_worker_config(model_name, ds_worker_config)
+        loaded = build_model(spec)
+        model = loaded.model
 
         zorro_train_enable = ds_worker_config.get("zorro_train_enable", False)
-        if zorro_train_enable:
-            self.model_patch_in_zorro(model, ds_worker_config)
+        self.dedup_actor_model_once_patcher = getattr(model, "_arctic_zorro_once_patcher", None)
 
         init_kwargs = dict(model=model, config=ds_config)
         if self._has_optimizer:
@@ -211,10 +178,6 @@ class DeepSpeedWorker:
         gpu_uuid = torch.cuda.get_device_properties(gpu_id).uuid
         logger.info("Rank %d initialized on GPU %d (uuid=%s, device=%s)", self.rank, gpu_id, gpu_uuid, self._device)
         self.cpu_device = torch.device("cpu")
-
-        enable_gradient_checkpointing = ds_worker_config.get("enable_gradient_checkpointing", True)
-        if enable_gradient_checkpointing:
-            model.gradient_checkpointing_enable()
 
         pr0(
             "ds_worker[after_initialize]:"
@@ -338,37 +301,6 @@ class DeepSpeedWorker:
             cfg["torch_autocast"] = {"enabled": True, "dtype": "bfloat16"}
         cfg["bf16"] = {"enabled": True}
         return cfg
-
-    def model_patch_in_zorro(self, model, ds_worker_config):
-        from arctic_platform.rl.zorro_train.qwen_model_patcher import Qwen3ModelOncePatcher
-
-        # pr0(f"Patching ZoRRO")
-
-        response_len = ds_worker_config.get("response_len")
-        max_token_len = ds_worker_config.get("max_token_len")
-        rollout_n = ds_worker_config.get("rollout_n")
-        temperature = ds_worker_config.get("temperature")
-        logits_optimization = ds_worker_config.get("logits_optimization", "none")
-        logits_optimization_peak_mem_size_in_gib = ds_worker_config.get("logits_optimization_peak_mem_size_in_gib", 4)
-        logits_compute_from_fp32_inputs = ds_worker_config.get("logits_compute_from_fp32_inputs", False)
-        logits_compute_in_fp32 = ds_worker_config.get("logits_compute_in_fp32", False)
-        use_unpad = ds_worker_config.get("use_unpad")
-        world_size = ds_worker_config.get("world_size")
-
-        self.dedup_actor_model_once_patcher = Qwen3ModelOncePatcher(
-            model,
-            response_len=response_len,
-            max_token_len=max_token_len,
-            rollout_n=rollout_n,
-            temperature=temperature,
-            logits_optimization=logits_optimization,
-            logits_optimization_peak_mem_size_in_gib=logits_optimization_peak_mem_size_in_gib,
-            logits_compute_from_fp32_inputs=logits_compute_from_fp32_inputs,
-            logits_compute_in_fp32=logits_compute_in_fp32,
-            use_unpad=use_unpad,
-            world_size=world_size,
-        )
-        self.dedup_actor_model_once_patcher.patch_forward()
 
     # move batch to device
     def _move_batch_to_device(self, batch: Any, device: torch.device):

--- a/arctic_platform/model/__init__.py
+++ b/arctic_platform/model/__init__.py
@@ -17,6 +17,7 @@
 from arctic_platform.model.config import ModelSpec
 from arctic_platform.model.config import ParallelismConfig
 from arctic_platform.model.config import Patches
+from arctic_platform.model.config import ZorroTrainPatch
 from arctic_platform.model.factory import build_model
 from arctic_platform.model.loader import LoadedModel
 from arctic_platform.model.loader import LoaderContext
@@ -35,6 +36,7 @@ __all__ = [
     "ModelSpec",
     "ParallelismConfig",
     "Patches",
+    "ZorroTrainPatch",
     "apply_patches",
     "build_model",
     "register_loader",

--- a/arctic_platform/model/config.py
+++ b/arctic_platform/model/config.py
@@ -78,31 +78,48 @@ class ModelSpec(BaseModel):
 
     @classmethod
     def from_ds_worker_config(cls, model_name: str, ds_worker_config: dict) -> "ModelSpec":
-        """Map flat ``ds_worker_config`` to ModelSpec (FA2 / bf16 / GC-on defaults)."""
+        """Transitional bridge: map flat verl ``ds_worker_config`` into a ``ModelSpec``.
+
+        Callers (adapter / SFT demos) own the knobs on the flat dict today. Longer-term,
+        ``ModelSpec`` should be constructed upstream as part of the main client config
+        instead of being inferred here.
+        """
         cfg = ds_worker_config or {}
 
-        zorro_train = None
-        if cfg.get("zorro_train_enable", False):
-            zorro_train = ZorroTrainPatch(
-                response_len=cfg.get("response_len"),
-                max_token_len=cfg.get("max_token_len"),
-                rollout_n=cfg.get("rollout_n"),
-                temperature=cfg.get("temperature"),
-                use_unpad=cfg.get("use_unpad", True),
-                world_size=cfg.get("world_size"),
-                logits_optimization=cfg.get("logits_optimization", "none"),
-                logits_optimization_peak_mem_size_in_gib=cfg.get("logits_optimization_peak_mem_size_in_gib", 4),
-                logits_compute_from_fp32_inputs=cfg.get("logits_compute_from_fp32_inputs", False),
-                logits_compute_in_fp32=cfg.get("logits_compute_in_fp32", False),
+        # Require an explicit attention backend. ZoRRo Train needs a flash-attention
+        # implementation; do not invent a second default here (ModelSpec leaves it None).
+        if "attn_implementation" not in cfg or cfg["attn_implementation"] is None:
+            raise ValueError(
+                "from_ds_worker_config requires attn_implementation "
+                "(ZoRRo Train needs a flash-attention backend)."
             )
 
+        zorro_train_patch = None
+        if cfg.get("zorro_train_enable", False):
+            # Only forward keys present in cfg; ZorroTrainPatch pydantic defaults fill the rest.
+            zorro_keys = (
+                "response_len",
+                "max_token_len",
+                "rollout_n",
+                "temperature",
+                "use_unpad",
+                "world_size",
+                "logits_optimization",
+                "logits_optimization_peak_mem_size_in_gib",
+                "logits_compute_from_fp32_inputs",
+                "logits_compute_in_fp32",
+            )
+            zorro_train_patch = ZorroTrainPatch(**{k: cfg[k] for k in zorro_keys if k in cfg})
+
+        # Worker bridge defaults GC on (historical DeepSpeedWorker behavior). Generic
+        # ``Patches.gradient_checkpointing`` stays False for direct ModelSpec users.
         return cls(
             model_path_or_name=model_name,
             dtype="bfloat16",
-            attn_implementation=cfg.get("attn_implementation", "flash_attention_2"),
+            attn_implementation=cfg["attn_implementation"],
             patches=Patches(
                 liger=cfg.get("use_liger", False),
-                zorro_train=zorro_train,
+                zorro_train=zorro_train_patch,
                 gradient_checkpointing=cfg.get("enable_gradient_checkpointing", True),
             ),
         )

--- a/arctic_platform/model/config.py
+++ b/arctic_platform/model/config.py
@@ -31,12 +31,31 @@ class ParallelismConfig(BaseModel):
     sequence_parallel: int = Field(1, description="Ulysses sequence-parallel degree.")
 
 
+class ZorroTrainPatch(BaseModel):
+    """ZoRRo Train forward-patch knobs. Non-None enables the patch."""
+
+    model_config = ConfigDict(extra="forbid", validate_default=True)
+
+    response_len: int | None = Field(None, description="Response length per rollout.")
+    max_token_len: int | None = Field(None, description="Per-GPU train token budget.")
+    rollout_n: int | None = Field(None, description="GRPO rollout group size.")
+    temperature: float | None = Field(None, description="Sampling temperature for logprob/entropy.")
+    use_unpad: bool = Field(True, description="Use unpadded (packed) sequences.")
+    world_size: int | None = Field(None, description="Distributed world size (injected by worker).")
+    logits_optimization: str = Field("none", description='One of "none" | "memory" | "compute".')
+    logits_optimization_peak_mem_size_in_gib: int = Field(4, description="Peak mem budget (GiB) for memory/compute.")
+    logits_compute_from_fp32_inputs: bool = Field(False, description="Logits from fp32 hiddens.")
+    logits_compute_in_fp32: bool = Field(False, description="Compute logits in fp32.")
+
+
 class Patches(BaseModel):
     """Optional features applied to the model after it is loaded."""
 
     model_config = ConfigDict(extra="forbid", validate_default=True)
 
     liger: bool = Field(False, description="Apply Liger kernels.")
+    zorro_train: ZorroTrainPatch | None = Field(None, description="ZoRRo Train patch (None disables).")
+    gradient_checkpointing: bool = Field(False, description="HF gradient checkpointing.")
 
 
 class ModelSpec(BaseModel):
@@ -56,6 +75,37 @@ class ModelSpec(BaseModel):
         default_factory=ParallelismConfig, description="Loader-specific parallelism."
     )
     patches: Patches = Field(default_factory=Patches, description="Post-load patches.")
+
+    @classmethod
+    def from_ds_worker_config(cls, model_name: str, ds_worker_config: dict) -> "ModelSpec":
+        """Map flat ``ds_worker_config`` to ModelSpec (FA2 / bf16 / GC-on defaults)."""
+        cfg = ds_worker_config or {}
+
+        zorro_train = None
+        if cfg.get("zorro_train_enable", False):
+            zorro_train = ZorroTrainPatch(
+                response_len=cfg.get("response_len"),
+                max_token_len=cfg.get("max_token_len"),
+                rollout_n=cfg.get("rollout_n"),
+                temperature=cfg.get("temperature"),
+                use_unpad=cfg.get("use_unpad", True),
+                world_size=cfg.get("world_size"),
+                logits_optimization=cfg.get("logits_optimization", "none"),
+                logits_optimization_peak_mem_size_in_gib=cfg.get("logits_optimization_peak_mem_size_in_gib", 4),
+                logits_compute_from_fp32_inputs=cfg.get("logits_compute_from_fp32_inputs", False),
+                logits_compute_in_fp32=cfg.get("logits_compute_in_fp32", False),
+            )
+
+        return cls(
+            model_path_or_name=model_name,
+            dtype="bfloat16",
+            attn_implementation=cfg.get("attn_implementation", "flash_attention_2"),
+            patches=Patches(
+                liger=cfg.get("use_liger", False),
+                zorro_train=zorro_train,
+                gradient_checkpointing=cfg.get("enable_gradient_checkpointing", True),
+            ),
+        )
 
     @field_validator("dtype")
     @classmethod

--- a/arctic_platform/model/config.py
+++ b/arctic_platform/model/config.py
@@ -90,8 +90,7 @@ class ModelSpec(BaseModel):
         # implementation; do not invent a second default here (ModelSpec leaves it None).
         if "attn_implementation" not in cfg or cfg["attn_implementation"] is None:
             raise ValueError(
-                "from_ds_worker_config requires attn_implementation "
-                "(ZoRRo Train needs a flash-attention backend)."
+                "from_ds_worker_config requires attn_implementation (ZoRRo Train needs a flash-attention backend)."
             )
 
         zorro_train_patch = None

--- a/arctic_platform/model/patch.py
+++ b/arctic_platform/model/patch.py
@@ -28,16 +28,11 @@ from arctic_platform.model.loader import LoaderContext
 Patch = Callable[[nn.Module, LoaderContext], None]
 
 
-# Canonical apply order; patches interact, so this is the single source of truth for
-# sequencing (e.g. fp32_lm_head before chunked_lm_head, compile last). Every
-# registered patch must appear here.
-#
-# Where does a new patch go? Patches form a dependency graph: some read or wrap
-# structures that others create or replace. Place a patch after everything it
-# depends on and before anything that depends on it. Independent patches can go in
-# any relative order; when unsure, put structural rewrites early and whole-model
-# wrappers (e.g. torch.compile) last.
-PATCH_ORDER: tuple[str, ...] = ("liger",)
+# Canonical order (every registered patch must appear here).
+# liger → zorro_train (replaces forward) → gradient_checkpointing (before DS wrap).
+# Note: ZoRRo's patched forward does not call `_gradient_checkpointing_func`, so GC
+# under ZoRRo is a no-op for activation savings (same as the old inline worker path).
+PATCH_ORDER: tuple[str, ...] = ("liger", "zorro_train", "gradient_checkpointing")
 
 _PATCHES: dict[str, Patch] = {}
 

--- a/arctic_platform/model/patches/__init__.py
+++ b/arctic_platform/model/patches/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 """Built-in patches. Importing this package registers them."""
 
+from arctic_platform.model.patches import gradient_checkpointing  # noqa: F401
 from arctic_platform.model.patches import liger  # noqa: F401
 from arctic_platform.model.patches import zorro_train  # noqa: F401
-from arctic_platform.model.patches import gradient_checkpointing  # noqa: F401

--- a/arctic_platform/model/patches/gradient_checkpointing.py
+++ b/arctic_platform/model/patches/gradient_checkpointing.py
@@ -12,8 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Built-in patches. Importing this package registers them."""
+"""Gradient-checkpointing patch: enable HF activation checkpointing before the DeepSpeed wrap."""
 
-from arctic_platform.model.patches import liger  # noqa: F401
-from arctic_platform.model.patches import zorro_train  # noqa: F401
-from arctic_platform.model.patches import gradient_checkpointing  # noqa: F401
+from __future__ import annotations
+
+import torch.nn as nn
+
+from arctic_platform.model.loader import LoaderContext
+from arctic_platform.model.patch import register_patch
+
+
+@register_patch("gradient_checkpointing")
+def apply_gradient_checkpointing(model: nn.Module, ctx: LoaderContext) -> None:
+    # Enable-only (matches old worker; do not call make_model_gradient_checkpointing_compatible).
+    model.gradient_checkpointing_enable()

--- a/arctic_platform/model/patches/zorro_train.py
+++ b/arctic_platform/model/patches/zorro_train.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ZoRRo Train forward patch (RL deduplication/reconstruction)."""
+
+from __future__ import annotations
+
+import torch.nn as nn
+
+from arctic_platform.model.loader import LoaderContext
+from arctic_platform.model.patch import register_patch
+
+
+@register_patch("zorro_train")
+def apply_zorro_train(model: nn.Module, ctx: LoaderContext) -> None:
+    # Lazy: keep `import arctic_platform.model` free of RL deps.
+    from arctic_platform.rl.zorro_train.qwen_model_patcher import Qwen3ModelOncePatcher
+
+    settings = ctx.spec.patches.zorro_train
+
+    patcher = Qwen3ModelOncePatcher(
+        model,
+        response_len=settings.response_len,
+        max_token_len=settings.max_token_len,
+        rollout_n=settings.rollout_n,
+        temperature=settings.temperature,
+        logits_optimization=settings.logits_optimization,
+        logits_optimization_peak_mem_size_in_gib=settings.logits_optimization_peak_mem_size_in_gib,
+        logits_compute_from_fp32_inputs=settings.logits_compute_from_fp32_inputs,
+        logits_compute_in_fp32=settings.logits_compute_in_fp32,
+        use_unpad=settings.use_unpad,
+        world_size=settings.world_size,
+    )
+    patcher.patch_forward()
+    # Pin patcher so attention sub-patcher / closures are not GC'd.
+    model._arctic_zorro_once_patcher = patcher

--- a/arctic_platform/model/patches/zorro_train.py
+++ b/arctic_platform/model/patches/zorro_train.py
@@ -26,6 +26,10 @@ from arctic_platform.model.patch import register_patch
 def apply_zorro_train(model: nn.Module, ctx: LoaderContext) -> None:
     # Lazy: keep `import arctic_platform.model` free of RL deps.
     from arctic_platform.rl.zorro_train.qwen_model_patcher import Qwen3ModelOncePatcher
+    from arctic_platform.rl.zorro_train.qwen_model_patcher import get_supported_model_type
+
+    # Fail fast: ZoRRo Train only supports Qwen3-family model_type values.
+    get_supported_model_type(model)
 
     settings = ctx.spec.patches.zorro_train
 

--- a/arctic_platform/model/patches/zorro_train.py
+++ b/arctic_platform/model/patches/zorro_train.py
@@ -24,14 +24,19 @@ from arctic_platform.model.patch import register_patch
 
 @register_patch("zorro_train")
 def apply_zorro_train(model: nn.Module, ctx: LoaderContext) -> None:
-    # Lazy: keep `import arctic_platform.model` free of RL deps.
-    from arctic_platform.rl.zorro_train.qwen_model_patcher import Qwen3ModelOncePatcher
-    from arctic_platform.rl.zorro_train.qwen_model_patcher import get_supported_model_type
+    # Lazy via importlib: keep `import arctic_platform.model` free of RL deps, and
+    # avoid mypy following into arctic_platform.rl (not in the model/ typecheck set).
+    import importlib
+
+    zorro_mod = importlib.import_module("arctic_platform.rl.zorro_train.qwen_model_patcher")
+    Qwen3ModelOncePatcher = zorro_mod.Qwen3ModelOncePatcher
+    get_supported_model_type = zorro_mod.get_supported_model_type
 
     # Fail fast: ZoRRo Train only supports Qwen3-family model_type values.
     get_supported_model_type(model)
 
     settings = ctx.spec.patches.zorro_train
+    assert settings is not None, "zorro_train patch applied with patches.zorro_train=None"
 
     patcher = Qwen3ModelOncePatcher(
         model,

--- a/tests/model/test_model_factory.py
+++ b/tests/model/test_model_factory.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import sys
 import types
 
 import pytest
@@ -187,3 +188,117 @@ class TestPatchPipeline:
 
         apply_patches(loaded, ctx)
         assert calls == ["a"]
+
+
+class TestFromDsWorkerConfig:
+    def test_defaults_preserve_worker_behavior(self):
+        spec = ModelSpec.from_ds_worker_config("Qwen/Qwen3-1.7B", {})
+
+        assert spec.model_path_or_name == "Qwen/Qwen3-1.7B"
+        assert spec.dtype == "bfloat16"
+        assert spec.attn_implementation == "flash_attention_2"
+        assert spec.patches.liger is False
+        assert spec.patches.gradient_checkpointing is True  # bridge default
+        assert spec.patches.zorro_train is None  # None disables (empty patch would be truthy)
+
+    def test_generic_patches_default_gc_off(self):
+        from arctic_platform.model.config import Patches
+
+        assert Patches().gradient_checkpointing is False
+
+    def test_liger_and_gc_flags_map(self):
+        spec = ModelSpec.from_ds_worker_config(
+            "x",
+            {"use_liger": True, "enable_gradient_checkpointing": False, "attn_implementation": "sdpa"},
+        )
+        assert spec.patches.liger is True
+        assert spec.patches.gradient_checkpointing is False
+        assert spec.attn_implementation == "sdpa"
+        assert spec.patches.zorro_train is None
+
+    def test_zorro_enabled_maps_fields(self):
+        spec = ModelSpec.from_ds_worker_config(
+            "x",
+            {
+                "zorro_train_enable": True,
+                "response_len": 1024,
+                "max_token_len": 16384,
+                "rollout_n": 8,
+                "temperature": 1.0,
+                "use_unpad": True,
+                "world_size": 2,
+                "logits_optimization": "memory",
+                "logits_optimization_peak_mem_size_in_gib": 8,
+                "logits_compute_from_fp32_inputs": True,
+                "logits_compute_in_fp32": True,
+            },
+        )
+        z = spec.patches.zorro_train
+        assert z is not None
+        assert z.response_len == 1024
+        assert z.max_token_len == 16384
+        assert z.rollout_n == 8
+        assert z.temperature == 1.0
+        assert z.world_size == 2
+        assert z.logits_optimization == "memory"
+        assert z.logits_optimization_peak_mem_size_in_gib == 8
+        assert z.logits_compute_from_fp32_inputs is True
+        assert z.logits_compute_in_fp32 is True
+
+
+class TestZorroAndGcPatches:
+    def test_gradient_checkpointing_patch_calls_enable(self):
+        from arctic_platform.model.patches.gradient_checkpointing import apply_gradient_checkpointing
+
+        class _Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.enabled = False
+
+            def gradient_checkpointing_enable(self):
+                self.enabled = True
+
+        model = _Model()
+        apply_gradient_checkpointing(model, _ctx(gradient_checkpointing=True))
+        assert model.enabled is True
+
+    def test_gradient_checkpointing_skipped_via_apply_patches(self, monkeypatch):
+        monkeypatch.setattr(patch_mod, "PATCH_ORDER", ("gradient_checkpointing",))
+        calls = []
+        patch_mod._PATCHES["gradient_checkpointing"] = lambda model, ctx: calls.append("gc")
+
+        apply_patches(LoadedModel(model=nn.Identity()), _ctx(gradient_checkpointing=False))
+        assert calls == []
+        apply_patches(LoadedModel(model=nn.Identity()), _ctx(gradient_checkpointing=True))
+        assert calls == ["gc"]
+
+    def test_zorro_patch_builds_patcher_and_attaches(self, monkeypatch):
+        from arctic_platform.model.config import ZorroTrainPatch
+        from arctic_platform.model.patches.zorro_train import apply_zorro_train
+
+        constructed = {}
+
+        class _FakePatcher:
+            def __init__(self, model, **kwargs):
+                constructed["model"] = model
+                constructed["kwargs"] = kwargs
+                self.patched = False
+
+            def patch_forward(self):
+                self.patched = True
+
+        fake_mod = types.ModuleType("arctic_platform.rl.zorro_train.qwen_model_patcher")
+        fake_mod.Qwen3ModelOncePatcher = _FakePatcher
+        monkeypatch.setitem(sys.modules, "arctic_platform.rl.zorro_train.qwen_model_patcher", fake_mod)
+
+        model = nn.Identity()
+        settings = ZorroTrainPatch(response_len=1024, rollout_n=8, world_size=2, logits_optimization="memory")
+        apply_zorro_train(model, _ctx(zorro_train=settings))
+
+        assert constructed["model"] is model
+        assert constructed["kwargs"]["response_len"] == 1024
+        assert constructed["kwargs"]["rollout_n"] == 8
+        assert constructed["kwargs"]["world_size"] == 2
+        assert constructed["kwargs"]["logits_optimization"] == "memory"
+        assert isinstance(model._arctic_zorro_once_patcher, _FakePatcher)
+        assert model._arctic_zorro_once_patcher.patched is True

--- a/tests/model/test_model_factory.py
+++ b/tests/model/test_model_factory.py
@@ -192,7 +192,9 @@ class TestPatchPipeline:
 
 class TestFromDsWorkerConfig:
     def test_defaults_preserve_worker_behavior(self):
-        spec = ModelSpec.from_ds_worker_config("Qwen/Qwen3-1.7B", {})
+        spec = ModelSpec.from_ds_worker_config(
+            "Qwen/Qwen3-1.7B", {"attn_implementation": "flash_attention_2"}
+        )
 
         assert spec.model_path_or_name == "Qwen/Qwen3-1.7B"
         assert spec.dtype == "bfloat16"
@@ -201,10 +203,15 @@ class TestFromDsWorkerConfig:
         assert spec.patches.gradient_checkpointing is True  # bridge default
         assert spec.patches.zorro_train is None  # None disables (empty patch would be truthy)
 
+    def test_requires_attn_implementation(self):
+        with pytest.raises(ValueError, match="requires attn_implementation"):
+            ModelSpec.from_ds_worker_config("Qwen/Qwen3-1.7B", {})
+
     def test_generic_patches_default_gc_off(self):
         from arctic_platform.model.config import Patches
 
         assert Patches().gradient_checkpointing is False
+        assert ModelSpec(model_path_or_name="x").attn_implementation is None
 
     def test_liger_and_gc_flags_map(self):
         spec = ModelSpec.from_ds_worker_config(
@@ -220,6 +227,7 @@ class TestFromDsWorkerConfig:
         spec = ModelSpec.from_ds_worker_config(
             "x",
             {
+                "attn_implementation": "flash_attention_2",
                 "zorro_train_enable": True,
                 "response_len": 1024,
                 "max_token_len": 16384,
@@ -244,6 +252,24 @@ class TestFromDsWorkerConfig:
         assert z.logits_optimization_peak_mem_size_in_gib == 8
         assert z.logits_compute_from_fp32_inputs is True
         assert z.logits_compute_in_fp32 is True
+
+    def test_zorro_uses_pydantic_defaults_for_omitted_fields(self):
+        from arctic_platform.model.config import ZorroTrainPatch
+
+        spec = ModelSpec.from_ds_worker_config(
+            "x",
+            {"attn_implementation": "flash_attention_2", "zorro_train_enable": True, "rollout_n": 4},
+        )
+        z = spec.patches.zorro_train
+        assert z is not None
+        assert z.rollout_n == 4
+        # Omitted keys come from ZorroTrainPatch field defaults (single source of truth).
+        defaults = ZorroTrainPatch()
+        assert z.use_unpad == defaults.use_unpad
+        assert z.logits_optimization == defaults.logits_optimization
+        assert z.logits_optimization_peak_mem_size_in_gib == defaults.logits_optimization_peak_mem_size_in_gib
+        assert z.logits_compute_from_fp32_inputs == defaults.logits_compute_from_fp32_inputs
+        assert z.logits_compute_in_fp32 == defaults.logits_compute_in_fp32
 
 
 class TestZorroAndGcPatches:

--- a/tests/model/test_model_factory.py
+++ b/tests/model/test_model_factory.py
@@ -289,9 +289,11 @@ class TestZorroAndGcPatches:
 
         fake_mod = types.ModuleType("arctic_platform.rl.zorro_train.qwen_model_patcher")
         fake_mod.Qwen3ModelOncePatcher = _FakePatcher
+        fake_mod.get_supported_model_type = lambda model: "qwen3"
         monkeypatch.setitem(sys.modules, "arctic_platform.rl.zorro_train.qwen_model_patcher", fake_mod)
 
         model = nn.Identity()
+        model.config = types.SimpleNamespace(model_type="qwen3")
         settings = ZorroTrainPatch(response_len=1024, rollout_n=8, world_size=2, logits_optimization="memory")
         apply_zorro_train(model, _ctx(zorro_train=settings))
 
@@ -302,3 +304,21 @@ class TestZorroAndGcPatches:
         assert constructed["kwargs"]["logits_optimization"] == "memory"
         assert isinstance(model._arctic_zorro_once_patcher, _FakePatcher)
         assert model._arctic_zorro_once_patcher.patched is True
+
+    def test_zorro_patch_rejects_non_qwen3(self, monkeypatch):
+        from arctic_platform.model.config import ZorroTrainPatch
+        from arctic_platform.model.patches.zorro_train import apply_zorro_train
+        from arctic_platform.rl.zorro_train.qwen_model_patcher import get_supported_model_type
+
+        # Keep the real guard; stub only the patcher constructor so we never patch.
+        fake_mod = types.ModuleType("arctic_platform.rl.zorro_train.qwen_model_patcher")
+        fake_mod.Qwen3ModelOncePatcher = object
+        fake_mod.get_supported_model_type = get_supported_model_type
+        monkeypatch.setitem(sys.modules, "arctic_platform.rl.zorro_train.qwen_model_patcher", fake_mod)
+
+        model = nn.Identity()
+        model.config = types.SimpleNamespace(model_type="llama")
+        with pytest.raises(ValueError, match="Unsupported model_type=llama"):
+            apply_zorro_train(
+                model, _ctx(zorro_train=ZorroTrainPatch(response_len=1024, rollout_n=8, world_size=1))
+            )

--- a/tests/model/test_model_factory.py
+++ b/tests/model/test_model_factory.py
@@ -192,9 +192,7 @@ class TestPatchPipeline:
 
 class TestFromDsWorkerConfig:
     def test_defaults_preserve_worker_behavior(self):
-        spec = ModelSpec.from_ds_worker_config(
-            "Qwen/Qwen3-1.7B", {"attn_implementation": "flash_attention_2"}
-        )
+        spec = ModelSpec.from_ds_worker_config("Qwen/Qwen3-1.7B", {"attn_implementation": "flash_attention_2"})
 
         assert spec.model_path_or_name == "Qwen/Qwen3-1.7B"
         assert spec.dtype == "bfloat16"
@@ -345,6 +343,4 @@ class TestZorroAndGcPatches:
         model = nn.Identity()
         model.config = types.SimpleNamespace(model_type="llama")
         with pytest.raises(ValueError, match="Unsupported model_type=llama"):
-            apply_zorro_train(
-                model, _ctx(zorro_train=ZorroTrainPatch(response_len=1024, rollout_n=8, world_size=1))
-            )
+            apply_zorro_train(model, _ctx(zorro_train=ZorroTrainPatch(response_len=1024, rollout_n=8, world_size=1)))


### PR DESCRIPTION
## Summary
- Register `zorro_train` and `gradient_checkpointing` in the model patch registry (alongside `liger`) and apply them via `build_model(ModelSpec)`.
- Bridge flat verl `ds_worker_config` into `ModelSpec.from_ds_worker_config` (require `attn_implementation`; ZoRRo disabled → `None`; worker bridge defaults GC-on).
- Replace inline HF load / liger / ZoRRo / post-init GC in `DeepSpeedWorker.initialize` with the factory path.
- Guard ZoRRo train patch to Qwen3-family `model_type` values only.

## Test plan
- [x] `pytest tests/model/test_model_factory.py` (22 passed, incl. attn required + non-Qwen3 reject)
- [x] CI formatting / unit-tests / semgrep green (`ad5e5b7`)
- [x] GSM8K Ray 1-step smoke after refactor (`job-20260817T165402Z`, exit 0)
- [x] GSM8K Ray 40-step quality smoke (`job-20260817T182704Z`, reached step 40)
- [x] GSM8K HTTP 10-step smoke (`job-20260817T205758Z`, `protocol=http`, reached step 10)
- [x] txt2sql BIRD 1-step smoke: Qwen3-1.7B on 2× H200, ZoRRo train on (`job-20260817T220459Z`, reward mean ~0.53)
- [x] txt2sql BIRD official recipe: Qwen3-32B on 8× H200, ZoRRo train+inference, 10 steps (`job-20260818T144500Z`, ~3h, reward mean ~0.53–0.66)