### PR TITLE
[bug fix] failed training initialize leaks DeepSpeed workers

### DIFF
--- a/arctic_platform/common/deepspeed_worker.py
+++ b/arctic_platform/common/deepspeed_worker.py
@@ -25,6 +25,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import numbers
 import os
@@ -83,6 +84,24 @@ def make_model_gradient_checkpointing_compatible(model):
 # ---------------------------------------------------------------------------
 # DeepSpeed training actor
 # ---------------------------------------------------------------------------
+
+
+async def spawn_and_initialize_workers(gpus, master_port, config_dict, actor_options):
+    """Create DeepSpeed ranks and initialize them. Destroy every spawned actor if any step fails.
+
+    ``actor_options(rank)`` is the kwargs for ``DeepSpeedWorker.options``. Rank 0's host is the
+    distributed rendezvous master so off-node ranks do not hang on their own localhost.
+    """
+    workers = []
+    try:
+        for rank in range(gpus):
+            workers.append(DeepSpeedWorker.options(**actor_options(rank)).remote(rank, gpus, master_port))
+        master_addr = await workers[0].get_ip.remote()
+        await asyncio.gather(*[w.initialize.remote(master_addr, config_dict) for w in workers])
+    except Exception:
+        await asyncio.gather(*[w.destroy.remote() for w in workers], return_exceptions=True)
+        raise
+    return workers
 
 
 @ray.remote

--- a/arctic_platform/common/http_server.py
+++ b/arctic_platform/common/http_server.py
@@ -48,6 +48,7 @@ from transformers import AutoTokenizer
 from arctic_platform import wire
 from arctic_platform._dependency_groups import require_any_dep_group
 from arctic_platform.common.deepspeed_worker import DeepSpeedWorker
+from arctic_platform.common.deepspeed_worker import spawn_and_initialize_workers
 from arctic_platform.common.ray_cluster import init_ray_cluster
 from arctic_platform.common.server import ArcticRLServerState
 from arctic_platform.common.utils import http_split_batch
@@ -182,28 +183,21 @@ async def initialize(job_config: JobConfig = Body(...)):
             raise HTTPException(400, "No training GPUs configured")
         if app.state.training_workers:
             raise HTTPException(409, "Training job already running")
+        if job_config.checkpoint_path is None:
+            raise HTTPException(400, "checkpoint_path is required for training jobs")
 
-        workers = []
-        config_dict = job_config.model_dump()
         # Honor MASTER_PORT when set so concurrent training jobs on one host (e.g.
         # parallel pytest-xdist workers) don't collide on the rendezvous port.
         master_port = int(os.environ.get("MASTER_PORT", 29500))
-        for rank in range(gpus):
-            if colocate and placement:
-                opts = _pg_options(bundle_index=rank, fraction_key="training")
-            else:
-                opts = dict(num_gpus=1)
-            w = DeepSpeedWorker.options(**opts).remote(rank, gpus, master_port)
-            workers.append(w)
 
-        # Use rank 0's host as the distributed rendezvous master. Passing None
-        # falls back to "localhost" in the worker, which only works when every
-        # rank is on the same node; on multi-node clusters the off-node ranks
-        # would rendezvous against their own localhost and init_distributed()
-        # hangs forever.
-        master_addr = await workers[0].get_ip.remote()
-        await asyncio.gather(*[w.initialize.remote(master_addr, config_dict) for w in workers])
-        app.state.training_workers = workers
+        def actor_options(rank):
+            if colocate and placement:
+                return _pg_options(bundle_index=rank, fraction_key="training")
+            return dict(num_gpus=1)
+
+        app.state.training_workers = await spawn_and_initialize_workers(
+            gpus, master_port, job_config.model_dump(), actor_options
+        )
 
     elif job_type == "sampling":
         gpus = app.state.sampling_gpus
@@ -346,7 +340,6 @@ async def initialize(job_config: JobConfig = Body(...)):
     if job_type == "log_prob":
         job_info["engine"] = engine
     if job_type == "training":
-        assert job_config.checkpoint_path is not None, "checkpoint_path is required for training jobs"
         ckpt_dir = pathlib.Path(job_config.checkpoint_path) / f"arctic_rl_job_{job_id}"
         ckpt_dir.mkdir(parents=True, exist_ok=True)
         job_info["checkpoint_path"] = str(ckpt_dir)

--- a/arctic_platform/common/ray_server.py
+++ b/arctic_platform/common/ray_server.py
@@ -348,6 +348,7 @@ class ArcticRLRayServerState(ArcticRLServerState):
             master_port = (
                 self.ds_master_port if self.ds_master_port is not None else int(os.environ.get("MASTER_PORT", 29500))
             )
