### PR TITLE
ds config bf16 default

### DIFF
--- a/arctic_platform/common/deepspeed_worker.py
+++ b/arctic_platform/common/deepspeed_worker.py
@@ -301,7 +301,9 @@ class DeepSpeedWorker:
 
         # Set reasonable defaults as fallbacks
         ds_config.setdefault("train_micro_batch_size_per_gpu", 1)
-        ds_config.setdefault("bf16", {"enabled": True})
+        fp16_on = bool((ds_config.get("fp16") or {}).get("enabled"))
+        if not fp16_on:
+            ds_config.setdefault("bf16", {"enabled": True})
         ds_config.setdefault(
             "optimizer",
             {


### PR DESCRIPTION
## Summary

- `DeepSpeedWorker.ds_training_config` no longer `setdefault`s `bf16` when the client already enabled `fp16`. Both at once is a DeepSpeed assert (`bfloat16 and fp16 modes cannot be simultaneously enabled`).

the issue got triggered via the axolotl integration PR and is tested there