### PR TITLE
[bug fix] default seed setting like Cortex

### DIFF
--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -220,7 +220,9 @@ class ArcticRLClientConfig(BaseModel):
     def to_onprem(self, job_type: str) -> dict[str, Any]:
         """Translate into one on-prem ``/initialize`` payload (see ArcticRLHTTPClient)."""
         tc, sc = self.training, self.sampling
-        payload: dict[str, Any] = {"model_name": self.model_name, "job_type": job_type, "seed": self.seed}
+        payload: dict[str, Any] = {"model_name": self.model_name, "job_type": job_type}
+        if self.seed is not None:
+            payload["seed"] = self.seed
         # log-prob runs on DeepSpeed only when asked; otherwise it's a vLLM engine.
         use_deepspeed = job_type == "training" or (job_type == "log_prob" and sc.log_prob_engine == "deepspeed")
         if use_deepspeed:

--- a/arctic_platform/common/utils/server_models.py
+++ b/arctic_platform/common/utils/server_models.py
@@ -22,6 +22,9 @@ from typing import Any
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
+
+DEFAULT_SEED = 42
 
 
 class JobConfig(BaseModel):
@@ -38,11 +41,16 @@ class JobConfig(BaseModel):
     checkpoint_path: str | None = None
     arctic_inference_config: dict | None = None
     full_determinism: bool = False
-    seed: int = 42
+    seed: int = DEFAULT_SEED
     # Weight-sync strategy for the source (training) job. A WeightSyncRequest may override either field for one call.
     # Meaningful only on a training job.
     cuda_ipc: bool = False
     low_memory: bool = False
+
+    @field_validator("seed", mode="before")
+    @classmethod
+    def _coerce_null_seed(cls, value: Any) -> Any:
+        return DEFAULT_SEED if value is None else value
 
 
 class GenerateRequest(BaseModel):

--- a/tests/sft/test_sft_config.py
+++ b/tests/sft/test_sft_config.py
@@ -71,9 +71,11 @@ class TestArcticSFTClientConfig(TestCasePlus):
         self.assertEqual(rl.sampling.vllm["tensor_parallel_size"], 1)
 
     def test_job_config_null_seed_uses_default(self):
-        """JSON null / Python None is the documented client default; initialize must accept it."""
+        """JSON null is accepted on /initialize; missing seed uses the server default."""
         job = JobConfig.model_validate({"model_name": "m", "seed": None})
         self.assertEqual(job.seed, 42)
+        omitted = JobConfig.model_validate({"model_name": "m"})
+        self.assertEqual(omitted.seed, 42)
 
     def test_job_config_explicit_seed_preserved(self):
         job = JobConfig.model_validate({"model_name": "m", "seed": 7})
@@ -81,11 +83,17 @@ class TestArcticSFTClientConfig(TestCasePlus):
         job0 = JobConfig.model_validate({"model_name": "m", "seed": 0})
         self.assertEqual(job0.seed, 0)
 
-    def test_default_seed_initialize_payload_is_accepted(self):
-        """Default SFT/RL client seed is None and is sent on /initialize; JobConfig must accept it."""
+    def test_default_seed_is_omitted_from_initialize_payload(self):
+        """Unset client seed is omitted on /initialize, same as Cortex; JobConfig still accepts the payload."""
         cfg = ArcticSFTClientConfig(model_name="m", training_gpus=2, checkpoint_path="/tmp/c")
         self.assertIsNone(cfg.seed)
         payload = cfg.to_rl_config().to_onprem("training")
-        self.assertIsNone(payload["seed"])
+        self.assertNotIn("seed", payload)
         job = JobConfig.model_validate(payload)
         self.assertEqual(job.seed, 42)
+
+    def test_explicit_seed_is_sent_on_initialize_payload(self):
+        cfg = ArcticSFTClientConfig(model_name="m", training_gpus=2, checkpoint_path="/tmp/c", seed=0)
+        payload = cfg.to_rl_config().to_onprem("training")
+        self.assertEqual(payload["seed"], 0)
+        self.assertEqual(JobConfig.model_validate(payload).seed, 0)

--- a/tests/sft/test_sft_config.py
+++ b/tests/sft/test_sft_config.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from pydantic import ValidationError
 
+from arctic_platform.common.utils.server_models import JobConfig
 from arctic_platform.sft import ArcticSFTClientConfig
 from arctic_platform.testing_utils import TestCasePlus
 
@@ -68,3 +69,23 @@ class TestArcticSFTClientConfig(TestCasePlus):
         self.assertEqual(rl.sampling_gpus, 1)
         self.assertTrue(rl.backend.colocate)
         self.assertEqual(rl.sampling.vllm["tensor_parallel_size"], 1)
+
+    def test_job_config_null_seed_uses_default(self):
+        """JSON null / Python None is the documented client default; initialize must accept it."""
+        job = JobConfig.model_validate({"model_name": "m", "seed": None})
+        self.assertEqual(job.seed, 42)
+
+    def test_job_config_explicit_seed_preserved(self):
+        job = JobConfig.model_validate({"model_name": "m", "seed": 7})
+        self.assertEqual(job.seed, 7)
+        job0 = JobConfig.model_validate({"model_name": "m", "seed": 0})
+        self.assertEqual(job0.seed, 0)
+
+    def test_default_seed_initialize_payload_is_accepted(self):
+        """Default SFT/RL client seed is None and is sent on /initialize; JobConfig must accept it."""
+        cfg = ArcticSFTClientConfig(model_name="m", training_gpus=2, checkpoint_path="/tmp/c")
+        self.assertIsNone(cfg.seed)
+        payload = cfg.to_rl_config().to_onprem("training")
+        self.assertIsNone(payload["seed"])
+        job = JobConfig.model_validate(payload)
+        self.assertEqual(job.seed, 42)


### PR DESCRIPTION
Client `seed` is `int | None = None` ("Global seed"). Cortex already omits that field when it is unset. On-prem `to_onprem` always sent `"seed": null`, and server `JobConfig` required `int`, so the documented default was HTTP 422 / Ray pydantic `int_type`.

On-prem now matches Cortex: `to_onprem` omits `seed` when it is `None`. `0` is still sent. `JobConfig` accepts a missing key or JSON `null` as the existing server default `42`, so a raw HTTP `seed: null` does not 422. An explicit integer is unchanged. HTTP `Body` and Ray `JobConfig(**)` share this model. Seed is only applied on the worker when `full_determinism=True`.