+
             def actor_options(rank):
                 if colocate and placement:
                     return _pg_options(bundle_index=rank, fraction_key="training")

--- a/arctic_platform/common/ray_server.py
+++ b/arctic_platform/common/ray_server.py
@@ -41,6 +41,7 @@ from transformers import AutoTokenizer
 
 from arctic_platform._dependency_groups import require_any_dep_group
 from arctic_platform.common.deepspeed_worker import DeepSpeedWorker
+from arctic_platform.common.deepspeed_worker import spawn_and_initialize_workers
 from arctic_platform.common.ray_cluster import init_ray_cluster
 from arctic_platform.common.server import ArcticRLServerState
 from arctic_platform.common.utils import finalize_fwd_bwd_metrics
@@ -340,23 +341,21 @@ class ArcticRLRayServerState(ArcticRLServerState):
                 raise ValueError("No training GPUs configured")
             if self.training_workers:
                 raise ValueError("Training job already running")
+            if job_config.checkpoint_path is None:
+                raise ValueError("checkpoint_path is required for training jobs")
             # Prefer the driver-captured port (avoids stale raylet env); fall back
             # to actor env / default. All ranks of THIS job share the same value.
             master_port = (
                 self.ds_master_port if self.ds_master_port is not None else int(os.environ.get("MASTER_PORT", 29500))
             )
-            workers = []
-            config_dict = job_config.model_dump()
-            for rank in range(gpus):
+            def actor_options(rank):
                 if colocate and placement:
-                    opts = _pg_options(bundle_index=rank, fraction_key="training")
-                else:
-                    opts = dict(num_gpus=1)
-                w = DeepSpeedWorker.options(**opts).remote(rank, gpus, master_port)
-                workers.append(w)
-            master_addr = await workers[0].get_ip.remote()
-            await asyncio.gather(*[w.initialize.remote(master_addr, config_dict) for w in workers])
-            self.training_workers = workers
+                    return _pg_options(bundle_index=rank, fraction_key="training")
+                return dict(num_gpus=1)
+
+            self.training_workers = await spawn_and_initialize_workers(
+                gpus, master_port, job_config.model_dump(), actor_options
+            )
 
         elif job_type == "sampling":
             gpus = self.sampling_gpus
@@ -509,7 +508,6 @@ class ArcticRLRayServerState(ArcticRLServerState):
             job_info["engine"] = engine
 
         if job_type == "training":
-            assert job_config.checkpoint_path is not None, "checkpoint_path is required for training jobs"
             job_info["checkpoint_path"] = os.path.join(job_config.checkpoint_path, f"arctic_rl_job_{job_id}")
             os.makedirs(job_info["checkpoint_path"], exist_ok=True)
             job_info["sync_path"] = os.path.join(job_info["checkpoint_path"], "weight_sync.pt")

