### PR TITLE
[bug fix] lm_head_logits squeeze(0) at temperature!=1 drops rank on size-1 leading dims

### DIFF
--- a/arctic_platform/common/utils/tiled_logits.py
+++ b/arctic_platform/common/utils/tiled_logits.py
@@ -75,7 +75,7 @@ def lm_head_logits(
     model, hidden_states, temperature=1.0, logits_compute_from_fp32_inputs=False, logits_compute_in_fp32=False
 ):
     """Project hidden states to vocab logits via the LM head, applying optional
-    temperature scaling. Returns the (possibly squeezed) logits tensor.
+    temperature scaling.
 
     Shared by the `none`/`compute` logits-optimization paths; the full logits are
     manifested here (the `memory` path avoids this by tiling inside the autograd
@@ -94,8 +94,6 @@ def lm_head_logits(
     if logits_compute_in_fp32:
         logits = logits.float()
     if temperature != 1.0:
-        # logits = logits / temperature
-        logits = logits.squeeze(0)  # (total_nnz, vocab_size)
         temperature = torch.tensor(temperature, device=logits.device)
         logits.div_(temperature.clamp(min=1e-8).unsqueeze(-1).to(logits.dtype))
     return logits

--- a/tests/common/test_tiled_logits.py
+++ b/tests/common/test_tiled_logits.py
@@ -15,6 +15,7 @@
 """Tests for the shared memory-efficient logits/CE primitives.
 
 * ``TestLogitsChunkRows`` — pure sizing math; runs anywhere (CPU client ok).
+* ``TestLmHeadTemperatureLayout`` — ``temperature != 1`` keeps the incoming logits rank.
 * ``TestPerTokenLogprobParityGPU`` — real GPU kernel path (``none`` / ``compute`` /
   ``memory``). Skips without CUDA via ``@require_torch_gpu``; run via autorun on the
   GPU box. Does **not** force the torch fallback — whatever CE kernel is installed
@@ -29,6 +30,7 @@ import torch
 
 from arctic_platform.common.utils.tiled_logits import TiledLogProbEntropy
 from arctic_platform.common.utils.tiled_logits import chunked_logprobs_entropy_from_hidden
+from arctic_platform.common.utils.tiled_logits import lm_head_logits
 from arctic_platform.common.utils.tiled_logits import logits_chunk_rows
 from arctic_platform.common.utils.tiled_logits import tiled_logprobs_entropy_from_hidden
 from arctic_platform.testing_utils import TestCasePlus
@@ -48,6 +50,67 @@ class TestLogitsChunkRows(TestCasePlus):
 
     def test_scales_with_budget(self):
         self.assertEqual(logits_chunk_rows(1000, 2), 2 * logits_chunk_rows(1000, 1))
+
+
+class TestLmHeadTemperatureLayout(TestCasePlus):
+    """#1: ``temperature != 1`` must not change logits rank."""
+
+    def _model(self, hidden_size, vocab_size, device="cpu"):
+        return make_tied_lm_head_model(hidden_size, vocab_size, device=device)
+
+    def test_temperature_keeps_incoming_shape(self):
+        set_seed(0)
+        b, s, hidden_size, vocab_size = 2, 4, 8, 16
+        model = self._model(hidden_size, vocab_size)
+        hidden = torch.randn(b, s, hidden_size)
+        logits = lm_head_logits(model, hidden, temperature=0.7)
+        self.assertEqual(tuple(logits.shape), (b, s, vocab_size))
+
+    def test_n1_row_temperature_keeps_shape(self):
+        set_seed(0)
+        hidden_size, vocab_size = 8, 16
+        model = self._model(hidden_size, vocab_size)
+        hidden = torch.randn(1, hidden_size)
+        labels = torch.randint(0, vocab_size, (1,))
+        logprobs, _ = tiled_logprobs_entropy_from_hidden(
+            model, hidden, labels, temperature=0.7, calculate_entropy=False
+        )
+        self.assertEqual(tuple(logprobs.shape), tuple(labels.shape))
+
+    def test_b1_keeps_batch_axis(self):
+        set_seed(0)
+        s, hidden_size, vocab_size = 4, 8, 16
+        model = self._model(hidden_size, vocab_size)
+        hidden1 = torch.randn(1, s, hidden_size)
+        labels1 = torch.randint(0, vocab_size, (1, s))
+        hidden2 = torch.randn(2, s, hidden_size)
+        labels2 = torch.randint(0, vocab_size, (2, s))
+        lp1, _ = tiled_logprobs_entropy_from_hidden(
+            model, hidden1, labels1, temperature=1.5, calculate_entropy=False
+        )
+        lp2, _ = tiled_logprobs_entropy_from_hidden(
+            model, hidden2, labels2, temperature=1.5, calculate_entropy=False
+        )
+        self.assertEqual(tuple(lp1.shape), tuple(labels1.shape))
+        self.assertEqual(tuple(lp2.shape), tuple(labels2.shape))
+
+    def test_one_row_memory_shard_temperature(self):
+        set_seed(0)
+        n, hidden_size, vocab_size = 3, 8, 16
+        model = self._model(hidden_size, vocab_size)
+        hidden = torch.randn(n, hidden_size)
+        labels = torch.randint(0, vocab_size, (n,))
+        logprobs, _ = TiledLogProbEntropy.apply(
+            tiled_logprobs_entropy_from_hidden,
+            model,
+            hidden,
+            labels,
+            0.7,
+            False,
+            n,
+            [model.lm_head.weight],
+        )
+        self.assertEqual(tuple(logprobs.shape), tuple(labels.shape))
 
 
 @require_torch_gpu

--- a/tests/common/test_tiled_logits.py
+++ b/tests/common/test_tiled_logits.py
@@ -85,12 +85,8 @@ class TestLmHeadTemperatureLayout(TestCasePlus):
         labels1 = torch.randint(0, vocab_size, (1, s))
         hidden2 = torch.randn(2, s, hidden_size)
         labels2 = torch.randint(0, vocab_size, (2, s))
-        lp1, _ = tiled_logprobs_entropy_from_hidden(
-            model, hidden1, labels1, temperature=1.5, calculate_entropy=False
-        )
-        lp2, _ = tiled_logprobs_entropy_from_hidden(
-            model, hidden2, labels2, temperature=1.5, calculate_entropy=False
-        )
+        lp1, _ = tiled_logprobs_entropy_from_hidden(model, hidden1, labels1, temperature=1.5, calculate_entropy=False)
+        lp2, _ = tiled_logprobs_entropy_from_hidden(model, hidden2, labels2, temperature=1.5, calculate_entropy=False)
         self.assertEqual(tuple(lp1.shape), tuple(labels1.shape))
         self.assertEqual(tuple(lp2.shape), tuple(labels2.shape))
 


### PR DESCRIPTION
## Summary

`lm_head_logits` no longer `squeeze(0)` when `temperature != 1`. The divide already broadcasts over any leading dims (`unsqueeze(-1)` on a scalar), so logits keep the incoming layout. `squeeze(0)` collapsed `[1, V]` to `[V]` (`view()` crash) and `[1, S, V]` to `[S, V]`.

## Testing

- Repro: `TestLmHeadTemperatureLayout` failed on `main` (N=1 / 1-row shard `TypeError`; B=1 rank drop).
- After fix: `tests/common/test_tiled_logits.py` CPU — `TestLmHeadTemperatureLayout` + `TestLogitsChunkRows`. GPU kernel class not run on this node.