### PR TITLE
zorro test coverage

### DIFF
--- a/tests/zorro_train/test_once_patcher.py
+++ b/tests/zorro_train/test_once_patcher.py
@@ -101,6 +101,8 @@ add_padding_modes = [True, False]
 model_attn_logits_cases = list(
     itertools.product(model_names, attn_implementations, add_padding_modes, logits_optimization_modes)
 )
+# Backward compares all three modes on one (model, attn, padding) case — do not parameterize by mode.
+model_attn_pad_cases = list(itertools.product(model_names, attn_implementations, add_padding_modes))
 
 
 @functools.lru_cache(maxsize=None)
@@ -203,15 +205,27 @@ class TestQwen3ModelOncePatcher(TestCasePlus):
         # offset-aware extraction fixes).
         torch_assert_close(output.logprobs.float(), reference_logprobs, rtol=0, atol=1e-3)
 
-    @parameterized.expand(model_attn_logits_cases)
-    def test_backward_produces_finite_gradients(
-        self, model_name, attn_implementation, add_padding, logits_optimization
-    ):
-        model, batch, _, _ = self._load_or_skip(model_name, attn_implementation, add_padding)
+    def _lm_head_grad(self, model, batch, logits_optimization: str) -> torch.Tensor:
         model.zero_grad(set_to_none=True)
         output = self._patch_and_forward(model, batch, logits_optimization, calculate_entropy=False)
         output.logprobs.mean().backward()
         grad = model.lm_head.weight.grad
-        self.assertIsNotNone(grad)
-        self.assertTrue(torch.isfinite(grad).all())
-        self.assertGreater(grad.abs().sum().item(), 0.0)
+        self.assertIsNotNone(grad, msg=f"{logits_optimization}: missing lm_head.grad")
+        return grad.detach().float().clone()
+
+    @parameterized.expand(model_attn_pad_cases)
+    def test_backward_matches_across_logits_optimization_modes(self, model_name, attn_implementation, add_padding):
+        """``none`` / ``compute`` / ``memory`` claim the same math — compare ``lm_head.grad``, not just finite."""
+        model, batch, _, _ = self._load_or_skip(model_name, attn_implementation, add_padding)
+        grads = {mode: self._lm_head_grad(model, batch, mode) for mode in logits_optimization_modes}
+        self.assertGreater(grads["none"].abs().sum().item(), 0.0)
+        # Same bf16 bound as the forward logprob check in this file (rtol=0). A ~1.5% mode split (the sft_ce
+        # none-vs-tiled failure) is far above 1e-3.
+        for mode in ("memory", "compute"):
+            torch_assert_close(
+                grads[mode],
+                grads["none"],
+                rtol=0,
+                atol=1e-3,
+                msg=f"{mode} vs none lm_head.grad",
+            )


### PR DESCRIPTION
## Summary

ZoRRo `logits_optimization` modes (`none` / `compute` / `memory`) already share one logprob core, but the backward test only checked that `lm_head.grad` was finite and nonzero. That oracle stays green if the modes diverge on the backward — the same gap that hid the SFT `sft_ce` `none` vs tiled-CE split.

`test_backward_produces_finite_gradients` is now `test_backward_matches_across_logits_optimization_modes`: for each `(model, attn, padding)` it runs all three modes on the same cached model/batch and compares `lm_head.grad` to `none` with `rtol=0`, `atol=1e-3` (same bf16 bound as the forward logprob check in that file).