--- a/tests/common/test_initialize_cleanup.py
+++ b/tests/common/test_initialize_cleanup.py
@@ -1,0 +1,189 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Failed training initialize must not leave DeepSpeed workers or a stuck job slot."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from arctic_platform.common.utils.server_models import JobConfig
+from arctic_platform.testing_utils import TestCasePlus
+
+
+class _Remote:
+    def __init__(self, fn):
+        self._fn = fn
+
+    def remote(self, *args, **kwargs):
+        return self._fn(*args, **kwargs)
+
+
+class FakeWorker:
+    def __init__(self, fail_initialize=False):
+        self.destroy_calls = 0
+        self.fail_initialize = fail_initialize
+        self.get_ip = _Remote(self._get_ip)
+        self.initialize = _Remote(self._initialize)
+        self.destroy = _Remote(self._destroy)
+
+    async def _get_ip(self):
+        return "127.0.0.1"
+
+    async def _initialize(self, *args, **kwargs):
+        if self.fail_initialize:
+            raise RuntimeError("worker initialize failed")
+
+    async def _destroy(self):
+        self.destroy_calls += 1
+
+
+class _WorkerFactory:
+    def __init__(self, created, fail_initialize=False):
+        self.created = created
+        self.fail_initialize = fail_initialize
+
+    def remote(self, *args, **kwargs):
+        w = FakeWorker(fail_initialize=self.fail_initialize)
+        self.created.append(w)
+        return w
+
+
+def _http_state(*, training_gpus=1):
+    from arctic_platform.common.http_server import app
+
+    app.state.training_gpus = training_gpus
+    app.state.sampling_gpus = 0
+    app.state.log_prob_gpus = 0
+    app.state.colocate = False
+    app.state.placement = None
+    app.state.training_workers = []
+    app.state.log_prob_workers = []
+    app.state.jobs = {}
+    app.state.next_job_id = 1
+    return app
+
+
+def _ray_stub(*, training_gpus=1):
+    from arctic_platform.common.ray_server import ArcticRLRayServerState
+
+    server = object.__new__(ArcticRLRayServerState)
+    server.training_gpus = training_gpus
+    server.sampling_gpus = 0
+    server.log_prob_gpus = 0
+    server.colocate = False
+    server.placement = None
+    server.ds_master_port = 29500
+    server.training_workers = []
+    server.jobs = {}
+    server.next_job_id = 1
+    return server
+
+
+class TestFailedTrainingInitializeCleanup(TestCasePlus):
+    def test_http_missing_checkpoint_path_leaves_no_workers(self):
+        from fastapi import HTTPException
+
+        from arctic_platform.common.http_server import initialize
+
+        app = _http_state()
+        created = []
+        factory = _WorkerFactory(created)
+        with patch("arctic_platform.common.deepspeed_worker.DeepSpeedWorker.options", return_value=factory):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(initialize(JobConfig(model_name="m", job_type="training")))
+            self.assertEqual(ctx.exception.status_code, 400)
+            self.assertEqual(app.state.training_workers, [])
+            self.assertEqual(app.state.jobs, {})
+            self.assertEqual(created, [])
+
+            out = asyncio.run(
+                initialize(
+                    JobConfig(
+                        model_name="m",
+                        job_type="training",
+                        checkpoint_path=str(self.get_auto_remove_tmp_dir()),
+                    )
+                )
+            )
+        self.assertTrue(out["running"])
+        self.assertEqual(len(app.state.training_workers), 1)
+        self.assertEqual(len(app.state.jobs), 1)
+
+    def test_http_worker_init_failure_destroys_actors(self):
+        from arctic_platform.common.http_server import initialize
+
+        app = _http_state()
+        created = []
+        factory = _WorkerFactory(created, fail_initialize=True)
+        with patch("arctic_platform.common.deepspeed_worker.DeepSpeedWorker.options", return_value=factory):
+            with self.assertRaises(RuntimeError):
+                asyncio.run(
+                    initialize(
+                        JobConfig(
+                            model_name="m",
+                            job_type="training",
+                            checkpoint_path=str(self.get_auto_remove_tmp_dir()),
+                        )
+                    )
+                )
+        self.assertEqual(app.state.training_workers, [])
+        self.assertEqual(app.state.jobs, {})
+        self.assertTrue(created)
+        self.assertTrue(all(w.destroy_calls == 1 for w in created))
+
+    def test_ray_missing_checkpoint_path_leaves_no_workers(self):
+        server = _ray_stub()
+        created = []
+        factory = _WorkerFactory(created)
+        with patch("arctic_platform.common.deepspeed_worker.DeepSpeedWorker.options", return_value=factory):
+            with self.assertRaises(ValueError):
+                asyncio.run(server.initialize({"model_name": "m", "job_type": "training"}))
+            self.assertEqual(server.training_workers, [])
+            self.assertEqual(server.jobs, {})
+            self.assertEqual(created, [])
+
+            out = asyncio.run(
+                server.initialize(
+                    {
+                        "model_name": "m",
+                        "job_type": "training",
+                        "checkpoint_path": str(self.get_auto_remove_tmp_dir()),
+                    }
+                )
+            )
+        self.assertTrue(out["running"])
+        self.assertEqual(len(server.training_workers), 1)
+        self.assertEqual(len(server.jobs), 1)
+
+    def test_ray_worker_init_failure_destroys_actors(self):
+        server = _ray_stub()
+        created = []
+        factory = _WorkerFactory(created, fail_initialize=True)
+        with patch("arctic_platform.common.deepspeed_worker.DeepSpeedWorker.options", return_value=factory):
+            with self.assertRaises(RuntimeError):
+                asyncio.run(
+                    server.initialize(
+                        {
+                            "model_name": "m",
+                            "job_type": "training",
+                            "checkpoint_path": str(self.get_auto_remove_tmp_dir()),
+                        }
+                    )
+                )
+        self.assertEqual(server.training_workers, [])
+        self.assertEqual(server.jobs, {})
+        self.assertTrue(created)
+        self.assertTrue(all(w.destroy_calls == 1 for w in created))


### PR DESCRIPTION
## Summary

Training `/initialize` spawned DeepSpeed workers, then asserted `checkpoint_path` before registering the job. A missing path 500'd with workers still set, so destroy was 404 and the next initialize was 409. HTTP and Ray now reject a missing path before spawn. Spawn+init+destroy-on-failure lives in one helper both servers call.

## Testing

- Repro failed on current `main` (`AssertionError` after workers were assigned). After the fix, `tests/common/test_initialize_cleanup.py` — 4 passed, and `tests/common` — 18 passed, on `stas-dev-2-0` (`conda` `dev`).
