### PR TITLE
[bug fix] all-masked sft returns HF NaN instead of a finite zero loss

### DIFF
--- a/arctic_platform/sft/processor.py
+++ b/arctic_platform/sft/processor.py
@@ -102,9 +102,11 @@ def sft_loss(
     labels = _require_labels(batch, "sft loss")
     # HF CE targets are labels[:, 1:], ignore_index=-100.
     n_valid = int((labels[:, 1:] != -100).sum().item())
+    if n_valid == 0:
+        # HF CE is NaN when every target is ignore_index.
+        loss = torch.zeros_like(loss, requires_grad=loss.requires_grad)
     # Reconstruct Σ CE from HF's token-mean so cross-rank aggregation stays exact.
-    # Zero valid targets → (0, 0) so the pair cancels in the global mean.
-    loss_sum = float(loss.detach().float().item()) * n_valid if n_valid else 0.0
+    loss_sum = float(loss.detach().float().item()) * n_valid
     return loss, _paired_loss_metrics(loss_sum, n_valid)
 
 

--- a/tests/sft/test_sft_edge_cases.py
+++ b/tests/sft/test_sft_edge_cases.py
@@ -48,6 +48,21 @@ class TestAllMaskedLabels(TestCasePlus):
         # Fixed: no bogus loss*1 injected when there are no valid targets.
         self.assertEqual(metrics["loss.sum"], 0.0)
 
+    def test_sft_loss_all_neg100_hf_nan_is_finite_zero(self):
+        # HF CE is NaN when every shifted target is ignore_index; return 0, not that NaN.
+        labels = torch.full((1, 5), -100, dtype=torch.long)
+        loss, metrics = sft_loss(
+            {"loss": torch.tensor(float("nan"), requires_grad=True)},
+            {"labels": labels},
+            {},
+            {},
+            "cpu",
+        )
+        self.assertTrue(torch.isfinite(loss))
+        self.assertEqual(loss.item(), 0.0)
+        self.assertEqual(metrics["loss.tokens"], 0.0)
+        self.assertEqual(metrics["loss.sum"], 0.0)
+
     def test_sft_ce_all_neg100_divides_by_one(self):
         labels = torch.full((1, 4), -100, dtype=torch.long)
         logits = torch.zeros(1, 4, 8)

--- a/tests/sft/test_sft_losses.py
+++ b/tests/sft/test_sft_losses.py
@@ -19,6 +19,7 @@ No GPU / Ray / DeepSpeed — tiny deterministic tensors and a stub engine.
 
 from __future__ import annotations
 
+import math
 from types import SimpleNamespace
 
 import torch
@@ -242,6 +243,46 @@ class TestRunSFTPipeline(TestCasePlus):
         self.assertIn("loss.sum", out["metrics"])
         self.assertIn("loss.tokens", out["metrics"])
         self.assertAlmostEqual(out["avg_loss"], 1.5, places=5)
+
+    def test_sft_all_masked_hf_nan_avg_loss_is_zero(self):
+        class NanOnAllMasked(_StubEngine):
+            def __call__(self, **kwargs):
+                out = super().__call__(**kwargs)
+                labels = kwargs["labels"]
+                if (labels[:, 1:] != -100).sum() == 0:
+                    out.loss = torch.tensor(float("nan"), requires_grad=True)
+                return out
+
+        engine = NanOnAllMasked()
+        finite = run_sft_pipeline(
+            engine,
+            self._batch(),
+            meta={},
+            processing={"loss_fn": "sft"},
+            device="cpu",
+            backward=True,
+        )
+        self.assertAlmostEqual(finite["avg_loss"], 1.5, places=5)
+
+        masked = {
+            "input_ids": torch.arange(8).view(2, 4),
+            "attention_mask": torch.ones(2, 4, dtype=torch.long),
+            "labels": torch.full((2, 4), -100, dtype=torch.long),
+        }
+        out = run_sft_pipeline(
+            engine,
+            masked,
+            meta={},
+            processing={"loss_fn": "sft"},
+            device="cpu",
+            backward=True,
+        )
+        self.assertTrue(math.isfinite(out["avg_loss"]))
+        self.assertEqual(out["avg_loss"], 0.0)
+        self.assertEqual(out["metrics"]["loss.tokens"], 0.0)
+        self.assertEqual(out["metrics"]["loss.sum"], 0.0)
+        self.assertTrue(torch.isfinite(engine.backward_calls[-1][0]))
+        self.assertEqual(engine.backward_calls[-1][0].item(), 0.0)
 
     def test_sft_ce_path_skips_labels_keeps_logits(self):
         engine = _StubEngine()


### PR DESCRIPTION
## Summary

When every SFT target is `-100`, Hugging Face still sets `outputs.loss` to NaN. `sft_loss` already emitted `(loss.sum, loss.tokens) = (0, 0)` but returned that NaN, so `AVG_LOSS` and `backward` were NaN. With no valid tokens it now replaces that NaN with a finite 0 (same `requires_grad`) and keeps the usual sum/metrics path, matching `sft_ce`.

