### PR TITLE
Add ArcticOPDClient for on-policy distillation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ Arctic Platform aims to cover the full post-training stack for LLMs behind a sma
 What is available today:
 
 * [**Arctic Reinforcement Learning**](#arctic-reinforcement-learning) — a high-throughput RL training/inference backend that plugs into existing RL frameworks ([docs/rl.md](docs/rl.md)).
+* [**On-policy distillation**](docs/opd.md) — student train+sample plus a frozen teacher (`ArcticOPDClient`); complementary to TRL DistillationTrainer, not a drop-in.
 * [**ZoRRo Train**](#zorro-train) — a prompt-deduplication optimization that removes redundant prompt computation during RL training ([docs/rl.md#zorro-train](docs/rl.md#zorro-train)).
 * [**ZoRRo Inference**](#zorro-inference) — forest cascade attention for efficient rollout step that eliminates redundant memory accesses via grouping ([docs/rl.md#zorro-inference-forest-cascade-attention](docs/rl.md#zorro-inference-forest-cascade-attention)).
 
-Full documentation index: [docs/index.md](docs/index.md) (RL, shared server infra; SFT docs forthcoming).
+Full documentation index: [docs/index.md](docs/index.md) (SFT, RL, OPD, shared server infra).
 
 What's coming next:
 
-* additional trainers (SFT/distillation), synthetic data generation and cleaning pipelines, and tighter inference integration.
+* additional trainers, synthetic data generation and cleaning pipelines, and tighter inference integration.
 
 ## Arctic Reinforcement Learning
 

--- a/arctic_platform/client/config.py
+++ b/arctic_platform/client/config.py
@@ -61,6 +61,13 @@ class OnPremConfig(BaseModel):
             "server child still sees GPUs. None = inherit the client's environment."
         ),
     )
+    server_extra_env: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Extra environment variables for a launched local server subprocess. "
+            "Used to isolate concurrent Ray clusters (student vs teacher OPD)."
+        ),
+    )
     startup_timeout: float = Field(
         600.0, description="onprem: seconds to wait for a launched server to become healthy."
     )

--- a/arctic_platform/client/transports/onprem_http.py
+++ b/arctic_platform/client/transports/onprem_http.py
@@ -177,11 +177,16 @@ class HttpTransport(OnPremTransport):
         ]
         if bc.colocate:
             cmd.append("--colocate")
+        # A launched server owns its cluster. Attaching to another head on the
+        # host (default auto_attach) would share GPUs with a sibling OPD server.
+        cmd.append("--no-ray-auto-attach")
         env = os.environ.copy()
         if bc.server_cuda_visible_devices is not None:
             # Client may run with CUDA_VISIBLE_DEVICES= (empty); give the
             # server subprocess an explicit GPU list so Ray workers see devices.
             env["CUDA_VISIBLE_DEVICES"] = bc.server_cuda_visible_devices
+        extra_env = getattr(bc, "server_extra_env", None) or {}
+        env.update({str(key): str(value) for key, value in extra_env.items()})
         self.proc = subprocess.Popen(cmd, env=env)
         try:
             self._wait_server_healthy(bc.startup_timeout)

--- a/arctic_platform/common/deepspeed_worker.py
+++ b/arctic_platform/common/deepspeed_worker.py
@@ -50,6 +50,9 @@ from arctic_platform.common.utils.debug import pr0
 from arctic_platform.common.utils.debug import see_memory_usage
 from arctic_platform.model import ModelSpec
 from arctic_platform.model import build_model
+from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import apply_qwen35_sync_op
+from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import plan_qwen35_vllm_sync
+from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import to_vllm_sync_weights
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +166,11 @@ class DeepSpeedWorker:
         ds_worker_config = job_config.get("ds_worker_config") or {}
         ds_worker_config["world_size"] = self.world_size
         self.ds_worker_config = ds_worker_config
+        # vLLM 0.26 pulls tilelang; FLA then JIT-compiles GDN backward via
+        # cute WGMMA and dies. Force the Triton path that v4 trained with.
+        if ds_worker_config.get("fla_tilelang", True) is False:
+            os.environ["FLA_TILELANG"] = "0"
+            os.environ["FLA_DISABLE_BACKEND_DISPATCH"] = "1"
 
         # Build the DeepSpeed config per job type. Training engines get an
         # optimizer; the reference/log-prob engine is forward-only and is
@@ -181,6 +189,21 @@ class DeepSpeedWorker:
         spec = ModelSpec.from_ds_worker_config(model_name, ds_worker_config)
         loaded = build_model(spec)
         model = loaded.model
+        self._maybe_inject_fp32_lm_head(model, ds_worker_config)
+
+        # Qwen3.5 instantiates a ViT even on text-only jobs. Unused trainable
+        # params produce no grads and stall ZeRO-3 reduction; freeze them
+        # before DeepSpeed registers the param set.
+        from arctic_platform.model.implementations.qwen35.vlm import freeze_unused_vision_tower
+
+        frozen = freeze_unused_vision_tower(model, self.rank)
+        if frozen:
+            logger.info(
+                "rank=%d froze %d vision-tower params (text-only job; unused params "
+                "produce no grads and stall ZeRO-3 reduction)",
+                self.rank,
+                frozen,
+            )
 
         zorro_train_enable = ds_worker_config.get("zorro_train_enable", False)
         self.dedup_actor_model_once_patcher = getattr(model, "_arctic_zorro_once_patcher", None)
@@ -367,6 +390,87 @@ class DeepSpeedWorker:
         meta_data["global_num_tokens"] = global_tokens
         meta_data["dp_size"] = self.world_size
 
+    @staticmethod
+    def _import_inject_prime_lm_head():
+        """Load ``inject_prime_lm_head`` without importing ``models`` (flash-attn cute)."""
+        import importlib.util
+        import sys
+        import types
+        from pathlib import Path
+
+        name = "arctic_platform.model.implementations.qwen35.models.layers.lm_head"
+        cached = sys.modules.get(name)
+        if cached is not None and hasattr(cached, "inject_prime_lm_head"):
+            return cached.inject_prime_lm_head
+        qwen35 = Path(__file__).resolve().parents[1] / "model" / "implementations" / "qwen35"
+        models_pkg = "arctic_platform.model.implementations.qwen35.models"
+        layers_pkg = f"{models_pkg}.layers"
+        if models_pkg not in sys.modules:
+            models = types.ModuleType(models_pkg)
+            models.__path__ = [str(qwen35 / "models")]
+            models.__package__ = models_pkg
+            sys.modules[models_pkg] = models
+        if layers_pkg not in sys.modules:
+            layers = types.ModuleType(layers_pkg)
+            layers.__path__ = [str(qwen35 / "models" / "layers")]
+            layers.__package__ = layers_pkg
+            sys.modules[layers_pkg] = layers
+        spec = importlib.util.spec_from_file_location(name, qwen35 / "models" / "layers" / "lm_head.py")
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {name} from {qwen35}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module.inject_prime_lm_head
+
+    def _maybe_inject_fp32_lm_head(self, model, ds_worker_config: dict) -> None:
+        """Chunked fp32 LM head so train logprobs match xyu (bf16 head error ~1e-2)."""
+        want_fp32 = bool(ds_worker_config.get("fp32_lm_head", False))
+        chunk = ds_worker_config.get("fused_lm_head_token_chunk_size")
+        chunk_size = chunk if isinstance(chunk, int) else None
+        if not want_fp32 and chunk_size is None:
+            return
+        inject_prime_lm_head = self._import_inject_prime_lm_head()
+
+        fused_ce = ds_worker_config.get("fused_cross_entropy", False)
+        inject_prime_lm_head(
+            model,
+            chunk_size=chunk_size,
+            fused_cross_entropy=fused_ce,
+            fp32_lm_head=want_fp32,
+        )
+        logger.info(
+            "rank=%d injected lm_head fp32=%s chunk_size=%s fused_cross_entropy=%s",
+            self.rank,
+            want_fp32,
+            chunk_size,
+            fused_ce,
+        )
+
+    def _inject_opd_global_token_config(self, loss_fn: str, batch_data, meta_data: dict, processing: dict) -> None:
+        """All-reduce ``loss_mask`` counts into OPD ``config`` + ``meta`` (like SFT).
+
+        Each microbatch then does ``sum(kl) / T_global * dp_size``. Without this,
+        ``agg_loss`` falls back to the local microbatch token count and a 29-token
+        rollout weighs the same as a 16k-token one.
+        """
+        if loss_fn != "on_policy_distill":
+            return
+        from arctic_platform.rl.processors.on_policy_distill import apply_opd_global_token_config
+        from arctic_platform.rl.processors.on_policy_distill import count_opd_loss_tokens
+
+        local_tokens, local_seqs = count_opd_loss_tokens(batch_data)
+        counts = torch.tensor([local_tokens, local_seqs], device=self._device, dtype=torch.long)
+        if torch.distributed.is_available() and torch.distributed.is_initialized() and self.world_size > 1:
+            torch.distributed.all_reduce(counts, op=torch.distributed.ReduceOp.SUM)
+        apply_opd_global_token_config(
+            processing,
+            meta_data,
+            dp_size=int(self.world_size),
+            batch_num_tokens=max(int(counts[0].item()), 1),
+            global_batch_size=max(int(counts[1].item()), 1),
+        )
+
     def _forward_maybe_backward(self, batch: dict, backward: bool) -> dict:
         # torch.autograd.set_detect_anomaly(True)
 
@@ -402,14 +506,20 @@ class DeepSpeedWorker:
                 pr0(f"[DeepSpeedWorker] {tag}: {k=}: {v.shape=}")
 
         grad_accum_steps = self.engine.gradient_accumulation_steps()
+        max_tokens_per_mb = self.ds_worker_config.get("max_tokens_per_mb")
+        pack_by_token_budget = bool(max_tokens_per_mb)
         # H3: list-of-microbatches from the client skips concat→split_dict.
+        # xyu mb_spec packs the rank shard as one padded batch; DeepSpeed GAS
+        # stays 1 so packing owns the token-budget split.
         if isinstance(batch_data, list):
             micro_batch_data = batch_data
-            if len(micro_batch_data) != grad_accum_steps:
+            if not pack_by_token_budget and len(micro_batch_data) != grad_accum_steps:
                 raise ValueError(
                     f"Received {len(micro_batch_data)} GAS microbatches but "
                     f"engine.gradient_accumulation_steps()={grad_accum_steps}"
                 )
+        elif pack_by_token_budget:
+            micro_batch_data = [batch_data]
         else:
             micro_batch_data = split_dict(batch_data, grad_accum_steps)
         num_micro_batches = len(micro_batch_data)
@@ -428,6 +538,7 @@ class DeepSpeedWorker:
 
         if use_sft_pipeline:
             self._inject_sft_global_token_meta(loss_fn, batch_data, meta_data)
+        self._inject_opd_global_token_config(loss_fn, batch_data, meta_data, processing)
 
         pr0(f"mbs {len(micro_batch_data)=} {grad_accum_steps=}")
 
@@ -476,6 +587,7 @@ class DeepSpeedWorker:
                 )
             else:
                 from arctic_platform.rl.processors import run_pipeline
+                from arctic_platform.rl.processors.microbatch import DEFAULT_MAX_TOKENS_PER_MB
 
                 micro_batch_output = run_pipeline(
                     self.engine,
@@ -485,7 +597,10 @@ class DeepSpeedWorker:
                     processing,
                     device=self._device,
                     backward=backward,
-                    pack=False,
+                    pack=pack_by_token_budget,
+                    max_tokens_per_mb=(
+                        int(max_tokens_per_mb) if pack_by_token_budget else DEFAULT_MAX_TOKENS_PER_MB
+                    ),
                     return_tensors=return_tensors,
                 )
 
@@ -552,9 +667,23 @@ class DeepSpeedWorker:
         timers.stop_and_print_elapsed(tname)
         return results
 
-    def step(self) -> dict:
+    def _apply_learning_rate(self, learning_rate: float) -> None:
+        """Set AdamW LR on the live DeepSpeed optimizer (xyu ``step(lr)``)."""
+        seen: list[object] = []
+        opt = getattr(self.engine, "optimizer", None)
+        while opt is not None and opt not in seen:
+            seen.append(opt)
+            groups = getattr(opt, "param_groups", None)
+            if groups:
+                for group in groups:
+                    group["lr"] = learning_rate
+            opt = getattr(opt, "optimizer", None)
+
+    def step(self, learning_rate: float | None = None) -> dict:
         from arctic_platform.common.utils import sft_profile
 
+        if learning_rate is not None:
+            self._apply_learning_rate(float(learning_rate))
         with sft_profile.timed("step"):
             self.engine.step()
             if sft_profile.enabled() and torch.cuda.is_available():
@@ -672,15 +801,28 @@ class DeepSpeedWorker:
         )
         return True
 
-    def get_weights(self) -> list[tuple[str, torch.Tensor]]:
+    def _qwen35_sync_ops(self):
+        names = [n for n, _ in self.engine.module.named_parameters()]
+        cached = getattr(self, "_qwen35_sync_plan", None)
+        key = tuple(names)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        ops = plan_qwen35_vllm_sync(names)
+        self._qwen35_sync_plan = (key, ops)
+        return ops
+
+    def _gather_named_weights(self) -> list[tuple[str, torch.Tensor]]:
         weights = []
         for n, p in self.engine.module.named_parameters():
             if hasattr(p, "ds_id"):
                 with deepspeed.zero.GatheredParameters([p], enabled=True):
-                    weights.append((n, p.data))
+                    weights.append((n, p.data.detach().clone()))
             else:
                 weights.append((n, p.data))
         return weights
+
+    def get_weights(self) -> list[tuple[str, torch.Tensor]]:
+        return to_vllm_sync_weights(self._gather_named_weights())
 
     def weight_norm(self) -> dict:
         """Global L2 norm of the model's parameters (sum of squares + count).
@@ -713,7 +855,7 @@ class DeepSpeedWorker:
         """Save weights to shared memory for colocated (same-GPU) transfer."""
         from arctic_inference.server.weight_sync.ipc_engine import save_weights_to_shm
 
-        weights = [(n, p.data) for n, p in self.engine.module.named_parameters()]
+        weights = to_vllm_sync_weights([(n, p.data) for n, p in self.engine.module.named_parameters()])
         return save_weights_to_shm(weights, group_id)
 
     def get_cuda_ipc_handles(self) -> dict:
@@ -736,8 +878,9 @@ class DeepSpeedWorker:
         handles = []
         self._ipc_tensor_refs = []
 
-        for name, p in self.engine.module.named_parameters():
-            weight = p.data.detach().contiguous()
+        raw = [(name, p.data.detach().contiguous()) for name, p in self.engine.module.named_parameters()]
+        for name, weight in to_vllm_sync_weights(raw):
+            weight = weight.detach().contiguous()
             self._ipc_tensor_refs.append(weight)
             handle = reduce_tensor(weight)
             handles.append({gpu_uuid: handle})
@@ -786,24 +929,22 @@ class DeepSpeedWorker:
         # merges these per-rank dicts so each replica finds its GPU's handle.
         # (Previously only rank 0 produced handles, which only worked when a
         # single sampling GPU was colocated with rank 0.)
+        raw: list[tuple[str, torch.Tensor]] = []
         for name, p in model.named_parameters():
             if hasattr(p, "ds_id"):
                 with deepspeed.zero.GatheredParameters([p], enabled=True):
-                    weight = p.data.detach().clone().contiguous()
-                    self._ipc_tensor_refs.append(weight)
-                    handle = reduce_tensor(weight)
-                    handles.append({gpu_uuid: handle})
-                    names.append(name)
-                    dtype_names.append(str(weight.dtype).split(".")[-1])
-                    shapes.append(list(weight.shape))
+                    raw.append((name, p.data.detach().clone().contiguous()))
             else:
-                weight = p.data.detach().contiguous()
-                self._ipc_tensor_refs.append(weight)
-                handle = reduce_tensor(weight)
-                handles.append({gpu_uuid: handle})
-                names.append(name)
-                dtype_names.append(str(weight.dtype).split(".")[-1])
-                shapes.append(list(weight.shape))
+                raw.append((name, p.data.detach().contiguous()))
+
+        for name, weight in to_vllm_sync_weights(raw):
+            weight = weight.detach().contiguous()
+            self._ipc_tensor_refs.append(weight)
+            handle = reduce_tensor(weight)
+            handles.append({gpu_uuid: handle})
+            names.append(name)
+            dtype_names.append(str(weight.dtype).split(".")[-1])
+            shapes.append(list(weight.shape))
 
         if hasattr(self.engine, "empty_partition_cache"):
             self.engine.empty_partition_cache()
@@ -838,7 +979,10 @@ class DeepSpeedWorker:
         on each rank inside ``get_cuda_ipc_handle`` so ZeRO-3 ``ds_id`` / live
         storage is preserved.
         """
-        return [name for name, _ in self.engine.module.named_parameters()]
+        ops = self._qwen35_sync_ops()
+        if ops is None:
+            return [name for name, _ in self.engine.module.named_parameters()]
+        return [op.dest for op in ops]
 
     def _param_by_name(self, name: str):
         """Resolve this rank's live module parameter for ``name`` (cached)."""
@@ -865,15 +1009,29 @@ class DeepSpeedWorker:
         import deepspeed
         from torch.multiprocessing.reductions import reduce_tensor
 
-        p = self._param_by_name(name)
-
         gpu_uuid = str(torch.cuda.get_device_properties(torch.cuda.current_device()).uuid)
 
-        if hasattr(p, "ds_id"):
-            with deepspeed.zero.GatheredParameters([p], enabled=True):
-                weight = p.data.detach().clone().contiguous()
+        ops = self._qwen35_sync_ops()
+        op = None
+        if ops is not None:
+            op = next((candidate for candidate in ops if candidate.dest == name), None)
+        if op is None:
+            p = self._param_by_name(name)
+            if hasattr(p, "ds_id"):
+                with deepspeed.zero.GatheredParameters([p], enabled=True):
+                    weight = p.data.detach().clone().contiguous()
+            else:
+                weight = p.data.detach().contiguous()
         else:
-            weight = p.data.detach().contiguous()
+            src_tensors = []
+            for src in op.sources:
+                p = self._param_by_name(src)
+                if hasattr(p, "ds_id"):
+                    with deepspeed.zero.GatheredParameters([p], enabled=True):
+                        src_tensors.append(p.data.detach().clone().contiguous())
+                else:
+                    src_tensors.append(p.data.detach().contiguous())
+            weight = apply_qwen35_sync_op(op, src_tensors).detach().contiguous()
 
         # Hold exactly one source tensor alive until release_ipc_handles().
         self._ipc_tensor_refs = [weight]

--- a/arctic_platform/common/http_server.py
+++ b/arctic_platform/common/http_server.py
@@ -80,7 +80,11 @@ def _replica_pool_cls():
     """Lazy import — training-only servers do not need arctic_inference / vLLM."""
     require_any_dep_group("rl")
     from arctic_inference.server.replica_pool import ReplicaPool
+    from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import (
+        install_optional_frozen_weight_sync_patch,
+    )
 
+    install_optional_frozen_weight_sync_patch()
     return ReplicaPool
 
 
@@ -460,10 +464,10 @@ async def forward(
 
 @app.post("/step")
 async def step(job_id: int, request: StepRequest = Body(default=StepRequest())):
-    # `learning_rate` is accepted for Cortex parity; on-prem uses the DeepSpeed
-    # scheduler's LR, so it is not applied here.
     _verify_job(job_id, "training")
-    results = await asyncio.gather(*[w.step.remote() for w in app.state.training_workers])
+    results = await asyncio.gather(
+        *[w.step.remote(learning_rate=request.learning_rate) for w in app.state.training_workers]
+    )
     merged = dict(
         job_id=job_id,
         metrics=merge_dict_shards([r["metrics"] for r in results]),

--- a/arctic_platform/common/ray_cluster.py
+++ b/arctic_platform/common/ray_cluster.py
@@ -183,6 +183,12 @@ def init_ray_cluster(auto_attach: bool = True) -> None:
     max_worker_port = os.environ.get("ARL_RAY_MAX_WORKER_PORT")
     if min_worker_port and max_worker_port:
         start_cmd += [f"--min-worker-port={min_worker_port}", f"--max-worker-port={max_worker_port}"]
+    client_server_port = os.environ.get("RAY_CLIENT_SERVER_PORT")
+    if client_server_port:
+        start_cmd += [f"--ray-client-server-port={client_server_port}"]
+    dashboard_agent_port = os.environ.get("RAY_DASHBOARD_AGENT_LISTEN_PORT")
+    if dashboard_agent_port:
+        start_cmd += [f"--dashboard-agent-listen-port={dashboard_agent_port}"]
     subprocess.run(
         start_cmd,
         check=True,

--- a/arctic_platform/common/ray_cluster.py
+++ b/arctic_platform/common/ray_cluster.py
@@ -20,8 +20,9 @@
 
 Behaviour:
 1. If a Ray cluster is already running, attach to it.
-2. Otherwise start a head node locally and, if ``/job/hostfile`` lists remote
-   hosts, fan out ``ray start`` via ``pdsh``.
+2. Otherwise start a head node locally and, if the active hostfile
+   (``ARL_RAY_HOSTFILE`` or ``/job/hostfile``) lists remote hosts, fan out
+   ``ray start`` via ``pdsh``.
 3. On exit, only tear down a cluster this process started.
 """
 
@@ -44,7 +45,7 @@ from arctic_platform.common.utils.debug import pr0
 
 logger = logging.getLogger(__name__)
 
-_HOSTFILE = "/job/hostfile"
+_DEFAULT_HOSTFILE = "/job/hostfile"
 _DEFAULT_RAY_PORT = 6379
 _DEFAULT_RAY_DASHBOARD_PORT = 8265
 
@@ -97,16 +98,25 @@ def primary_ip() -> str:
         s.close()
 
 
-def _peer_hosts() -> list[str]:
-    """Return remote host entries from ``/job/hostfile``, excluding this machine."""
+def hostfile_path() -> str:
+    """Hostfile used to fan out ``ray start``. Override with ``ARL_RAY_HOSTFILE``."""
+    return os.environ.get("ARL_RAY_HOSTFILE", _DEFAULT_HOSTFILE)
+
+
+def hostfile_hosts(path: str | None = None) -> list[str]:
+    """Return host entries from a hostfile, ignoring comments and blank lines."""
     try:
-        with open(_HOSTFILE, encoding="utf-8") as f:
+        with open(path or hostfile_path(), encoding="utf-8") as f:
             lines = f.readlines()
     except OSError:
         return []
+    return [ln.split()[0] for ln in lines if ln.strip() and not ln.strip().startswith("#")]
+
+
+def _peer_hosts() -> list[str]:
+    """Return remote host entries from the active hostfile, excluding this machine."""
     head = primary_ip()
-    hosts = [ln.split()[0] for ln in lines if ln.strip() and not ln.strip().startswith("#")]
-    return [h for h in hosts if h != head]
+    return [h for h in hostfile_hosts() if h != head]
 
 
 def _pdsh(hosts: list[str], cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
@@ -197,20 +207,34 @@ def init_ray_cluster(auto_attach: bool = True) -> None:
     )
     pr0(f"[init_ray_cluster] ray started with port {ray_port} and dashboard port {dashboard_port}")
 
-    # 3. Start workers on peer nodes (if any).
+    # 3. Start workers on peer nodes (if any). Unset CUDA_VISIBLE_DEVICES on the
+    # remote so a head that is hiding local GPUs (OPD teacher on a disjoint
+    # hostfile) does not hide GPUs on the worker node if ssh forwards the env.
     peers = _peer_hosts()
-    pr0(f"[init_ray_cluster] peers: {peers}")
+    pr0(f"[init_ray_cluster] hostfile={hostfile_path()} peers={peers}")
     gcs = read_ray_address(_spawned_temp_dir)
     if peers:
         logger.info("Starting Ray workers on %s (address=%s)", peers, gcs)
         result = _pdsh(
             peers,
-            [r, "start", f"--address={gcs}", f"--temp-dir={_spawned_temp_dir}", "--disable-usage-stats"],
+            [
+                "env",
+                "-u",
+                "CUDA_VISIBLE_DEVICES",
+                r,
+                "start",
+                f"--address={gcs}",
+                f"--temp-dir={_spawned_temp_dir}",
+                "--disable-usage-stats",
+            ],
             check=False,
             timeout=600,
         )
         if result.returncode != 0:
-            logger.warning("pdsh ray start returned exit code %d", result.returncode)
+            raise RuntimeError(
+                f"pdsh ray start on {peers} failed with exit code {result.returncode} "
+                f"(missing remote env/python is a common cause)"
+            )
 
     _spawned_cluster = True
     # Use the explicit GCS address instead of ``auto`` so we don't accidentally
@@ -218,12 +242,18 @@ def init_ray_cluster(auto_attach: bool = True) -> None:
     ray.init(address=gcs, ignore_reinit_error=True, log_to_driver=True)
     pr0(f"[init_ray_cluster] ray initialized with address {gcs}")
     resources = ray.available_resources()
+    n_gpu = float(resources.get("GPU", 0))
     logger.info(
         "Ray cluster: %.0f GPU(s), %.0f CPU(s), %d node(s)",
-        resources.get("GPU", 0),
+        n_gpu,
         resources.get("CPU", 0),
         sum(1 for k in resources if k.startswith("node:")),
     )
+    if peers and n_gpu <= 0:
+        raise RuntimeError(
+            f"Ray peers {peers} produced a cluster with 0 GPUs; "
+            "refusing to schedule workers that would block forever"
+        )
 
 
 def _reset_cached_ray_address() -> None:

--- a/arctic_platform/common/ray_server.py
+++ b/arctic_platform/common/ray_server.py
@@ -70,7 +70,11 @@ def _replica_pool_cls():
     """Lazy import — training-only servers do not need arctic_inference / vLLM."""
     require_any_dep_group("rl")
     from arctic_inference.server.replica_pool import ReplicaPool
+    from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import (
+        install_optional_frozen_weight_sync_patch,
+    )
 
+    install_optional_frozen_weight_sync_patch()
     return ReplicaPool
 
 
@@ -742,10 +746,9 @@ class ArcticRLRayServer:
         return merged
 
     async def step(self, job_id: int, body: dict[str, Any] | None = None) -> dict[str, Any]:
-        # `body` is unused; accepted so the client can call with (job_id, body).
         self._verify_job(job_id, "training")
-        # results = await asyncio.gather(*[w.step.remote() for w in self.training_workers])
-        refs = [w.step.remote() for w in self.training_workers]
+        learning_rate = (body or {}).get("learning_rate")
+        refs = [w.step.remote(learning_rate=learning_rate) for w in self.training_workers]
         results = ray.get(refs)
         merged = dict(
             job_id=job_id,

--- a/arctic_platform/common/utils/server_models.py
+++ b/arctic_platform/common/utils/server_models.py
@@ -150,6 +150,10 @@ def build_model_config(
     from arctic_inference.server.config import ModelConfig
 
     cfg = dict(vllm_config or {})
+    cfg.setdefault(
+        "worker_extension_cls",
+        "arctic_platform.common.weight_sync_extension.TextOnlyWeightSyncExtension",
+    )
     cfg["model"] = model_name
     known_fields = set(ModelConfig.model_fields.keys())
     cfg.update(parse_arctic_inference_rollout(arctic_inference_config, known_fields))

--- a/arctic_platform/common/utils/server_models.py
+++ b/arctic_platform/common/utils/server_models.py
@@ -46,7 +46,9 @@ class JobConfig(BaseModel):
 
 
 class GenerateRequest(BaseModel):
-    prompts: list[str]
+    # Token-id prompts are required for exact teacher scoring in on-policy
+    # distillation; accepting text only would retokenize sampled completions.
+    prompts: list[str | list[int]]
     sampling_params: dict[str, Any] | None = None
     routing_key: Any = None
     strict: bool = False
@@ -92,6 +94,7 @@ class WeightSyncRequest(BaseModel):
     # cuda_ipc / low_memory: None uses the training job's JobConfig values.
     source_sub_job_id: int
     target_sub_job_ids: list[int]
+    weight_format: str | None = None
     cuda_ipc: bool | None = None
     low_memory: bool | None = None
 

--- a/arctic_platform/common/weight_sync_extension.py
+++ b/arctic_platform/common/weight_sync_extension.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM worker extension loaded inside EngineCore for weight-sync name checks.
+
+Monkey-patching ``WeightSyncExtension`` in the HTTP/Ray parent process does not
+reach the EngineCore subprocess. Register this class via ``worker_extension_cls``
+so the optional vision/MTP filter runs where names are validated.
+"""
+
+from __future__ import annotations
+
+from arctic_inference.server.weight_sync.receiver import WeightSyncExtension
+from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import (
+    expected_hf_names_for_text_sync,
+)
+
+WORKER_EXTENSION_CLS = (
+    "arctic_platform.common.weight_sync_extension.TextOnlyWeightSyncExtension"
+)
+
+
+class TextOnlyWeightSyncExtension(WeightSyncExtension):
+    """Same as arctic-inference's extension, but missing ``visual.*`` / ``mtp.*`` are ok."""
+
+    def _validate_weight_sync_names(self, model, sender_names, *, context: str = ""):
+        from arctic_inference.server.weight_sync import utils as ws_utils
+
+        orig_compute = ws_utils.compute_expected_hf_param_names
+        sender_set = {n for n in sender_names if not ws_utils._name_is_non_synced(n)}
+
+        def _compute_expected(module):
+            return expected_hf_names_for_text_sync(orig_compute(module), sender_set)
+
+        ws_utils.compute_expected_hf_param_names = _compute_expected
+        try:
+            return super()._validate_weight_sync_names(model, sender_names, context=context)
+        finally:
+            ws_utils.compute_expected_hf_param_names = orig_compute

--- a/arctic_platform/model/implementations/qwen35/deepspeed_integration.py
+++ b/arctic_platform/model/implementations/qwen35/deepspeed_integration.py
@@ -40,6 +40,7 @@ from .model_builder import (
 from .models.layers.lm_head import inject_prime_lm_head
 from .models.layers.moe import FeedForward, LatentMoE, MoE
 from .parallel_dims import ParallelDims
+from .hf_vllm_weight_sync import pack_qwen35_gdn_layer
 from .vlm import get_language_model
 
 
@@ -172,19 +173,7 @@ def _convert_qwen3_5_moe_layer_to_vllm(
         if old in layer_sd:
             layer_sd[new] = layer_sd.pop(old)
 
-    qkv_key = f"{prefix}.linear_attn.in_proj_qkv.weight"
-    z_key = f"{prefix}.linear_attn.in_proj_z.weight"
-    if qkv_key in layer_sd and z_key in layer_sd:
-        qkv = layer_sd.pop(qkv_key)
-        z = layer_sd.pop(z_key)
-        layer_sd[f"{prefix}.linear_attn.in_proj_qkvz.weight"] = torch.cat([qkv, z], dim=0)
-
-    b_key = f"{prefix}.linear_attn.in_proj_b.weight"
-    a_key = f"{prefix}.linear_attn.in_proj_a.weight"
-    if b_key in layer_sd and a_key in layer_sd:
-        b = layer_sd.pop(b_key)
-        a = layer_sd.pop(a_key)
-        layer_sd[f"{prefix}.linear_attn.in_proj_ba.weight"] = torch.cat([b, a], dim=0)
+    pack_qwen35_gdn_layer(layer_sd, prefix)
 
     for buf_key in (f"{prefix}.mlp.expert_bias", f"{prefix}.mlp.tokens_per_expert"):
         layer_sd.pop(buf_key, None)

--- a/arctic_platform/model/implementations/qwen35/hf_vllm_weight_sync.py
+++ b/arctic_platform/model/implementations/qwen35/hf_vllm_weight_sync.py
@@ -1,0 +1,212 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HF Qwen3.5 → vLLM storage layout for training→sampling weight sync.
+
+HuggingFace ``AutoModelForCausalLM`` ships unpacked GDN projections under
+``model.*``. vLLM's ``Qwen3_5ForConditionalGeneration`` stores a fused GDN
+layout under ``language_model.model.*`` plus a frozen vision tower. NCCL
+TP=1 copies by name into vLLM param views, so the sender must emit that
+storage layout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+from typing import Sequence
+
+import torch
+
+_UNPACKED_GDN_SUFFIX = "linear_attn.in_proj_qkv.weight"
+_QKV_SUFFIX = ".linear_attn.in_proj_qkv.weight"
+_CONV1D_SUFFIX = ".linear_attn.conv1d.weight"
+
+
+def has_unpacked_qwen35_gdn(names: Iterable[str]) -> bool:
+    """True when the name set is HF Qwen3.5 GDN (not Qwen3 / Qwen3-Next)."""
+    return any(name.endswith(_UNPACKED_GDN_SUFFIX) for name in names)
+
+
+def is_optional_frozen_vllm_param(name: str) -> bool:
+    """Vision / MTP params that text-only OPD does not train or ship."""
+    if name.startswith("visual.") or name.startswith("model.visual."):
+        return True
+    if name.startswith("mtp.") or name.startswith("model.mtp."):
+        return True
+    return ".mtp." in name
+
+
+def expected_hf_names_for_text_sync(expected: set[str], sender_names: Iterable[str]) -> set[str]:
+    """Drop frozen vision/MTP names from *expected* unless the sender shipped them."""
+    sender_set = set(sender_names)
+    return {n for n in expected if n in sender_set or not is_optional_frozen_vllm_param(n)}
+
+
+def pack_qwen35_gdn_layer(layer_sd: dict, prefix: str) -> dict:
+    """Pack unpacked HF GDN projections into vLLM fused ``in_proj_qkvz`` / ``in_proj_ba``.
+
+    Row order matches vLLM ``Qwen3_5GatedDeltaNet``:
+    ``in_proj_qkvz = cat([qkv, z], dim=0)``, ``in_proj_ba = cat([b, a], dim=0)``.
+    Mutates ``layer_sd`` in place (same contract as the MoE layer converter).
+    """
+    qkv_key = f"{prefix}.linear_attn.in_proj_qkv.weight"
+    z_key = f"{prefix}.linear_attn.in_proj_z.weight"
+    if qkv_key in layer_sd and z_key in layer_sd:
+        qkv = layer_sd.pop(qkv_key)
+        z = layer_sd.pop(z_key)
+        layer_sd[f"{prefix}.linear_attn.in_proj_qkvz.weight"] = torch.cat([qkv, z], dim=0)
+
+    b_key = f"{prefix}.linear_attn.in_proj_b.weight"
+    a_key = f"{prefix}.linear_attn.in_proj_a.weight"
+    if b_key in layer_sd and a_key in layer_sd:
+        b = layer_sd.pop(b_key)
+        a = layer_sd.pop(a_key)
+        layer_sd[f"{prefix}.linear_attn.in_proj_ba.weight"] = torch.cat([b, a], dim=0)
+    return layer_sd
+
+
+def to_vllm_param_name(name: str) -> str | None:
+    """Map an HF / Prime-RL Qwen3.5 name onto vLLM's VLM internal name.
+
+    Returns ``None`` for frozen vision / MTP params that should not be synced.
+    """
+    if is_optional_frozen_vllm_param(name):
+        return None
+    if name.startswith("model.language_model."):
+        return "language_model.model." + name[len("model.language_model.") :]
+    if name.startswith("lm_head."):
+        return "language_model.lm_head." + name[len("lm_head.") :]
+    if name.startswith("model."):
+        return "language_model.model." + name[len("model.") :]
+    return name
+
+
+@dataclass(frozen=True)
+class _SyncOp:
+    dest: str
+    sources: tuple[str, ...]
+    kind: str  # copy | cat0 | unsqueeze1
+
+
+def _gdn_layer_prefix(qkv_name: str) -> str:
+    if not qkv_name.endswith(_QKV_SUFFIX):
+        raise ValueError(f"not an unpacked GDN qkv name: {qkv_name!r}")
+    return qkv_name[: -len(_QKV_SUFFIX)]
+
+
+def plan_qwen35_vllm_sync(names: Sequence[str]) -> list[_SyncOp] | None:
+    """Build copy/pack ops from HF names. ``None`` means leave the list unchanged."""
+    if not has_unpacked_qwen35_gdn(names):
+        return None
+
+    name_set = set(names)
+    consumed: set[str] = set()
+    ops: list[_SyncOp] = []
+
+    for name in names:
+        if not name.endswith(_UNPACKED_GDN_SUFFIX):
+            continue
+        prefix = _gdn_layer_prefix(name)
+        qkv_key = f"{prefix}.linear_attn.in_proj_qkv.weight"
+        z_key = f"{prefix}.linear_attn.in_proj_z.weight"
+        b_key = f"{prefix}.linear_attn.in_proj_b.weight"
+        a_key = f"{prefix}.linear_attn.in_proj_a.weight"
+        if qkv_key in name_set and z_key in name_set:
+            dest = to_vllm_param_name(f"{prefix}.linear_attn.in_proj_qkvz.weight")
+            if dest is not None:
+                ops.append(_SyncOp(dest, (qkv_key, z_key), "cat0"))
+            consumed.update((qkv_key, z_key))
+        if b_key in name_set and a_key in name_set:
+            dest = to_vllm_param_name(f"{prefix}.linear_attn.in_proj_ba.weight")
+            if dest is not None:
+                ops.append(_SyncOp(dest, (b_key, a_key), "cat0"))
+            consumed.update((b_key, a_key))
+
+    has_embed = any(name.endswith("embed_tokens.weight") for name in names)
+    for name in names:
+        if name in consumed or is_optional_frozen_vllm_param(name):
+            continue
+        # vLLM ties language_model.lm_head to embed_tokens; a separate lm_head
+        # name is unexpected on the DirectParamWriter path.
+        if has_embed and name.endswith("lm_head.weight"):
+            continue
+        dest = to_vllm_param_name(name)
+        if dest is None:
+            continue
+        kind = "unsqueeze1" if name.endswith(_CONV1D_SUFFIX) else "copy"
+        ops.append(_SyncOp(dest, (name,), kind))
+    return ops
+
+
+def apply_qwen35_sync_op(op: _SyncOp, tensors: Sequence[torch.Tensor]) -> torch.Tensor:
+    if op.kind == "cat0":
+        return torch.cat(list(tensors), dim=0)
+    if op.kind == "unsqueeze1":
+        tensor = tensors[0]
+        return tensor.unsqueeze(1) if tensor.ndim == 2 else tensor
+    return tensors[0]
+
+
+def to_vllm_sync_weights(
+    weights: Sequence[tuple[str, torch.Tensor]],
+) -> list[tuple[str, torch.Tensor]]:
+    """Convert HF named weights to the vLLM storage layout, or return ``weights`` unchanged."""
+    names = [name for name, _ in weights]
+    ops = plan_qwen35_vllm_sync(names)
+    if ops is None:
+        return list(weights)
+    by_name = dict(weights)
+    out: list[tuple[str, torch.Tensor]] = []
+    for op in ops:
+        tensors = [by_name[src] for src in op.sources]
+        out.append((op.dest, apply_qwen35_sync_op(op, tensors)))
+    return out
+
+
+def install_optional_frozen_weight_sync_patch() -> None:
+    """Ignore missing ``visual.*`` / ``mtp.*`` in arctic-inference name validation.
+
+    Text-only Qwen3.5 training does not ship the vLLM vision tower. Unexpected
+    LM names still fail. Does not set ``ARCTIC_WEIGHT_SYNC_STRICT_NAMES=0``.
+    Idempotent. No-op when arctic-inference is not installed.
+    """
+    try:
+        from arctic_inference.server.weight_sync.receiver import WeightSyncExtension
+    except ImportError:
+        return
+
+    if getattr(WeightSyncExtension, "_arctic_optional_frozen_params", False):
+        return
+
+    orig = WeightSyncExtension._validate_weight_sync_names
+
+    def _validate_weight_sync_names(self, model, sender_names, *, context: str = ""):
+        from arctic_inference.server.weight_sync import utils as ws_utils
+
+        orig_compute = ws_utils.compute_expected_hf_param_names
+        sender_set = {n for n in sender_names if not ws_utils._name_is_non_synced(n)}
+
+        def _compute_expected(module):
+            return expected_hf_names_for_text_sync(orig_compute(module), sender_set)
+
+        ws_utils.compute_expected_hf_param_names = _compute_expected
+        try:
+            return orig(self, model, sender_names, context=context)
+        finally:
+            ws_utils.compute_expected_hf_param_names = orig_compute
+
+    WeightSyncExtension._validate_weight_sync_names = _validate_weight_sync_names
+    WeightSyncExtension._arctic_optional_frozen_params = True

--- a/arctic_platform/model/implementations/qwen35/vlm.py
+++ b/arctic_platform/model/implementations/qwen35/vlm.py
@@ -87,6 +87,27 @@ def get_layer_prefix(model_config: PretrainedConfig, override: str | None = None
     return DEFAULT_LAYER_PREFIX
 
 
+def freeze_unused_vision_tower(model: nn.Module, rank: int = 0) -> int:
+    """Freeze a VLM vision tower that a text-only job will never activate.
+
+    Qwen3.5 checkpoints ship a composite config, so ``AutoModelForCausalLM``
+    instantiates language model plus ViT even for pure-text distillation.
+    Those vision params produce no gradients; ZeRO-3 waits on every trainable
+    param at the accumulation boundary and can stall. Returns the number of
+    parameters frozen (0 when there is no vision tower).
+    """
+    vision_encoder = get_vision_encoder(model)
+    if vision_encoder is None:
+        return 0
+
+    frozen = 0
+    for param in vision_encoder.parameters():
+        if param.requires_grad:
+            param.requires_grad_(False)
+            frozen += 1
+    return frozen
+
+
 def _get_model_info(model: nn.Module) -> VLMModelInfo | None:
     model_type = getattr(getattr(model, "config", None), "model_type", None)
     return VLM_REGISTRY.get(model_type) if model_type else None

--- a/arctic_platform/opd/__init__.py
+++ b/arctic_platform/opd/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arctic on-policy distillation client."""
+
+from arctic_platform.opd.client import ArcticOPDClient
+from arctic_platform.opd.client import DEFAULT_PROCESSING
+from arctic_platform.opd.client import create_arctic_opd_client
+from arctic_platform.opd.config import ArcticOPDClientConfig
+from arctic_platform.opd.scoring import score_teacher
+
+__all__ = [
+    "ArcticOPDClient",
+    "ArcticOPDClientConfig",
+    "DEFAULT_PROCESSING",
+    "create_arctic_opd_client",
+    "score_teacher",
+]

--- a/arctic_platform/opd/__init__.py
+++ b/arctic_platform/opd/__init__.py
@@ -1,10 +1,22 @@
 # Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Arctic on-policy distillation client."""
 
-from arctic_platform.opd.client import ArcticOPDClient
 from arctic_platform.opd.client import DEFAULT_PROCESSING
+from arctic_platform.opd.client import ArcticOPDClient
 from arctic_platform.opd.client import create_arctic_opd_client
 from arctic_platform.opd.config import ArcticOPDClientConfig
 from arctic_platform.opd.scoring import score_teacher

--- a/arctic_platform/opd/__init__.py
+++ b/arctic_platform/opd/__init__.py
@@ -13,13 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Arctic on-policy distillation client."""
+"""Arctic on-policy distillation client.
+
+Complementary to Hugging Face TRL DistillationTrainer, not a drop-in. See
+``docs/opd.md``.
+"""
 
 from arctic_platform.opd.client import DEFAULT_PROCESSING
 from arctic_platform.opd.client import ArcticOPDClient
 from arctic_platform.opd.client import create_arctic_opd_client
 from arctic_platform.opd.config import ArcticOPDClientConfig
 from arctic_platform.opd.scoring import score_teacher
+from arctic_platform.opd.scoring import score_teacher_topk
 
 __all__ = [
     "ArcticOPDClient",
@@ -27,4 +32,5 @@ __all__ = [
     "DEFAULT_PROCESSING",
     "create_arctic_opd_client",
     "score_teacher",
+    "score_teacher_topk",
 ]

--- a/arctic_platform/opd/client.py
+++ b/arctic_platform/opd/client.py
@@ -1,5 +1,17 @@
 # Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """On-policy distillation as two ``SyncArcticRLClient``s: student + frozen teacher."""
 
@@ -11,7 +23,6 @@ from arctic_platform.client.client import SyncArcticRLClient
 from arctic_platform.client.config import CortexConfig
 from arctic_platform.client.transport import Request
 from arctic_platform.opd.config import ArcticOPDClientConfig
-
 
 DEFAULT_PROCESSING = {
     "loss_fn": "on_policy_distill",

--- a/arctic_platform/opd/client.py
+++ b/arctic_platform/opd/client.py
@@ -1,0 +1,182 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-policy distillation as two ``SyncArcticRLClient``s: student + frozen teacher."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from arctic_platform.client.client import SyncArcticRLClient
+from arctic_platform.client.config import CortexConfig
+from arctic_platform.client.transport import Request
+from arctic_platform.opd.config import ArcticOPDClientConfig
+
+
+DEFAULT_PROCESSING = {
+    "loss_fn": "on_policy_distill",
+    "post": ["compute_entropy_and_logprobs"],
+    "config": {
+        "distill_estimator": "low_var_kl",
+        "kl_coef": 1.0,
+        "loss_agg_mode": "token-mean",
+    },
+    "return_post_outputs": False,
+}
+
+
+def _fwd_bwd_body(
+    config: ArcticOPDClientConfig,
+    batch: dict,
+    processing: dict | None,
+    meta: dict | None = None,
+) -> dict:
+    descriptor = processing or DEFAULT_PROCESSING
+    meta_payload = {"zorro_train_enable": False, **(meta or {})}
+    if isinstance(config.backend, CortexConfig):
+        model_keys = {"input_ids", "attention_mask", "position_ids", "use_cache"}
+        kwargs = {key: value for key, value in batch.items() if key in model_keys}
+        return {
+            "args": (),
+            "kwargs": kwargs,
+            "context": dict(batch),
+            "processing": descriptor,
+        }
+    return {"batch": dict(batch), "meta": meta_payload, "processing": descriptor}
+
+
+class ArcticOPDClient:
+    """Student train+sample plus a sampling-only teacher, each a ``SyncArcticRLClient``.
+
+    The teacher has ``training_gpus=0``; only ``generate`` is used. Weight sync
+    runs on the student (train → student sampler) and never targets the teacher.
+    """
+
+    def __init__(self, config: ArcticOPDClientConfig) -> None:
+        self.config = config
+        self.student = SyncArcticRLClient(config.student_transport_config())
+        try:
+            self.teacher = SyncArcticRLClient(config.teacher_transport_config())
+        except Exception:
+            self.student.shutdown()
+            raise
+
+    @property
+    def student_jobs(self):
+        return self.student.jobs
+
+    @property
+    def teacher_jobs(self):
+        return self.teacher.jobs
+
+    def generate(
+        self,
+        prompts: list,
+        sampling_params: dict | None = None,
+        routing_key: Any = None,
+        strict: bool = False,
+    ) -> list:
+        return self.student.generate(prompts, sampling_params, routing_key, strict)
+
+    def generate_teacher(
+        self,
+        prompts: list,
+        sampling_params: dict | None = None,
+        routing_key: Any = None,
+        strict: bool = False,
+    ) -> list:
+        return self.teacher.generate(prompts, sampling_params, routing_key, strict)
+
+    def fwd_bwd(self, batch: dict, processing: dict | None = None, meta: dict | None = None) -> dict:
+        return self.student.fwd_bwd(_fwd_bwd_body(self.config, batch, processing, meta))
+
+    def step(self, learning_rate: float | None = None) -> dict:
+        return self.student.step(learning_rate)
+
+    def sync_weights(self, cuda_ipc: bool | None = None, low_memory: bool | None = None) -> dict:
+        """Student train → student sampler. Cortex has no wake-inference op."""
+        if isinstance(self.config.backend, CortexConfig):
+            tid = self.student.jobs.require("training")
+            sid = self.student.jobs.require("sampling")
+            payload: dict[str, Any] = {
+                "source_sub_job_id": tid,
+                "target_sub_job_ids": [sid],
+                "weight_format": "hf",
+            }
+            if cuda_ipc is not None:
+                payload["cuda_ipc"] = cuda_ipc
+            if low_memory is not None:
+                payload["low_memory"] = low_memory
+            out = self.student.transport.call(
+                Request(
+                    "operation",
+                    tid,
+                    {
+                        "operation_type": "weight-sync",
+                        "sub_job_id": tid,
+                        "sub_job_type": "training",
+                        "payload": payload,
+                    },
+                )
+            )
+            self.student.reset_prefix_cache()
+            return out
+        return self.student.sync_weights(cuda_ipc=cuda_ipc, low_memory=low_memory)
+
+    def reset_student_prefix_cache(
+        self, drain: bool = True, timeout_s: float = 60.0, retry_interval_s: float = 0.1
+    ) -> dict:
+        return self.student.reset_prefix_cache(drain, timeout_s, retry_interval_s)
+
+    def wake_student_inference(self, tags: list | None = None) -> dict:
+        return self.student.wake_inference(tags)
+
+    def save_checkpoint(
+        self,
+        checkpoint_id: str | None = None,
+        checkpoint_type: str = "weights-only",
+        path: str | None = None,
+        *,
+        step: int | None = None,
+        export_hf: bool = False,
+        save_total_limit: int | None = None,
+    ) -> dict:
+        return self.student.save_checkpoint(
+            checkpoint_id=checkpoint_id,
+            checkpoint_type=checkpoint_type,
+            path=path,
+            step=step,
+            export_hf=export_hf,
+            save_total_limit=save_total_limit,
+        )
+
+    def reconnect_config(self) -> ArcticOPDClientConfig:
+        return self.config.model_copy(
+            update={
+                "training_job_id": self.student.jobs.training,
+                "sampling_job_id": self.student.jobs.sampling,
+                "teacher_job_id": self.teacher.jobs.sampling,
+            }
+        )
+
+    def shutdown(self) -> None:
+        teacher_error: Exception | None = None
+        try:
+            self.teacher.shutdown()
+        except Exception as exc:  # teardown must still reach the student
+            teacher_error = exc
+        try:
+            self.student.shutdown()
+        finally:
+            if teacher_error is not None:
+                raise teacher_error
+
+    def __enter__(self) -> ArcticOPDClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.shutdown()
+
+
+def create_arctic_opd_client(config: ArcticOPDClientConfig) -> ArcticOPDClient:
+    return ArcticOPDClient(config)

--- a/arctic_platform/opd/client.py
+++ b/arctic_platform/opd/client.py
@@ -61,6 +61,10 @@ class ArcticOPDClient:
 
     The teacher has ``training_gpus=0``; only ``generate`` is used. Weight sync
     runs on the student (train → student sampler) and never targets the teacher.
+
+    This is not TRL ``DistillationTrainer``. Arctic uses a single-logit reverse-KL
+    estimator on the sampled token; TRL matches a (full or top-k) next-token
+    distribution with generalized JSD. See ``docs/opd.md``.
     """
 
     def __init__(self, config: ArcticOPDClientConfig) -> None:
@@ -100,6 +104,10 @@ class ArcticOPDClient:
 
     def fwd_bwd(self, batch: dict, processing: dict | None = None, meta: dict | None = None) -> dict:
         return self.student.fwd_bwd(_fwd_bwd_body(self.config, batch, processing, meta))
+
+    def fwd_no_grad(self, batch: dict, processing: dict | None = None, meta: dict | None = None) -> dict:
+        """Student training-engine forward without backward. Used by the TRL distill client."""
+        return self.student.fwd_no_grad(_fwd_bwd_body(self.config, batch, processing, meta))
 
     def step(self, learning_rate: float | None = None) -> dict:
         return self.student.step(learning_rate)

--- a/arctic_platform/opd/config.py
+++ b/arctic_platform/opd/config.py
@@ -1,0 +1,164 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the first-class on-policy distillation client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import model_validator
+
+from arctic_platform.client.config import ArcticRLClientConfig
+from arctic_platform.client.config import CortexConfig
+from arctic_platform.client.config import JobId
+from arctic_platform.client.config import OnPremConfig
+from arctic_platform.client.config import SamplingConfig
+from arctic_platform.client.config import TrainingConfig
+
+
+def _local_cluster_env(http_port: int) -> dict[str, str]:
+    """Disjoint Ray / DeepSpeed ports derived from the HTTP listen port.
+
+    Two HTTP servers on one host cannot share Ray GCS, worker-port ranges, or
+    the DeepSpeed rendezvous port.
+    """
+    slot = http_port % 10
+    worker_base = 40000 + slot * 10000
+    return {
+        "PYTHONUNBUFFERED": "1",
+        "RAY_PORT": str(25000 + slot),
+        "RAY_DASHBOARD_PORT": str(26000 + slot),
+        "RAY_CLIENT_SERVER_PORT": str(10010 + slot),
+        "RAY_DASHBOARD_AGENT_LISTEN_PORT": str(23000 + slot),
+        "MASTER_PORT": str(27000 + slot),
+        "ARL_WEIGHT_SYNC_PORT": str(28000 + slot),
+        "ARL_RAY_MIN_WORKER_PORT": str(worker_base),
+        "ARL_RAY_MAX_WORKER_PORT": str(worker_base + 9999),
+    }
+
+
+class ArcticOPDClientConfig(BaseModel):
+    """Student training/sampling plus a fixed teacher sampling engine.
+
+    ``sampling_gpus`` follows the ArcticRLClient convention and belongs to the
+    student rollout engine. ``teacher_sampling_gpus`` is the teacher scorer.
+    """
+
+    model_config = ConfigDict(extra="forbid", validate_default=True)
+
+    student_model: str
+    teacher_model: str
+    seed: int | None = None
+    dtype: str | None = None
+    max_seq_len: int = 8192
+
+    training_gpus: int = Field(..., gt=0)
+    sampling_gpus: int = Field(..., gt=0)
+    teacher_sampling_gpus: int = Field(..., gt=0)
+
+    training: TrainingConfig = Field(default_factory=TrainingConfig)
+    sampling: SamplingConfig = Field(default_factory=SamplingConfig)
+    teacher_sampling: SamplingConfig = Field(default_factory=SamplingConfig)
+    backend: OnPremConfig | CortexConfig = Field(default_factory=OnPremConfig, discriminator="type")
+
+    # A local OPD deployment uses a second server for the teacher because the
+    # current on-prem server owns one sampling pool. Cortex similarly needs a
+    # second parent job because generate has no sub-job selector.
+    teacher_port: int | None = None
+    teacher_server_cuda_visible_devices: str | None = None
+
+    job_ready_timeout: float = 1800.0
+    request_timeout: float = 1800.0
+
+    training_job_id: JobId | None = None
+    sampling_job_id: JobId | None = None
+    teacher_job_id: JobId | None = None
+
+    @model_validator(mode="after")
+    def _validate_reconnect(self) -> ArcticOPDClientConfig:
+        ids = (self.training_job_id, self.sampling_job_id, self.teacher_job_id)
+        if any(job_id is not None for job_id in ids) and not all(job_id is not None for job_id in ids):
+            raise ValueError("OPD reconnect requires training_job_id, sampling_job_id, and teacher_job_id together")
+        if isinstance(self.backend, OnPremConfig) and self.backend.launch_local_server:
+            teacher_port = self.teacher_port or self.backend.port + 1
+            if teacher_port == self.backend.port:
+                raise ValueError("teacher_port must differ from the student server port")
+            student_devices = self.backend.server_cuda_visible_devices
+            teacher_devices = self.teacher_server_cuda_visible_devices
+            if student_devices is None or teacher_devices is None:
+                raise ValueError(
+                    "local OPD launch requires server_cuda_visible_devices and "
+                    "teacher_server_cuda_visible_devices"
+                )
+            if set(student_devices.split(",")) & set(teacher_devices.split(",")):
+                raise ValueError("student and teacher server CUDA device lists must be disjoint")
+        return self
+
+    def _base_kwargs(self) -> dict[str, Any]:
+        return {
+            "seed": self.seed,
+            "dtype": self.dtype,
+            "max_seq_len": self.max_seq_len,
+            "job_ready_timeout": self.job_ready_timeout,
+            "request_timeout": self.request_timeout,
+        }
+
+    def student_transport_config(self) -> ArcticRLClientConfig:
+        """Internal adapter for the shared transport; not an ArcticRLClient."""
+        backend = self.backend
+        if isinstance(backend, OnPremConfig) and backend.launch_local_server:
+            backend = backend.model_copy(
+                update={
+                    "server_extra_env": {
+                        **_local_cluster_env(backend.port),
+                        **backend.server_extra_env,
+                    }
+                }
+            )
+        return ArcticRLClientConfig(
+            model_name=self.student_model,
+            training_gpus=self.training_gpus,
+            sampling_gpus=self.sampling_gpus,
+            log_prob_gpus=0,
+            training=self.training,
+            sampling=self.sampling,
+            backend=backend,
+            training_job_id=self.training_job_id,
+            sampling_job_id=self.sampling_job_id,
+            **self._base_kwargs(),
+        )
+
+    def teacher_transport_config(self) -> ArcticRLClientConfig:
+        """Internal sampling-only transport config for the fixed teacher."""
+        backend = self.backend
+        if isinstance(backend, OnPremConfig):
+            teacher_port = self.teacher_port or backend.port + 1
+            extra_env = dict(backend.server_extra_env)
+            if backend.launch_local_server:
+                extra_env = {**_local_cluster_env(teacher_port), **backend.server_extra_env}
+            backend = backend.model_copy(
+                update={
+                    "port": teacher_port,
+                    "colocate": False,
+                    "server_cuda_visible_devices": (
+                        self.teacher_server_cuda_visible_devices
+                        if self.teacher_server_cuda_visible_devices is not None
+                        else backend.server_cuda_visible_devices
+                    ),
+                    "server_extra_env": extra_env,
+                }
+            )
+        return ArcticRLClientConfig(
+            model_name=self.teacher_model,
+            training_gpus=0,
+            sampling_gpus=self.teacher_sampling_gpus,
+            log_prob_gpus=0,
+            sampling=self.teacher_sampling,
+            backend=backend,
+            sampling_job_id=self.teacher_job_id,
+            **self._base_kwargs(),
+        )

--- a/arctic_platform/opd/config.py
+++ b/arctic_platform/opd/config.py
@@ -32,6 +32,21 @@ from arctic_platform.client.config import SamplingConfig
 from arctic_platform.client.config import TrainingConfig
 
 
+def _cuda_ids(spec: str) -> set[str]:
+    return {part.strip() for part in spec.split(",") if part.strip()}
+
+
+def _hostfile_hosts(path: str | None) -> set[str]:
+    if not path:
+        return set()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return set()
+    return {ln.split()[0] for ln in lines if ln.strip() and not ln.strip().startswith("#")}
+
+
 def _local_cluster_env(http_port: int) -> dict[str, str]:
     """Disjoint Ray / DeepSpeed ports derived from the HTTP listen port.
 
@@ -82,6 +97,8 @@ class ArcticOPDClientConfig(BaseModel):
     # second parent job because generate has no sub-job selector.
     teacher_port: int | None = None
     teacher_server_cuda_visible_devices: str | None = None
+    student_ray_hostfile: str | None = None
+    teacher_ray_hostfile: str | None = None
 
     job_ready_timeout: float = 1800.0
     request_timeout: float = 1800.0
@@ -105,7 +122,10 @@ class ArcticOPDClientConfig(BaseModel):
                 raise ValueError(
                     "local OPD launch requires server_cuda_visible_devices and teacher_server_cuda_visible_devices"
                 )
-            if set(student_devices.split(",")) & set(teacher_devices.split(",")):
+            student_hosts = _hostfile_hosts(self.student_ray_hostfile)
+            teacher_hosts = _hostfile_hosts(self.teacher_ray_hostfile)
+            isolated_clusters = bool(student_hosts and teacher_hosts and student_hosts.isdisjoint(teacher_hosts))
+            if not isolated_clusters and _cuda_ids(student_devices) & _cuda_ids(teacher_devices):
                 raise ValueError("student and teacher server CUDA device lists must be disjoint")
         return self
 
@@ -122,14 +142,10 @@ class ArcticOPDClientConfig(BaseModel):
         """Internal adapter for the shared transport; not an ArcticRLClient."""
         backend = self.backend
         if isinstance(backend, OnPremConfig) and backend.launch_local_server:
-            backend = backend.model_copy(
-                update={
-                    "server_extra_env": {
-                        **_local_cluster_env(backend.port),
-                        **backend.server_extra_env,
-                    }
-                }
-            )
+            extra_env = {**_local_cluster_env(backend.port), **backend.server_extra_env}
+            if self.student_ray_hostfile:
+                extra_env["ARL_RAY_HOSTFILE"] = self.student_ray_hostfile
+            backend = backend.model_copy(update={"server_extra_env": extra_env})
         return ArcticRLClientConfig(
             model_name=self.student_model,
             training_gpus=self.training_gpus,
@@ -151,6 +167,8 @@ class ArcticOPDClientConfig(BaseModel):
             extra_env = dict(backend.server_extra_env)
             if backend.launch_local_server:
                 extra_env = {**_local_cluster_env(teacher_port), **backend.server_extra_env}
+            if self.teacher_ray_hostfile:
+                extra_env["ARL_RAY_HOSTFILE"] = self.teacher_ray_hostfile
             backend = backend.model_copy(
                 update={
                     "port": teacher_port,

--- a/arctic_platform/opd/config.py
+++ b/arctic_platform/opd/config.py
@@ -1,5 +1,17 @@
 # Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Configuration for the first-class on-policy distillation client."""
 
@@ -91,8 +103,7 @@ class ArcticOPDClientConfig(BaseModel):
             teacher_devices = self.teacher_server_cuda_visible_devices
             if student_devices is None or teacher_devices is None:
                 raise ValueError(
-                    "local OPD launch requires server_cuda_visible_devices and "
-                    "teacher_server_cuda_visible_devices"
+                    "local OPD launch requires server_cuda_visible_devices and teacher_server_cuda_visible_devices"
                 )
             if set(student_devices.split(",")) & set(teacher_devices.split(",")):
                 raise ValueError("student and teacher server CUDA device lists must be disjoint")

--- a/arctic_platform/opd/examples/__init__.py
+++ b/arctic_platform/opd/examples/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/arctic_platform/opd/examples/__init__.py
+++ b/arctic_platform/opd/examples/__init__.py
@@ -1,2 +1,14 @@
 # Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/arctic_platform/opd/examples/run_on_policy_distill.py
+++ b/arctic_platform/opd/examples/run_on_policy_distill.py
@@ -1,0 +1,345 @@
+"""Minimal synchronous single-logit on-policy distillation loop.
+
+Use ``--dry-run`` to validate causal alignment without launching jobs.
+Use ``--live`` to run student/teacher sampling plus a few train steps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from typing import Any
+
+import torch
+from transformers import AutoTokenizer
+
+from arctic_platform.client.config import OnPremConfig
+from arctic_platform.client.config import SamplingConfig
+from arctic_platform.client.config import TrainingConfig
+from arctic_platform.opd import ArcticOPDClient
+from arctic_platform.opd import ArcticOPDClientConfig
+from arctic_platform.opd import score_teacher
+
+
+def build_batch(
+    rollouts: list[dict[str, Any]], pad_token_id: int, max_seq_len: int
+) -> dict[str, torch.Tensor]:
+    lengths = [len(row["prompt_ids"]) + len(row["completion_ids"]) for row in rollouts]
+    width = max(lengths)
+    if width > max_seq_len:
+        raise ValueError(f"batch width {width} exceeds max_seq_len={max_seq_len}")
+    batch_size = len(rollouts)
+    input_ids = torch.full((batch_size, width), pad_token_id, dtype=torch.long)
+    attention_mask = torch.zeros((batch_size, width), dtype=torch.bool)
+    loss_mask = torch.zeros((batch_size, width), dtype=torch.bool)
+    teacher = torch.zeros((batch_size, width), dtype=torch.float32)
+    sampler = torch.zeros((batch_size, width), dtype=torch.float32)
+
+    prompt_width = max(len(row["prompt_ids"]) for row in rollouts)
+    prompts = torch.full((batch_size, prompt_width), pad_token_id, dtype=torch.long)
+
+    for row_index, row in enumerate(rollouts):
+        prompt = list(row["prompt_ids"])
+        completion = list(row["completion_ids"])
+        full_ids = prompt + completion
+        start, stop = len(prompt) - 1, len(full_ids) - 1
+        if len(row["teacher_logprobs"]) != len(completion):
+            raise ValueError("teacher logprobs are not aligned with completion tokens")
+        if len(row["sampler_logprobs"]) != len(completion):
+            raise ValueError("sampler logprobs are not aligned with completion tokens")
+        input_ids[row_index, : len(full_ids)] = torch.tensor(full_ids)
+        attention_mask[row_index, : len(full_ids)] = True
+        loss_mask[row_index, start:stop] = True
+        teacher[row_index, start:stop] = torch.tensor(row["teacher_logprobs"])
+        sampler[row_index, start:stop] = torch.tensor(row["sampler_logprobs"])
+        prompts[row_index, : len(prompt)] = torch.tensor(prompt)
+
+    return {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "loss_mask": loss_mask,
+        "teacher_log_probs_shifted": teacher,
+        "old_log_probs_shifted": sampler,
+        "prompts": prompts,
+    }
+
+
+def lr_at(step: int, peak_lr: float, warmup_steps: int) -> float:
+    if warmup_steps <= 0:
+        return peak_lr
+    return peak_lr * min(1.0, (step + 1) / warmup_steps)
+
+
+def sampled_logprobs(output: dict[str, Any]) -> tuple[list[int], list[float]]:
+    token_ids = list(output["token_ids"])
+    positions = output.get("logprobs")
+    if positions is None:
+        raise RuntimeError("generate did not return logprobs; pass logprobs=0")
+    values: list[float] = []
+    for token_id, position in zip(token_ids, positions):
+        if isinstance(position, dict):
+            entry = position.get(token_id, position.get(str(token_id)))
+            if entry is None:
+                raise RuntimeError(f"generated token {token_id} missing from logprob keys")
+            values.append(float(entry["logprob"] if isinstance(entry, dict) else entry))
+        else:
+            values.append(float(position))
+    return token_ids, values
+
+
+def train_step(
+    client: ArcticOPDClient,
+    prompt_ids: list[list[int]],
+    pad_token_id: int,
+    max_seq_len: int,
+    learning_rate: float,
+    *,
+    max_tokens: int = 32,
+) -> dict:
+    outputs = client.generate(
+        prompt_ids,
+        {
+            "n": 1,
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "max_tokens": max_tokens,
+            "logprobs": 0,
+        },
+    )
+    rollouts = []
+    for prompt, output in zip(prompt_ids, outputs):
+        token_ids, sampler_logprobs = sampled_logprobs(output)
+        if not token_ids:
+            continue
+        rollouts.append(
+            {
+                "prompt_ids": prompt,
+                "completion_ids": token_ids,
+                "sampler_logprobs": sampler_logprobs,
+            }
+        )
+    if not rollouts:
+        raise RuntimeError("student generated empty completions for every prompt")
+    scored = score_teacher(client, rollouts)
+    batch = build_batch(scored, pad_token_id, max_seq_len)
+    fwd = client.fwd_bwd(batch, meta={"pad_token_id": pad_token_id, "zorro_train_enable": False})
+    step_result = client.step(learning_rate)
+    sync_result = client.sync_weights()
+    return {"forward_backward": fwd, "step": step_result, "sync": sync_result, "n_rollouts": len(scored)}
+
+
+def _metric(value: Any) -> float:
+    if isinstance(value, (list, tuple)):
+        value = value[0]
+    return float(value)
+
+
+def live_main(args: argparse.Namespace) -> None:
+    print(f"client CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES', '<unset>')!r}")
+    tokenizer = AutoTokenizer.from_pretrained(args.student_model, trust_remote_code=True)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    pad_token_id = int(tokenizer.pad_token_id)
+    texts = [
+        "In one sentence, what is the capital of France?",
+        "In one sentence, what is 2 + 2?",
+        "In one sentence, why is the sky blue?",
+        "In one sentence, what is the largest planet in the solar system?",
+        "In one sentence, who wrote Hamlet?",
+        "In one sentence, what is water made of?",
+        "In one sentence, what year did the Apollo 11 moon landing happen?",
+        "In one sentence, what is the boiling point of water at sea level?",
+    ]
+    prompt_ids = []
+    for prompt in texts:
+        messages = [{"role": "user", "content": prompt}]
+        try:
+            ids = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                tokenize=True,
+                enable_thinking=False,
+            )
+        except TypeError:
+            ids = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                tokenize=True,
+            )
+        prompt_ids.append(ids)
+
+    checkpoint_path = args.checkpoint_dir or f"/tmp/arctic_opd_ckpt_{os.getpid()}"
+    print(f"checkpoint_path={checkpoint_path}")
+    print(f"student={args.student_model} teacher={args.teacher_model}")
+
+    vllm = {
+        "gpu_memory_utilization": args.gpu_memory_utilization,
+        "max_model_len": args.max_seq_len,
+        "enforce_eager": True,
+        "enable_prefix_caching": False,
+        "tensor_parallel_size": 1,
+    }
+    config = ArcticOPDClientConfig(
+        student_model=args.student_model,
+        teacher_model=args.teacher_model,
+        seed=42,
+        max_seq_len=args.max_seq_len,
+        training_gpus=args.training_gpus,
+        sampling_gpus=args.sampling_gpus,
+        teacher_sampling_gpus=args.teacher_sampling_gpus,
+        training=TrainingConfig(
+            checkpoint_path=checkpoint_path,
+            cuda_ipc=True,
+            ds_config={
+                "train_micro_batch_size_per_gpu": 1,
+                "train_batch_size": args.training_gpus,
+                "gradient_accumulation_steps": 1,
+                "zero_optimization": {
+                    "stage": 2,
+                    "offload_optimizer": {"device": "none"},
+                    "offload_param": {"device": "none"},
+                },
+                "gradient_clipping": 1.0,
+                "optimizer": {
+                    "type": "AdamW",
+                    "params": {"lr": args.lr, "betas": [0.9, 0.999], "eps": 1e-8, "weight_decay": 0.0},
+                },
+            },
+            ds_worker_config={
+                "attn_implementation": args.attn,
+                "enable_gradient_checkpointing": False,
+                "zorro_train_enable": False,
+            },
+        ),
+        sampling=SamplingConfig(vllm=dict(vllm)),
+        teacher_sampling=SamplingConfig(vllm=dict(vllm)),
+        backend=OnPremConfig(
+            protocol="http",
+            host="localhost",
+            port=args.port,
+            colocate=True,
+            launch_local_server=True,
+            server_cuda_visible_devices=args.server_cuda_visible_devices,
+            startup_timeout=args.startup_timeout,
+        ),
+        teacher_port=args.teacher_port,
+        teacher_server_cuda_visible_devices=args.teacher_server_cuda_visible_devices,
+        job_ready_timeout=args.job_ready_timeout,
+        request_timeout=args.request_timeout,
+    )
+
+    client = ArcticOPDClient(config)
+    print(
+        "composed "
+        f"student={type(client.student).__name__}(train_gpus={client.student.config.training_gpus},"
+        f" sample_gpus={client.student.config.sampling_gpus}) "
+        f"teacher={type(client.teacher).__name__}(train_gpus={client.teacher.config.training_gpus},"
+        f" sample_gpus={client.teacher.config.sampling_gpus})"
+    )
+    print(
+        "jobs "
+        f"train={client.student_jobs.training} "
+        f"sample={client.student_jobs.sampling} "
+        f"teacher={client.teacher_jobs.sampling}"
+    )
+    metrics_path = args.metrics_jsonl or f"/tmp/arctic_opd_metrics_{os.getpid()}.jsonl"
+    print(f"metrics_jsonl={metrics_path}")
+    started = time.monotonic()
+    try:
+        for step in range(args.steps):
+            learning_rate = lr_at(step, args.lr, args.warmup_steps)
+            result = train_step(
+                client,
+                prompt_ids,
+                pad_token_id,
+                args.max_seq_len,
+                learning_rate,
+                max_tokens=args.max_tokens,
+            )
+            metrics = (result["forward_backward"] or {}).get("metrics") or {}
+            step_metrics = (result["step"] or {}).get("metrics") or {}
+            record = {
+                "step": step + 1,
+                "lr": learning_rate,
+                "loss": _metric(metrics.get("loss", float("nan"))),
+                "distill_kl": _metric(metrics.get("distill_kl", float("nan"))),
+                "distill_kl_count": metrics.get("distill_kl_count"),
+                "sampler_train_abs_delta_max": metrics.get("sampler_train_abs_delta_max"),
+                "sampler_train_abs_delta_mean": metrics.get("sampler_train_abs_delta_mean"),
+                "grad_norm": step_metrics.get("grad_norm"),
+                "n_rollouts": result["n_rollouts"],
+                "elapsed_s": time.monotonic() - started,
+            }
+            with open(metrics_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record) + "\n")
+            print("METRICS " + json.dumps(record), flush=True)
+            line = (
+                f"step {record['step']}/{args.steps} "
+                f"lr={learning_rate:.3g} "
+                f"loss={record['loss']:.4g} "
+                f"distill_kl={record['distill_kl']:.4g} "
+                f"n={record['n_rollouts']}"
+            )
+            if record["sampler_train_abs_delta_max"] is not None:
+                line += f" sampler_train_abs_delta_max={_metric(record['sampler_train_abs_delta_max']):.4g}"
+            if record["grad_norm"] is not None:
+                line += f" grad_norm={_metric(record['grad_norm']):.4g}"
+            print(line, flush=True)
+        print("live OPD run complete")
+    finally:
+        client.shutdown()
+        print("shutdown complete")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--live", action="store_true")
+    parser.add_argument("--student-model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--teacher-model", default="Qwen/Qwen3-1.7B")
+    parser.add_argument("--steps", type=int, default=3)
+    parser.add_argument("--warmup-steps", type=int, default=2)
+    parser.add_argument("--lr", type=float, default=1e-5)
+    parser.add_argument("--max-seq-len", type=int, default=512)
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument("--training-gpus", type=int, default=1)
+    parser.add_argument("--sampling-gpus", type=int, default=1)
+    parser.add_argument("--teacher-sampling-gpus", type=int, default=1)
+    parser.add_argument("--port", type=int, default=18100)
+    parser.add_argument("--teacher-port", type=int, default=18101)
+    parser.add_argument("--server-cuda-visible-devices", default="0")
+    parser.add_argument("--teacher-server-cuda-visible-devices", default="1")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.35)
+    parser.add_argument("--attn", default="flash_attention_2")
+    parser.add_argument("--checkpoint-dir", default=None)
+    parser.add_argument("--metrics-jsonl", default=None)
+    parser.add_argument("--startup-timeout", type=float, default=600.0)
+    parser.add_argument("--job-ready-timeout", type=float, default=1800.0)
+    parser.add_argument("--request-timeout", type=float, default=1800.0)
+    args = parser.parse_args()
+    if args.dry_run:
+        batch = build_batch(
+            [
+                {
+                    "prompt_ids": [1, 2],
+                    "completion_ids": [3, 4],
+                    "sampler_logprobs": [-0.2, -0.3],
+                    "teacher_logprobs": [-0.1, -0.25],
+                }
+            ],
+            pad_token_id=0,
+            max_seq_len=8,
+        )
+        assert batch["loss_mask"].tolist() == [[False, True, True, False]]
+        print("dry-run OK")
+        return
+    if args.live:
+        live_main(args)
+        return
+    raise SystemExit("Pass --dry-run or --live.")
+
+
+if __name__ == "__main__":
+    main()

--- a/arctic_platform/opd/examples/run_on_policy_distill.py
+++ b/arctic_platform/opd/examples/run_on_policy_distill.py
@@ -1,3 +1,18 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Minimal synchronous single-logit on-policy distillation loop.
 
 Use ``--dry-run`` to validate causal alignment without launching jobs.
@@ -23,9 +38,7 @@ from arctic_platform.opd import ArcticOPDClientConfig
 from arctic_platform.opd import score_teacher
 
 
-def build_batch(
-    rollouts: list[dict[str, Any]], pad_token_id: int, max_seq_len: int
-) -> dict[str, torch.Tensor]:
+def build_batch(rollouts: list[dict[str, Any]], pad_token_id: int, max_seq_len: int) -> dict[str, torch.Tensor]:
     lengths = [len(row["prompt_ids"]) + len(row["completion_ids"]) for row in rollouts]
     width = max(lengths)
     if width > max_seq_len:

--- a/arctic_platform/opd/examples/run_on_policy_distill.py
+++ b/arctic_platform/opd/examples/run_on_policy_distill.py
@@ -16,15 +16,97 @@
 """Minimal synchronous single-logit on-policy distillation loop.
 
 Use ``--dry-run`` to validate causal alignment without launching jobs.
-Use ``--live`` to run student/teacher sampling plus a few train steps.
+Use ``--live`` to run student/teacher sampling plus train steps.
+
+3-node on-prem packing matching xyu ``yak/opd-qwen35/446z0mnb``
+(8 train + 8 student-infer + 8 teacher-infer, teacher TP=2). Student Ray
+cluster is nodes 0-1; teacher Ray cluster is node 2 (head has no local
+GPUs). Neutrino / ``--image-tag`` are omitted::
+
+    python -m arctic_platform.opd.examples.run_on_policy_distill \\
+      --live \\
+      --student-model Qwen/Qwen3.5-4B \\
+      --teacher-model Qwen/Qwen3.6-27B \\
+      --training-gpus 8 --sampling-gpus 8 --teacher-sampling-gpus 8 \\
+      --student-tp 1 --teacher-tp 2 \\
+      --no-colocate \\
+      --server-cuda-visible-devices 0,1,2,3,4,5,6,7 \\
+      --teacher-server-cuda-visible-devices '' \\
+      --student-ray-hostfile /tmp/opd_student_hostfile \\
+      --teacher-ray-hostfile /tmp/opd_teacher_hostfile \\
+      --steps 152 --batch-size 16 \\
+      --max-prompt-len 30144 --max-new-tokens 16384 --seq-len 46592 \\
+      --prompts-file /data/xyu/important/opd_prompts_30720.jsonl \\
+      --lr 2e-5 --warmup-steps 8 --lr-schedule cosine \\
+      --distill-estimator low_var_kl \\
+      --max-num-batched-tokens 2048 --max-tokens-per-mb 46592 \\
+      --gpu-memory-utilization 0.85 \\
+      --shuffle --seed 0 \\
+      --save-every 25 --checkpoint-dir /data-fast/truwase/opd_qwen35_4b27b_3node_ckpt \\
+      --metrics-jsonl opd_qwen35_4b27b_3node_metrics.jsonl \\
+      --wandb-project arctic-opd-3node \\
+      --wandb-run-name opd3n_qwen35_4b_27b_lr2e-5 \\
+      --attn flash_attention_3
+
+1-node 8-GPU pack (train 2 + student-infer 2 + teacher-infer 4), used when
+only one box is available::
+
+    python -m arctic_platform.opd.examples.run_on_policy_distill \\
+      --live \\
+      --student-model Qwen/Qwen3.5-4B \\
+      --teacher-model Qwen/Qwen3.6-27B \\
+      --training-gpus 2 --sampling-gpus 2 --teacher-sampling-gpus 4 \\
+      --student-tp 1 --teacher-tp 2 \\
+      --no-colocate \\
+      --server-cuda-visible-devices 0,1,2,3 \\
+      --teacher-server-cuda-visible-devices 4,5,6,7 \\
+      --steps 152 --batch-size 16 \\
+      --max-prompt-len 30144 --max-new-tokens 16384 --seq-len 46592 \\
+      --prompts-file /data/xyu/important/opd_prompts_30720.jsonl \\
+      --lr 2e-5 --warmup-steps 8 --lr-schedule cosine \\
+      --distill-estimator low_var_kl \\
+      --max-num-batched-tokens 2048 --max-tokens-per-mb 46592 \\
+      --gpu-memory-utilization 0.85 \\
+      --shuffle --seed 0 \\
+      --save-every 25 --checkpoint-dir /data-fast/truwase/opd_qwen35_4b27b_1node_ckpt \\
+      --metrics-jsonl opd_qwen35_4b27b_1node_metrics.jsonl \\
+      --wandb-project arctic-opd-1node \\
+      --wandb-run-name opd3n_20260812_194823_lr2e-5-1node \\
+      --attn flash_attention_3
+
+1+1+1 debug pack (one node, three GPUs; teacher TP=1)::
+
+    python -m arctic_platform.opd.examples.run_on_policy_distill \\
+      --live \\
+      --student-model Qwen/Qwen3.5-4B \\
+      --teacher-model Qwen/Qwen3.6-27B \\
+      --training-gpus 1 --sampling-gpus 1 --teacher-sampling-gpus 1 \\
+      --student-tp 1 --teacher-tp 1 \\
+      --no-colocate \\
+      --server-cuda-visible-devices 0,1 \\
+      --teacher-server-cuda-visible-devices 2 \\
+      --steps 5 --batch-size 2 \\
+      --max-prompt-len 30144 --max-new-tokens 16384 --seq-len 46592 \\
+      --prompts-file /data/xyu/important/opd_prompts_30720.jsonl \\
+      --lr 2e-5 --warmup-steps 8 --lr-schedule cosine \\
+      --distill-estimator low_var_kl \\
+      --max-num-batched-tokens 2048 --max-tokens-per-mb 46592 \\
+      --gpu-memory-utilization 0.85 \\
+      --shuffle --seed 0 --save-every 0 \\
+      --attn flash_attention_3
 """
 
 from __future__ import annotations
 
 import argparse
+import copy
 import json
+import logging
+import math
 import os
+import random
 import time
+from collections.abc import Mapping
 from typing import Any
 
 import torch
@@ -35,7 +117,184 @@ from arctic_platform.client.config import SamplingConfig
 from arctic_platform.client.config import TrainingConfig
 from arctic_platform.opd import ArcticOPDClient
 from arctic_platform.opd import ArcticOPDClientConfig
+from arctic_platform.opd import DEFAULT_PROCESSING
 from arctic_platform.opd import score_teacher
+
+
+logger = logging.getLogger(__name__)
+
+# A genuine sync stall is permanent; bf16 rounding produces isolated zeros, which
+# is why the threshold is a run length rather than a single step.
+MAX_CONSECUTIVE_ZERO_SYNCS = 5
+_SYNC_ZERO_RUN = [0]
+
+
+DEFAULT_TRIVIA_PROMPTS = [
+    "In one sentence, what is the capital of France?",
+    "In one sentence, what is 2 + 2?",
+    "In one sentence, why is the sky blue?",
+    "In one sentence, what is the largest planet in the solar system?",
+    "In one sentence, who wrote Hamlet?",
+    "In one sentence, what is water made of?",
+    "In one sentence, what year did the Apollo 11 moon landing happen?",
+    "In one sentence, what is the boiling point of water at sea level?",
+]
+
+
+def _walk_sync_scalars(result: Any) -> tuple[list[float], list[float], list[float]]:
+    """Collect (model_l2_sq_before, model_l2_sq_after, params_loaded) from a sync response."""
+    before: list[float] = []
+    after: list[float] = []
+    loaded: list[float] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in ("model_l2_sq_before", "l2_sq_before") and isinstance(value, (int, float)):
+                    before.append(float(value))
+                elif key in ("model_l2_sq_after", "l2_sq_after") and isinstance(value, (int, float)):
+                    after.append(float(value))
+                elif key in ("params_loaded", "num_params_loaded") and isinstance(value, (int, float)):
+                    loaded.append(float(value))
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(result)
+    return before, after, loaded
+
+
+def check_sync_result(result: Any) -> tuple[list[str], str]:
+    """Confirm a weight sync actually landed.
+
+    ``params_loaded=0`` is the unambiguous name-mismatch failure. An isolated
+    zero L2 delta is normal at small lr (bf16 rounding); a consecutive run of
+    zeros is a stall. On-prem CUDA-IPC often reports only ``status=ok`` — that
+    is unverifiable from L2, so sampler/trainer parity is the real gate.
+    """
+    warnings: list[str] = []
+    before, after, loaded = _walk_sync_scalars(result)
+
+    if loaded and all(count == 0 for count in loaded):
+        warnings.append("weight sync reported params_loaded=0 on every worker")
+
+    if before and after:
+        unchanged = sum(1 for b, a in zip(before, after) if b == a)
+        if unchanged == len(before):
+            _SYNC_ZERO_RUN[0] += 1
+        else:
+            _SYNC_ZERO_RUN[0] = 0
+        if _SYNC_ZERO_RUN[0] >= MAX_CONSECUTIVE_ZERO_SYNCS:
+            warnings.append(
+                f"weight sync has changed nothing on all {len(before)} inference "
+                f"worker(s) for {_SYNC_ZERO_RUN[0]} consecutive steps (model_l2_sq "
+                f"identical before and after every time). An isolated zero is normal "
+                f"at small lr -- a run this long is not, so the tensors are likely "
+                f"being received and dropped and the sampler is serving stale weights"
+            )
+        deltas = [a - b for b, a in zip(before, after)]
+        zero_note = f" [zero-delta run {_SYNC_ZERO_RUN[0]}]" if _SYNC_ZERO_RUN[0] else ""
+        summary = (
+            f"sync: {len(before)} worker(s), params_loaded="
+            f"{sorted({int(c) for c in loaded}) if loaded else 'n/a'}, "
+            f"L2^2 {before[0]:.6f} -> {after[0]:.6f} "
+            f"(delta {min(deltas):+.3g}..{max(deltas):+.3g}){zero_note}"
+        )
+        return warnings, summary
+
+    if loaded:
+        return warnings, f"sync: params_loaded={sorted({int(c) for c in loaded})}"
+    return warnings, "sync: unverifiable (no L2 / params_loaded reported)"
+
+
+def check_metrics(metrics: dict[str, Any], step: int) -> list[str]:
+    """Sanity-check fwd-bwd metrics. Returns human-readable warnings."""
+    warnings: list[str] = []
+
+    for key in ("distill_kl_coef", "distill_estimator_is_k3"):
+        if key not in metrics:
+            warnings.append(
+                f"expected metric {key} missing: is processing.loss_fn actually "
+                "resolving to the distillation loss?"
+            )
+
+    clamped = float(metrics.get("distill_delta_clamped_count", 0.0) or 0.0)
+    if clamped > 0:
+        warnings.append(
+            f"distill_delta_clamped_count={clamped:g}: teacher and student "
+            "disagree by more than delta_clamp somewhere; the k3 gradient is "
+            "truncated for those tokens"
+        )
+    out_clamped = float(metrics.get("distill_kl_output_clamped_count", 0.0) or 0.0)
+    if out_clamped > 0:
+        warnings.append(
+            f"distill_kl_output_clamped_count={out_clamped:g}: the KL output clamp "
+            "fired, which zeroes the gradient for those tokens. It is off by "
+            "default -- something enabled it"
+        )
+
+    if "sampler_train_kl_sum" not in metrics and "sampler_train_abs_delta_max" not in metrics:
+        warnings.append(
+            "sampler_train_* metrics absent: the trainer did not compare its "
+            "logprobs against old_log_probs_shifted, so the sampler/trainer "
+            "parity gate did NOT run"
+        )
+    else:
+        kl_sum = float(metrics.get("sampler_train_kl_sum", 0.0) or 0.0)
+        n = float(metrics.get("distill_kl_count", 0.0) or 0.0)
+        mean_lowvar = kl_sum / n if n else 0.0
+        gap = math.sqrt(2.0 * max(mean_lowvar, 0.0))
+        abs_max = metrics.get("sampler_train_abs_delta_max")
+        threshold = 0.05 if step == 0 else 0.25
+        abs_threshold = 0.1 if step == 0 else 0.5
+        if abs_max is not None and float(abs_max) > abs_threshold:
+            warnings.append(
+                f"step {step} sampler/trainer abs_delta_max = {float(abs_max):.4f} > "
+                f"{abs_threshold} (RMS={gap:.4f}, n={n}). "
+                + (
+                    "Before any update these must match; bf16 lm-head noise or a "
+                    "loss-mask / prompt-completion split bug."
+                    if step == 0
+                    else "Weights are synced every step, so a growing max gap points "
+                    "at sampler/trainer precision drift or /sync-weights not landing."
+                )
+            )
+        if gap > threshold:
+            warnings.append(
+                f"step {step} sampler/trainer RMS delta = {gap:.4f} > "
+                f"{threshold} (mean_lowvar={mean_lowvar:.6g}, "
+                f"abs_delta_max={abs_max}, n={n}). "
+                + (
+                    "Before any update these must match; check the loss-mask "
+                    "shift and the prompt/completion split."
+                    if step == 0
+                    else "Weights are synced every step, so a growing gap points "
+                    "at /sync-weights not landing."
+                )
+            )
+        elif not (abs_max is not None and float(abs_max) > abs_threshold):
+            logger.info(
+                "step %d parity OK: sampler/trainer RMS delta=%.5f "
+                "(mean_lowvar=%.3g, abs_delta_max=%s) over n=%s tokens",
+                step,
+                gap,
+                mean_lowvar,
+                abs_max,
+                n,
+            )
+
+    kl_sum = metrics.get("distill_kl_sum")
+    kl_count = metrics.get("distill_kl_count")
+    if kl_sum is not None and kl_count:
+        per_tok = float(kl_sum) / float(kl_count)
+        if per_tok < 0:
+            warnings.append(
+                f"mean per-token KL is negative ({per_tok:.6g}); k3 is "
+                "non-negative by construction, so this indicates a bad estimator"
+            )
+    return warnings
 
 
 def build_batch(rollouts: list[dict[str, Any]], pad_token_id: int, max_seq_len: int) -> dict[str, torch.Tensor]:
@@ -79,10 +338,227 @@ def build_batch(rollouts: list[dict[str, Any]], pad_token_id: int, max_seq_len: 
     }
 
 
-def lr_at(step: int, peak_lr: float, warmup_steps: int) -> float:
-    if warmup_steps <= 0:
+def lr_at(
+    step: int,
+    peak_lr: float,
+    warmup_steps: int,
+    *,
+    schedule: str = "linear",
+    total_steps: int | None = None,
+) -> float:
+    """xyu ``lr_at``: warmup then cosine floored at 10% of peak. Applied via ``step(lr)``."""
+    if warmup_steps > 0 and step < warmup_steps:
+        return peak_lr * (step + 1) / warmup_steps
+    if schedule != "cosine":
         return peak_lr
-    return peak_lr * min(1.0, (step + 1) / warmup_steps)
+    span = max(1, (total_steps or 0) - max(warmup_steps, 0))
+    frac = min(1.0, max(0.0, float(step - warmup_steps) / float(span)))
+    return peak_lr * (0.1 + 0.9 * 0.5 * (1.0 + math.cos(math.pi * frac)))
+
+
+def prompt_content_from_record(record: dict[str, Any]) -> str | list[dict[str, Any]]:
+    messages = record.get("messages")
+    if messages:
+        return list(messages)
+    for key in ("prompt", "text", "content"):
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            return value
+    raise ValueError(f"jsonl record is missing prompt/text/content/messages: {sorted(record)}")
+
+
+def load_prompt_records(path: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                raise ValueError(f"{path}:{line_number}: expected a JSON object")
+            records.append(payload)
+    if not records:
+        raise ValueError(f"{path} contained no prompt records")
+    return records
+
+
+def _as_token_ids(ids: Any) -> list[int]:
+    """Normalize chat-template output to a 1-D ``list[int]``.
+
+    Qwen3 tokenizers return ``list[int]``. Qwen3.5 processors return a
+    ``BatchEncoding`` / mapping with ``input_ids`` (sometimes one batch dim).
+    """
+    if isinstance(ids, Mapping):
+        if "input_ids" not in ids:
+            raise TypeError(f"chat template mapping has no input_ids: {type(ids).__name__}")
+        ids = ids["input_ids"]
+    if hasattr(ids, "tolist") and not isinstance(ids, (list, tuple)):
+        ids = ids.tolist()
+    if isinstance(ids, tuple):
+        ids = list(ids)
+    if isinstance(ids, list) and ids and isinstance(ids[0], (list, tuple)):
+        if len(ids) != 1:
+            raise ValueError(f"expected a single prompt, got batch of {len(ids)}")
+        ids = list(ids[0])
+    try:
+        out = [int(x) for x in ids]
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"chat template did not return token ids: {type(ids).__name__} {ids!r}") from exc
+    if not out:
+        raise TypeError("chat template returned empty token ids")
+    return out
+
+
+def tokenize_prompt(
+    tokenizer: Any,
+    prompt: str | list[dict[str, Any]],
+    enable_thinking: bool = False,
+) -> list[int]:
+    """Chat-template tokenize one prompt the way xyu's Neutrino client does.
+
+    xyu documents the Qwen3.5 student template as non-thinking
+    (``<think>\\n\\n</think>\\n\\n``). transformers 5.16 defaults to an open
+    ``<think>`` block when ``enable_thinking`` is omitted, so we pin it here.
+    ``enable_thinking=True`` matches xyu's omit-the-kwarg default on 5.16 and is
+    used by the Phase-1 thinking smoke.
+    """
+    messages = prompt if isinstance(prompt, list) else [{"role": "user", "content": prompt}]
+    kwargs: dict[str, Any] = {
+        "add_generation_prompt": True,
+        "tokenize": True,
+        "enable_thinking": enable_thinking,
+    }
+    try:
+        ids = tokenizer.apply_chat_template(messages, **kwargs)
+    except TypeError:
+        kwargs.pop("enable_thinking", None)
+        ids = tokenizer.apply_chat_template(messages, **kwargs)
+    return _as_token_ids(ids)
+
+
+def student_sampling_params(max_tokens: int) -> dict[str, Any]:
+    """vLLM sampling dict matching xyu ``446z0mnb``, minus keys this engine rejects."""
+    params: dict[str, Any] = {
+        "n": 1,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "max_tokens": max_tokens,
+        "logprobs": 0,
+        "top_k": -1,
+        "min_p": 0.0,
+    }
+    try:
+        from vllm.sampling_params import SamplingParams
+    except Exception:
+        params["return_sampled_logprobs_only"] = True
+        return params
+    try:
+        SamplingParams(**params)
+    except TypeError:
+        params.pop("min_p", None)
+        params.pop("top_k", None)
+    try:
+        SamplingParams(**{**params, "return_sampled_logprobs_only": True})
+    except TypeError:
+        return params
+    params["return_sampled_logprobs_only"] = True
+    return params
+
+
+def _vllm_engine_fields() -> set[str]:
+    try:
+        from vllm.engine.arg_utils import EngineArgs
+    except Exception:
+        return set()
+    fields = getattr(EngineArgs, "model_fields", None)
+    if fields is None:
+        fields = getattr(EngineArgs, "__dataclass_fields__", {})
+    return set(fields)
+
+
+def _vllm_version_tuple() -> tuple[int, ...]:
+    try:
+        import vllm
+    except Exception:
+        return ()
+    parts: list[int] = []
+    for token in str(getattr(vllm, "__version__", "")).split("."):
+        digits = "".join(ch for ch in token if ch.isdigit())
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def vllm_supports_fp32_lm_head() -> bool:
+    """True when this vLLM build accepts Neutrino's ``fp32_lm_head`` flag."""
+    return "fp32_lm_head" in _vllm_engine_fields()
+
+
+def vllm_fp32_engine_kwargs() -> dict[str, Any]:
+    """Engine kwargs that put the vLLM LM head in fp32.
+
+    Neutrino exposes ``fp32_lm_head``. Stock vLLM 0.26 uses
+    ``hf_overrides={"head_dtype": "float32"}`` (PR #48390). 0.18 generation
+    models ignore ``head_dtype``, so do not send it there.
+    """
+    if vllm_supports_fp32_lm_head():
+        return {"fp32_lm_head": True}
+    if _vllm_version_tuple() >= (0, 26):
+        return {"hf_overrides": {"head_dtype": "float32"}}
+    return {}
+
+
+def vllm_fa2_engine_kwargs() -> dict[str, Any]:
+    """Force vLLM softmax attention to FA2 so it matches ``--attn flash_attention_2``.
+
+    Stock vLLM 0.26 picks FA3 on Hopper. The trainer still uses FA2, and the
+    step-8 length cliff survived fp32 heads with a healthy ``abs_delta_max``.
+    """
+    if _vllm_version_tuple() >= (0, 26):
+        return {"attention_config": {"flash_attn_version": 2}}
+    return {}
+
+
+def tokenize_and_filter(
+    tokenizer: Any,
+    prompts: list[str | list[dict[str, Any]] | dict[str, Any]],
+    max_prompt_len: int | None,
+    enable_thinking: bool = False,
+) -> list[list[int]]:
+    kept: list[list[int]] = []
+    for prompt in prompts:
+        content = prompt_content_from_record(prompt) if isinstance(prompt, dict) else prompt
+        ids = tokenize_prompt(tokenizer, content, enable_thinking=enable_thinking)
+        if max_prompt_len is not None and len(ids) > max_prompt_len:
+            continue
+        kept.append(ids)
+    if not kept:
+        raise ValueError("no prompts left after max-prompt-len filter")
+    return kept
+
+
+def iter_batches(
+    prompt_ids: list[list[int]],
+    batch_size: int,
+    steps: int,
+    *,
+    shuffle: bool,
+    seed: int,
+) -> list[list[list[int]]]:
+    if batch_size <= 0:
+        raise ValueError("batch_size must be > 0")
+    ids = list(prompt_ids)
+    if shuffle:
+        rng = random.Random(seed)
+        rng.shuffle(ids)
+    n = len(ids)
+    batches: list[list[list[int]]] = []
+    for step in range(steps):
+        start = (step * batch_size) % n
+        batches.append([ids[(start + offset) % n] for offset in range(batch_size)])
+    return batches
 
 
 def sampled_logprobs(output: dict[str, Any]) -> tuple[list[int], list[float]]:
@@ -110,17 +586,12 @@ def train_step(
     learning_rate: float,
     *,
     max_tokens: int = 32,
+    processing: dict[str, Any] | None = None,
 ) -> dict:
-    outputs = client.generate(
-        prompt_ids,
-        {
-            "n": 1,
-            "temperature": 1.0,
-            "top_p": 1.0,
-            "max_tokens": max_tokens,
-            "logprobs": 0,
-        },
-    )
+    t0 = time.monotonic()
+    t_phase = time.monotonic()
+    outputs = client.generate(prompt_ids, student_sampling_params(max_tokens))
+    gen_s = time.monotonic() - t_phase
     rollouts = []
     for prompt, output in zip(prompt_ids, outputs):
         token_ids, sampler_logprobs = sampled_logprobs(output)
@@ -135,12 +606,36 @@ def train_step(
         )
     if not rollouts:
         raise RuntimeError("student generated empty completions for every prompt")
+    t_phase = time.monotonic()
     scored = score_teacher(client, rollouts)
+    score_s = time.monotonic() - t_phase
     batch = build_batch(scored, pad_token_id, max_seq_len)
-    fwd = client.fwd_bwd(batch, meta={"pad_token_id": pad_token_id, "zorro_train_enable": False})
+    t_phase = time.monotonic()
+    fwd = client.fwd_bwd(
+        batch,
+        processing=processing,
+        meta={"pad_token_id": pad_token_id, "zorro_train_enable": False},
+    )
+    fwdbwd_s = time.monotonic() - t_phase
+    t_phase = time.monotonic()
     step_result = client.step(learning_rate)
     sync_result = client.sync_weights()
-    return {"forward_backward": fwd, "step": step_result, "sync": sync_result, "n_rollouts": len(scored)}
+    step_sync_s = time.monotonic() - t_phase
+    tokens_scored = sum(len(row["completion_ids"]) for row in scored)
+    return {
+        "forward_backward": fwd,
+        "step": step_result,
+        "sync": sync_result,
+        "n_rollouts": len(scored),
+        "tokens_scored": tokens_scored,
+        "times": {
+            "gen_s": gen_s,
+            "score_s": score_s,
+            "fwdbwd_s": fwdbwd_s,
+            "step_sync_s": step_sync_s,
+            "total_s": time.monotonic() - t0,
+        },
+    }
 
 
 def _metric(value: Any) -> float:
@@ -149,55 +644,254 @@ def _metric(value: Any) -> float:
     return float(value)
 
 
-def live_main(args: argparse.Namespace) -> None:
+def _maybe_metric(value: Any) -> float | None:
+    if value is None:
+        return None
+    return _metric(value)
+
+
+def kl_per_token_len_adj(per_token: float, tokens_per_rollout: float, len_ref: float, exponent: float) -> float:
+    """xyu length adjustment: ``kl * (tokens_per_rollout / len_ref) ** exponent``."""
+    if tokens_per_rollout <= 0 or len_ref <= 0:
+        return per_token
+    return per_token * (tokens_per_rollout / len_ref) ** exponent
+
+
+def build_step_record(
+    *,
+    step: int,
+    learning_rate: float,
+    result: dict[str, Any],
+    tokens_cumulative: int,
+    elapsed_s: float,
+    wandb_len_ref: float,
+    wandb_len_exponent: float,
+) -> dict[str, Any]:
+    """xyu-style namespaced metrics plus the previous flat aliases."""
+    metrics = (result.get("forward_backward") or {}).get("metrics") or {}
+    step_metrics = (result.get("step") or {}).get("metrics") or {}
+    times = result.get("times") or {}
+    n_rollouts = int(result.get("n_rollouts") or 0)
+    tokens_scored = int(result.get("tokens_scored") or 0)
+    tokens_per_rollout = tokens_scored / n_rollouts if n_rollouts else 0.0
+    loss = _metric(metrics.get("loss", float("nan")))
+    kl_count = _maybe_metric(metrics.get("distill_kl.tokens")) or _maybe_metric(metrics.get("distill_kl_count"))
+    paired_kl_sum = _maybe_metric(metrics.get("distill_kl.sum"))
+    if paired_kl_sum is not None and kl_count:
+        kl_per_token = paired_kl_sum / kl_count
+    elif "distill_kl" in metrics:
+        kl_per_token = _metric(metrics["distill_kl"])
+    elif metrics.get("distill_kl_sum") is not None and kl_count:
+        kl_per_token = _metric(metrics["distill_kl_sum"]) / kl_count
+    else:
+        kl_per_token = float("nan")
+    if "distill_k1" in metrics:
+        k1_per_token: float | None = _metric(metrics["distill_k1"])
+    elif metrics.get("distill_k1_sum") is not None and kl_count:
+        k1_per_token = _metric(metrics["distill_k1_sum"]) / kl_count
+    else:
+        k1_per_token = None
+    record: dict[str, Any] = {
+        "step": step,
+        "loss/avg": loss,
+        "kl/per_token": kl_per_token,
+        "kl/per_token_len_adj": kl_per_token_len_adj(
+            kl_per_token, tokens_per_rollout, wandb_len_ref, wandb_len_exponent
+        ),
+        "optim/lr": learning_rate,
+        "optim/update_successful": 1.0,
+        "tokens/scored": tokens_scored,
+        "tokens/per_rollout": tokens_per_rollout,
+        "tokens/cumulative": tokens_cumulative,
+        "n_rollouts": n_rollouts,
+        "lr": learning_rate,
+        "loss": loss,
+        "distill_kl": kl_per_token,
+        "elapsed_s": elapsed_s,
+    }
+    for dest, source in (
+        ("kl/k1_per_token", None),
+        ("distill_kl_count", "distill_kl_count"),
+        ("distill_kl_max", "distill_kl_max"),
+        ("distill_delta_max", "distill_delta_max"),
+        ("distill_delta_min", "distill_delta_min"),
+        ("distill_delta_clamped_count", "distill_delta_clamped_count"),
+        ("sampler_train_abs_delta_max", "sampler_train_abs_delta_max"),
+        ("sampler_train_abs_delta_mean", "sampler_train_abs_delta_mean"),
+        ("sampler_train_kl_sum", "sampler_train_kl_sum"),
+        ("distill_batch_num_tokens", "distill_batch_num_tokens"),
+        ("distill_dp_size", "distill_dp_size"),
+        ("distill_kl.sum", "distill_kl.sum"),
+        ("distill_kl.tokens", "distill_kl.tokens"),
+        ("loss.sum", "loss.sum"),
+        ("loss.tokens", "loss.tokens"),
+    ):
+        if dest == "kl/k1_per_token":
+            value = k1_per_token
+        else:
+            value = _maybe_metric(metrics.get(source))
+        if value is not None:
+            record[dest] = value
+    if "sampler_train_abs_delta_max" in record:
+        record["sync/abs_delta_max"] = record["sampler_train_abs_delta_max"]
+    grad_norm = _maybe_metric(step_metrics.get("grad_norm"))
+    if grad_norm is not None:
+        record["optim/grad_norm"] = grad_norm
+        record["grad_norm"] = grad_norm
+    for key in ("gen_s", "score_s", "fwdbwd_s", "step_sync_s", "total_s"):
+        if key in times:
+            record[f"time/{key}"] = float(times[key])
+    return record
+
+
+def _student_gpu_memory_utilization(args: argparse.Namespace) -> float:
+    if args.student_gpu_memory_utilization is not None:
+        return args.student_gpu_memory_utilization
+    if args.colocate:
+        return 0.35
+    return args.gpu_memory_utilization
+
+
+def resolve_train_attn(requested: str) -> str:
+    """xyu trains with FA3. Stock transformers needs the FA3 package; fall back to FA2."""
+    if requested != "flash_attention_3":
+        return requested
+    try:
+        from transformers.utils import is_flash_attn_3_available
+    except Exception:
+        print("train_attn_fallback flash_attention_3 -> flash_attention_2 (import check failed)")
+        return "flash_attention_2"
+    if is_flash_attn_3_available():
+        return requested
+    print("train_attn_fallback flash_attention_3 -> flash_attention_2 (HF FlashAttention3 not installed)")
+    return "flash_attention_2"
+
+
+def _ds_config(args: argparse.Namespace) -> dict[str, Any]:
+    if args.batch_size % args.training_gpus != 0:
+        raise SystemExit(
+            f"--batch-size {args.batch_size} must be divisible by --training-gpus {args.training_gpus}"
+        )
+    gas = args.batch_size // args.training_gpus
+    ds_config: dict[str, Any] = {
+        "train_micro_batch_size_per_gpu": 1,
+        "train_batch_size": args.batch_size,
+        "gradient_accumulation_steps": gas,
+        "zero_optimization": {
+            "stage": 1,
+            "offload_optimizer": {"device": "none"},
+            "offload_param": {"device": "none"},
+        },
+        "gradient_clipping": 1.0,
+        "optimizer": {
+            "type": "AdamW",
+            "params": {"lr": args.lr, "betas": [0.9, 0.999], "eps": 1e-8, "weight_decay": 0.0},
+        },
+    }
+    if getattr(args, "max_tokens_per_mb", None):
+        per_gpu = max(1, args.batch_size // args.training_gpus)
+        ds_config["train_micro_batch_size_per_gpu"] = per_gpu
+        ds_config["gradient_accumulation_steps"] = 1
+        ds_config["train_batch_size"] = per_gpu * args.training_gpus
+    # LR schedule is applied per step via ``step(lr)`` (xyu ``lr_at``), not a
+    # DeepSpeed scheduler that would overwrite the client LR.
+    return ds_config
+
+
+def build_live_client(args: argparse.Namespace):
+    """Construct the live client and its inputs.
+
+    Shared by ``live_main`` and the offline kl/per_token probe so both exercise
+    the exact same student/teacher bring-up. Returns
+    ``(client, tokenizer, pad_token_id, prompt_ids, batches, processing, checkpoint_path)``.
+    """
     print(f"client CUDA_VISIBLE_DEVICES={os.environ.get('CUDA_VISIBLE_DEVICES', '<unset>')!r}")
     tokenizer = AutoTokenizer.from_pretrained(args.student_model, trust_remote_code=True)
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
     pad_token_id = int(tokenizer.pad_token_id)
-    texts = [
-        "In one sentence, what is the capital of France?",
-        "In one sentence, what is 2 + 2?",
-        "In one sentence, why is the sky blue?",
-        "In one sentence, what is the largest planet in the solar system?",
-        "In one sentence, who wrote Hamlet?",
-        "In one sentence, what is water made of?",
-        "In one sentence, what year did the Apollo 11 moon landing happen?",
-        "In one sentence, what is the boiling point of water at sea level?",
-    ]
-    prompt_ids = []
-    for prompt in texts:
-        messages = [{"role": "user", "content": prompt}]
-        try:
-            ids = tokenizer.apply_chat_template(
-                messages,
-                add_generation_prompt=True,
-                tokenize=True,
-                enable_thinking=False,
-            )
-        except TypeError:
-            ids = tokenizer.apply_chat_template(
-                messages,
-                add_generation_prompt=True,
-                tokenize=True,
-            )
-        prompt_ids.append(ids)
+    if args.prompts_file:
+        raw_prompts: list[str | list[dict[str, Any]] | dict[str, Any]] = load_prompt_records(args.prompts_file)
+    else:
+        raw_prompts = list(DEFAULT_TRIVIA_PROMPTS)
+    enable_thinking = bool(getattr(args, "enable_thinking", False))
+    print(f"enable_thinking={enable_thinking}")
+    prompt_ids = tokenize_and_filter(
+        tokenizer, raw_prompts, args.max_prompt_len, enable_thinking=enable_thinking
+    )
+    batches = iter_batches(
+        prompt_ids,
+        args.batch_size,
+        args.steps,
+        shuffle=args.shuffle,
+        seed=args.seed,
+    )
+    print(f"n_prompts={len(prompt_ids)} batch_size={args.batch_size} steps={args.steps}")
 
     checkpoint_path = args.checkpoint_dir or f"/tmp/arctic_opd_ckpt_{os.getpid()}"
     print(f"checkpoint_path={checkpoint_path}")
     print(f"student={args.student_model} teacher={args.teacher_model}")
 
-    vllm = {
+    if args.sampling_gpus % args.student_tp != 0:
+        raise SystemExit(
+            f"--student-infer-gpus {args.sampling_gpus} must be divisible by --student-tp {args.student_tp}"
+        )
+    if args.teacher_sampling_gpus % args.teacher_tp != 0:
+        raise SystemExit(
+            f"--teacher-infer-gpus {args.teacher_sampling_gpus} must be divisible by --teacher-tp {args.teacher_tp}"
+        )
+
+    student_util = _student_gpu_memory_utilization(args)
+    student_vllm: dict[str, Any] = {
+        "gpu_memory_utilization": student_util,
+        "max_model_len": args.max_seq_len,
+        "enforce_eager": args.enforce_eager,
+        "enable_prefix_caching": False,
+        "tensor_parallel_size": args.student_tp,
+    }
+    teacher_vllm: dict[str, Any] = {
         "gpu_memory_utilization": args.gpu_memory_utilization,
         "max_model_len": args.max_seq_len,
-        "enforce_eager": True,
+        "enforce_eager": args.enforce_eager,
         "enable_prefix_caching": False,
-        "tensor_parallel_size": 1,
+        "tensor_parallel_size": args.teacher_tp,
     }
+    if args.max_num_batched_tokens is not None:
+        student_vllm["max_num_batched_tokens"] = args.max_num_batched_tokens
+        teacher_vllm["max_num_batched_tokens"] = args.max_num_batched_tokens
+    if args.vllm_fp32_lm_head:
+        fp32_engine = vllm_fp32_engine_kwargs()
+        if fp32_engine:
+            student_vllm.update(fp32_engine)
+            teacher_vllm.update(fp32_engine)
+            print(f"vllm_fp32_lm_head={fp32_engine}")
+        else:
+            print("vllm_fp32_lm_head=skipped (need Neutrino fp32_lm_head or vLLM>=0.26 head_dtype)")
+    else:
+        print("vllm_fp32_lm_head=disabled")
+    print(f"vllm_enforce_eager={args.enforce_eager}")
+    fa_version = args.vllm_flash_attn_version
+    if fa_version == 2:
+        fa2_engine = vllm_fa2_engine_kwargs()
+        if fa2_engine:
+            student_vllm.update(fa2_engine)
+            teacher_vllm.update(fa2_engine)
+        print(f"vllm_flash_attn={fa2_engine or 'env VLLM_FLASH_ATTN_VERSION=2'}")
+    elif fa_version is not None:
+        print(f"vllm_flash_attn=pin {fa_version}")
+    else:
+        print("vllm_flash_attn=default (FA3 on Hopper)")
+
+    processing = copy.deepcopy(DEFAULT_PROCESSING)
+    processing["config"]["distill_estimator"] = args.distill_estimator
+    train_attn = resolve_train_attn(args.attn)
+    print(f"train_attn={train_attn} requested={args.attn}")
+    print(f"train_fp32_lm_head={args.train_fp32_lm_head}")
+
     config = ArcticOPDClientConfig(
         student_model=args.student_model,
         teacher_model=args.teacher_model,
-        seed=42,
+        seed=args.seed,
         max_seq_len=args.max_seq_len,
         training_gpus=args.training_gpus,
         sampling_gpus=args.sampling_gpus,
@@ -205,40 +899,46 @@ def live_main(args: argparse.Namespace) -> None:
         training=TrainingConfig(
             checkpoint_path=checkpoint_path,
             cuda_ipc=True,
-            ds_config={
-                "train_micro_batch_size_per_gpu": 1,
-                "train_batch_size": args.training_gpus,
-                "gradient_accumulation_steps": 1,
-                "zero_optimization": {
-                    "stage": 2,
-                    "offload_optimizer": {"device": "none"},
-                    "offload_param": {"device": "none"},
-                },
-                "gradient_clipping": 1.0,
-                "optimizer": {
-                    "type": "AdamW",
-                    "params": {"lr": args.lr, "betas": [0.9, 0.999], "eps": 1e-8, "weight_decay": 0.0},
-                },
-            },
+            ds_config=_ds_config(args),
             ds_worker_config={
-                "attn_implementation": args.attn,
-                "enable_gradient_checkpointing": False,
+                "attn_implementation": train_attn,
+                "enable_gradient_checkpointing": args.max_seq_len > 2048,
                 "zorro_train_enable": False,
+                "fp32_lm_head": args.train_fp32_lm_head,
+                "fused_cross_entropy": False,
+                "fla_tilelang": False,
+                **({"fused_lm_head_token_chunk_size": 2048} if args.train_fp32_lm_head else {}),
+                **(
+                    {"max_tokens_per_mb": args.max_tokens_per_mb}
+                    if args.max_tokens_per_mb
+                    else {}
+                ),
             },
         ),
-        sampling=SamplingConfig(vllm=dict(vllm)),
-        teacher_sampling=SamplingConfig(vllm=dict(vllm)),
+        sampling=SamplingConfig(vllm=student_vllm),
+        teacher_sampling=SamplingConfig(vllm=teacher_vllm),
         backend=OnPremConfig(
             protocol="http",
             host="localhost",
             port=args.port,
-            colocate=True,
+            colocate=args.colocate,
             launch_local_server=True,
             server_cuda_visible_devices=args.server_cuda_visible_devices,
             startup_timeout=args.startup_timeout,
+            server_extra_env={
+                "FLA_TILELANG": "0",
+                "FLA_DISABLE_BACKEND_DISPATCH": "1",
+                **(
+                    {"VLLM_FLASH_ATTN_VERSION": str(args.vllm_flash_attn_version)}
+                    if args.vllm_flash_attn_version is not None
+                    else {}
+                ),
+            },
         ),
         teacher_port=args.teacher_port,
         teacher_server_cuda_visible_devices=args.teacher_server_cuda_visible_devices,
+        student_ray_hostfile=args.student_ray_hostfile,
+        teacher_ray_hostfile=args.teacher_ray_hostfile,
         job_ready_timeout=args.job_ready_timeout,
         request_timeout=args.request_timeout,
     )
@@ -257,56 +957,115 @@ def live_main(args: argparse.Namespace) -> None:
         f"sample={client.student_jobs.sampling} "
         f"teacher={client.teacher_jobs.sampling}"
     )
+    print(
+        f"colocate={args.colocate} student_tp={args.student_tp} teacher_tp={args.teacher_tp} "
+        f"student_gpu_mem={student_util} teacher_gpu_mem={args.gpu_memory_utilization} "
+        f"max_tokens_per_mb={args.max_tokens_per_mb} "
+        f"student_hostfile={args.student_ray_hostfile} teacher_hostfile={args.teacher_ray_hostfile}"
+    )
+    return client, tokenizer, pad_token_id, prompt_ids, batches, processing, checkpoint_path
+
+
+def live_main(args: argparse.Namespace) -> None:
+    (
+        client,
+        tokenizer,
+        pad_token_id,
+        prompt_ids,
+        batches,
+        processing,
+        checkpoint_path,
+    ) = build_live_client(args)
     metrics_path = args.metrics_jsonl or f"/tmp/arctic_opd_metrics_{os.getpid()}.jsonl"
     print(f"metrics_jsonl={metrics_path}")
+    wandb_run = None
+    if args.wandb_project:
+        try:
+            import wandb
+        except ImportError as exc:
+            raise SystemExit(" --wandb-project requires the wandb package") from exc
+        wandb_kwargs: dict[str, Any] = {"project": args.wandb_project, "config": vars(args)}
+        if args.wandb_run_name:
+            wandb_kwargs["name"] = args.wandb_run_name
+        wandb_run = wandb.init(**wandb_kwargs)
     started = time.monotonic()
+    tokens_cumulative = 0
     try:
-        for step in range(args.steps):
-            learning_rate = lr_at(step, args.lr, args.warmup_steps)
+        for step, batch_prompts in enumerate(batches):
+            learning_rate = lr_at(
+                step,
+                args.lr,
+                args.warmup_steps,
+                schedule=args.lr_schedule,
+                total_steps=args.steps,
+            )
             result = train_step(
                 client,
-                prompt_ids,
+                batch_prompts,
                 pad_token_id,
                 args.max_seq_len,
                 learning_rate,
                 max_tokens=args.max_tokens,
+                processing=processing,
             )
-            metrics = (result["forward_backward"] or {}).get("metrics") or {}
-            step_metrics = (result["step"] or {}).get("metrics") or {}
-            record = {
-                "step": step + 1,
-                "lr": learning_rate,
-                "loss": _metric(metrics.get("loss", float("nan"))),
-                "distill_kl": _metric(metrics.get("distill_kl", float("nan"))),
-                "distill_kl_count": metrics.get("distill_kl_count"),
-                "sampler_train_abs_delta_max": metrics.get("sampler_train_abs_delta_max"),
-                "sampler_train_abs_delta_mean": metrics.get("sampler_train_abs_delta_mean"),
-                "grad_norm": step_metrics.get("grad_norm"),
-                "n_rollouts": result["n_rollouts"],
-                "elapsed_s": time.monotonic() - started,
-            }
+            tokens_cumulative += int(result.get("tokens_scored") or 0)
+            record = build_step_record(
+                step=step + 1,
+                learning_rate=learning_rate,
+                result=result,
+                tokens_cumulative=tokens_cumulative,
+                elapsed_s=time.monotonic() - started,
+                wandb_len_ref=args.wandb_len_ref,
+                wandb_len_exponent=args.wandb_len_exponent,
+            )
+            metrics = (result.get("forward_backward") or {}).get("metrics") or {}
+            metric_warnings = check_metrics(metrics, step)
+            sync_warnings, sync_summary = check_sync_result(result.get("sync"))
+            record["sync/summary"] = sync_summary
+            for warning in metric_warnings + sync_warnings:
+                print("WARNING " + warning, flush=True)
+            print(sync_summary, flush=True)
             with open(metrics_path, "a", encoding="utf-8") as handle:
                 handle.write(json.dumps(record) + "\n")
+            if wandb_run is not None:
+                wandb_run.log(record, step=record["step"])
             print("METRICS " + json.dumps(record), flush=True)
             line = (
                 f"step {record['step']}/{args.steps} "
                 f"lr={learning_rate:.3g} "
                 f"loss={record['loss']:.4g} "
                 f"distill_kl={record['distill_kl']:.4g} "
-                f"n={record['n_rollouts']}"
+                f"n={record['n_rollouts']} "
+                f"tokens={record['tokens/scored']}"
             )
-            if record["sampler_train_abs_delta_max"] is not None:
+            if "time/total_s" in record:
+                line += (
+                    f" gen={record['time/gen_s']:.1f}s"
+                    f" score={record['time/score_s']:.1f}s"
+                    f" fwdbwd={record['time/fwdbwd_s']:.1f}s"
+                    f" step_sync={record['time/step_sync_s']:.1f}s"
+                    f" total={record['time/total_s']:.1f}s"
+                )
+            if record.get("sampler_train_abs_delta_max") is not None:
                 line += f" sampler_train_abs_delta_max={_metric(record['sampler_train_abs_delta_max']):.4g}"
-            if record["grad_norm"] is not None:
+            if record.get("grad_norm") is not None:
                 line += f" grad_norm={_metric(record['grad_norm']):.4g}"
             print(line, flush=True)
+            if args.save_every and (step + 1) % args.save_every == 0:
+                save_result = client.save_checkpoint(step=step + 1, path=checkpoint_path)
+                print(f"checkpoint step={step + 1} {save_result}", flush=True)
+        if args.save_every and args.steps % args.save_every != 0:
+            save_result = client.save_checkpoint(step=args.steps, path=checkpoint_path)
+            print(f"checkpoint step={args.steps} {save_result}", flush=True)
         print("live OPD run complete")
     finally:
+        if wandb_run is not None:
+            wandb_run.finish()
         client.shutdown()
         print("shutdown complete")
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--live", action="store_true")
@@ -314,24 +1073,110 @@ def main() -> None:
     parser.add_argument("--teacher-model", default="Qwen/Qwen3-1.7B")
     parser.add_argument("--steps", type=int, default=3)
     parser.add_argument("--warmup-steps", type=int, default=2)
-    parser.add_argument("--lr", type=float, default=1e-5)
-    parser.add_argument("--max-seq-len", type=int, default=512)
-    parser.add_argument("--max-tokens", type=int, default=32)
-    parser.add_argument("--training-gpus", type=int, default=1)
-    parser.add_argument("--sampling-gpus", type=int, default=1)
-    parser.add_argument("--teacher-sampling-gpus", type=int, default=1)
+    parser.add_argument("--lr", "--learning-rate", dest="lr", type=float, default=1e-5)
+    parser.add_argument("--lr-schedule", choices=("linear", "cosine"), default="linear")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--max-seq-len", "--seq-len", dest="max_seq_len", type=int, default=512)
+    parser.add_argument("--max-tokens", "--max-new-tokens", dest="max_tokens", type=int, default=32)
+    parser.add_argument("--max-prompt-len", type=int, default=None)
+    parser.add_argument("--prompts-file", default=None)
+    parser.add_argument("--shuffle", action="store_true")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--distill-estimator", default="low_var_kl")
+    parser.add_argument("--max-num-batched-tokens", type=int, default=None)
+    parser.add_argument(
+        "--max-tokens-per-mb",
+        type=int,
+        default=None,
+        help="Token budget per packed train microbatch (xyu mb_spec). "
+        "When set, the worker packs instead of splitting by DeepSpeed GAS.",
+    )
+    parser.add_argument("--training-gpus", "--train-gpus", dest="training_gpus", type=int, default=1)
+    parser.add_argument("--sampling-gpus", "--student-infer-gpus", dest="sampling_gpus", type=int, default=1)
+    parser.add_argument(
+        "--teacher-sampling-gpus", "--teacher-infer-gpus", dest="teacher_sampling_gpus", type=int, default=1
+    )
+    parser.add_argument("--student-tp", type=int, default=1)
+    parser.add_argument("--teacher-tp", type=int, default=1)
+    parser.add_argument("--colocate", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--port", type=int, default=18100)
     parser.add_argument("--teacher-port", type=int, default=18101)
     parser.add_argument("--server-cuda-visible-devices", default="0")
     parser.add_argument("--teacher-server-cuda-visible-devices", default="1")
+    parser.add_argument(
+        "--student-ray-hostfile",
+        default=None,
+        help="Hostfile for the student Ray cluster (ARL_RAY_HOSTFILE). "
+        "Use with --teacher-ray-hostfile to pin 8+8+8 roles onto disjoint nodes.",
+    )
+    parser.add_argument(
+        "--teacher-ray-hostfile",
+        default=None,
+        help="Hostfile for the teacher Ray cluster (ARL_RAY_HOSTFILE).",
+    )
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.35)
-    parser.add_argument("--attn", default="flash_attention_2")
+    parser.add_argument("--student-gpu-memory-utilization", type=float, default=None)
+    parser.add_argument("--attn", default="flash_attention_3")
+    parser.add_argument(
+        "--enable-thinking",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Student chat template thinking block. Default off (pinned "
+        "non-thinking). --enable-thinking matches xyu's omit-the-kwarg default "
+        "on transformers 5.16 (thinking ON); used by the Phase-1 thinking smoke.",
+    )
+    parser.add_argument(
+        "--enforce-eager",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="vLLM enforce_eager. Default off so CUDA graphs can run (v6). "
+        "v5 used --enforce-eager and paid ~2x generate vs xyu.",
+    )
+    parser.add_argument(
+        "--vllm-flash-attn-version",
+        type=int,
+        default=None,
+        choices=(2, 3, 4),
+        help="Pin vLLM FlashAttention version. Default: let vLLM pick (FA3 on Hopper).",
+    )
+    parser.add_argument(
+        "--vllm-fp32-lm-head",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Send stock vLLM head_dtype=float32 (or Neutrino fp32_lm_head). "
+        "Use --no-vllm-fp32-lm-head to isolate bf16 infer head vs v9.",
+    )
+    parser.add_argument(
+        "--train-fp32-lm-head",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Inject chunked fp32 train LM head. Use --no-train-fp32-lm-head to isolate.",
+    )
     parser.add_argument("--checkpoint-dir", default=None)
+    parser.add_argument("--save-every", type=int, default=0)
     parser.add_argument("--metrics-jsonl", default=None)
+    parser.add_argument("--wandb-project", default=None)
+    parser.add_argument("--wandb-run-name", default=None)
+    parser.add_argument(
+        "--wandb-len-ref",
+        type=float,
+        default=4096.0,
+        help="Reference completion length for kl/per_token_len_adj (xyu default 4096).",
+    )
+    parser.add_argument(
+        "--wandb-len-exponent",
+        type=float,
+        default=0.486,
+        help="Exponent for kl/per_token_len_adj (xyu default 0.486).",
+    )
     parser.add_argument("--startup-timeout", type=float, default=600.0)
     parser.add_argument("--job-ready-timeout", type=float, default=1800.0)
     parser.add_argument("--request-timeout", type=float, default=1800.0)
-    args = parser.parse_args()
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
     if args.dry_run:
         batch = build_batch(
             [

--- a/arctic_platform/opd/examples/run_on_policy_distill.py
+++ b/arctic_platform/opd/examples/run_on_policy_distill.py
@@ -675,20 +675,23 @@ def build_step_record(
     tokens_scored = int(result.get("tokens_scored") or 0)
     tokens_per_rollout = tokens_scored / n_rollouts if n_rollouts else 0.0
     loss = _metric(metrics.get("loss", float("nan")))
-    kl_count = _maybe_metric(metrics.get("distill_kl.tokens")) or _maybe_metric(metrics.get("distill_kl_count"))
+    # Only the paired ``.tokens`` key is a token count. ``distill_kl_count`` survives
+    # the combiner as a per-rollout average, so dividing a global sum by it reports a
+    # batch-size-times-too-large KL -- the rank-scope mismatch that corrupted xyu's runs.
+    kl_tokens = _maybe_metric(metrics.get("distill_kl.tokens"))
     paired_kl_sum = _maybe_metric(metrics.get("distill_kl.sum"))
-    if paired_kl_sum is not None and kl_count:
-        kl_per_token = paired_kl_sum / kl_count
+    if paired_kl_sum is not None and kl_tokens:
+        kl_per_token = paired_kl_sum / kl_tokens
     elif "distill_kl" in metrics:
         kl_per_token = _metric(metrics["distill_kl"])
-    elif metrics.get("distill_kl_sum") is not None and kl_count:
-        kl_per_token = _metric(metrics["distill_kl_sum"]) / kl_count
+    elif metrics.get("distill_kl_sum") is not None and kl_tokens:
+        kl_per_token = _metric(metrics["distill_kl_sum"]) / kl_tokens
     else:
         kl_per_token = float("nan")
     if "distill_k1" in metrics:
         k1_per_token: float | None = _metric(metrics["distill_k1"])
-    elif metrics.get("distill_k1_sum") is not None and kl_count:
-        k1_per_token = _metric(metrics["distill_k1_sum"]) / kl_count
+    elif metrics.get("distill_k1_sum") is not None and kl_tokens:
+        k1_per_token = _metric(metrics["distill_k1_sum"]) / kl_tokens
     else:
         k1_per_token = None
     record: dict[str, Any] = {

--- a/arctic_platform/opd/scoring.py
+++ b/arctic_platform/opd/scoring.py
@@ -1,5 +1,17 @@
 # Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Token-aligned teacher scoring for on-policy distillation."""
 
@@ -40,16 +52,11 @@ def score_teacher(
         if prompt_logprobs is None:
             raise RuntimeError("teacher response has no prompt_logprobs")
         if len(prompt_logprobs) != len(full_ids):
-            raise RuntimeError(
-                f"prompt_logprobs length {len(prompt_logprobs)} != token length {len(full_ids)}"
-            )
+            raise RuntimeError(f"prompt_logprobs length {len(prompt_logprobs)} != token length {len(full_ids)}")
         if prompt_logprobs[0] is not None:
             raise RuntimeError("prompt_logprobs[0] must be None")
         prompt_len = len(rollout["prompt_ids"])
-        teacher_logprobs = [
-            _logprob_at(prompt_logprobs[i], full_ids[i])
-            for i in range(prompt_len, len(full_ids))
-        ]
+        teacher_logprobs = [_logprob_at(prompt_logprobs[i], full_ids[i]) for i in range(prompt_len, len(full_ids))]
         if any(not math.isfinite(value) or value > 0.0 for value in teacher_logprobs):
             raise RuntimeError("teacher returned a non-finite or positive logprob")
         scored_rollout = dict(rollout)

--- a/arctic_platform/opd/scoring.py
+++ b/arctic_platform/opd/scoring.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Token-aligned teacher scoring for on-policy distillation."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Any
+
+
+def _logprob_at(position: Any, token_id: int) -> float:
+    if not isinstance(position, dict):
+        raise RuntimeError(f"expected prompt_logprobs position dict, got {type(position).__name__}")
+    entry = position.get(token_id)
+    if entry is None:
+        entry = position.get(str(token_id))
+    if entry is None:
+        raise RuntimeError(f"token {token_id} is absent from its prompt_logprobs position")
+    return float(entry["logprob"] if isinstance(entry, dict) else entry)
+
+
+def score_teacher(
+    client: Any,
+    rollouts: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Score exact student token IDs with the teacher, without retokenization."""
+    full_batch = [list(r["prompt_ids"]) + list(r["completion_ids"]) for r in rollouts]
+    outputs = client.generate_teacher(
+        full_batch,
+        {"max_tokens": 1, "temperature": 1.0, "prompt_logprobs": 0},
+    )
+    if len(outputs) != len(full_batch):
+        raise RuntimeError(f"teacher returned {len(outputs)} results for {len(full_batch)} prompts")
+
+    scored: list[dict[str, Any]] = []
+    for rollout, full_ids, output in zip(rollouts, full_batch, outputs):
+        prompt_logprobs = output.get("prompt_logprobs")
+        if prompt_logprobs is None:
+            raise RuntimeError("teacher response has no prompt_logprobs")
+        if len(prompt_logprobs) != len(full_ids):
+            raise RuntimeError(
+                f"prompt_logprobs length {len(prompt_logprobs)} != token length {len(full_ids)}"
+            )
+        if prompt_logprobs[0] is not None:
+            raise RuntimeError("prompt_logprobs[0] must be None")
+        prompt_len = len(rollout["prompt_ids"])
+        teacher_logprobs = [
+            _logprob_at(prompt_logprobs[i], full_ids[i])
+            for i in range(prompt_len, len(full_ids))
+        ]
+        if any(not math.isfinite(value) or value > 0.0 for value in teacher_logprobs):
+            raise RuntimeError("teacher returned a non-finite or positive logprob")
+        scored_rollout = dict(rollout)
+        scored_rollout["teacher_logprobs"] = teacher_logprobs
+        scored.append(scored_rollout)
+    return scored

--- a/arctic_platform/opd/scoring.py
+++ b/arctic_platform/opd/scoring.py
@@ -22,6 +22,10 @@ from collections.abc import Sequence
 from typing import Any
 
 
+def _logprob_value(entry: Any) -> float:
+    return float(entry["logprob"] if isinstance(entry, dict) else entry)
+
+
 def _logprob_at(position: Any, token_id: int) -> float:
     if not isinstance(position, dict):
         raise RuntimeError(f"expected prompt_logprobs position dict, got {type(position).__name__}")
@@ -30,7 +34,53 @@ def _logprob_at(position: Any, token_id: int) -> float:
         entry = position.get(str(token_id))
     if entry is None:
         raise RuntimeError(f"token {token_id} is absent from its prompt_logprobs position")
-    return float(entry["logprob"] if isinstance(entry, dict) else entry)
+    return _logprob_value(entry)
+
+
+def _position_candidates(position: Any) -> list[tuple[int, float]]:
+    if not isinstance(position, dict):
+        raise RuntimeError(f"expected prompt_logprobs position dict, got {type(position).__name__}")
+    pairs: list[tuple[int, float]] = []
+    for key, entry in position.items():
+        pairs.append((int(key), _logprob_value(entry)))
+    pairs.sort(key=lambda item: -item[1])
+    return pairs
+
+
+def _tail_logprob(logprobs: Sequence[float]) -> float:
+    mass = sum(math.exp(value) for value in logprobs)
+    remainder = max(1.0 - mass, 0.0)
+    if remainder <= 0.0:
+        return float("-inf")
+    return math.log(remainder)
+
+
+def _teacher_outputs(
+    client: Any,
+    rollouts: Sequence[dict[str, Any]],
+    *,
+    prompt_logprobs: int,
+    temperature: float,
+) -> tuple[list[list[int]], list[Any]]:
+    full_batch = [list(r["prompt_ids"]) + list(r["completion_ids"]) for r in rollouts]
+    outputs = client.generate_teacher(
+        full_batch,
+        {"max_tokens": 1, "temperature": temperature, "prompt_logprobs": prompt_logprobs},
+    )
+    if len(outputs) != len(full_batch):
+        raise RuntimeError(f"teacher returned {len(outputs)} results for {len(full_batch)} prompts")
+    return full_batch, outputs
+
+
+def _require_prompt_logprobs(output: dict[str, Any], full_ids: list[int]) -> list[Any]:
+    prompt_logprobs = output.get("prompt_logprobs")
+    if prompt_logprobs is None:
+        raise RuntimeError("teacher response has no prompt_logprobs")
+    if len(prompt_logprobs) != len(full_ids):
+        raise RuntimeError(f"prompt_logprobs length {len(prompt_logprobs)} != token length {len(full_ids)}")
+    if prompt_logprobs[0] is not None:
+        raise RuntimeError("prompt_logprobs[0] must be None")
+    return prompt_logprobs
 
 
 def score_teacher(
@@ -38,28 +88,64 @@ def score_teacher(
     rollouts: Sequence[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Score exact student token IDs with the teacher, without retokenization."""
-    full_batch = [list(r["prompt_ids"]) + list(r["completion_ids"]) for r in rollouts]
-    outputs = client.generate_teacher(
-        full_batch,
-        {"max_tokens": 1, "temperature": 1.0, "prompt_logprobs": 0},
-    )
-    if len(outputs) != len(full_batch):
-        raise RuntimeError(f"teacher returned {len(outputs)} results for {len(full_batch)} prompts")
+    full_batch, outputs = _teacher_outputs(client, rollouts, prompt_logprobs=0, temperature=1.0)
 
     scored: list[dict[str, Any]] = []
     for rollout, full_ids, output in zip(rollouts, full_batch, outputs):
-        prompt_logprobs = output.get("prompt_logprobs")
-        if prompt_logprobs is None:
-            raise RuntimeError("teacher response has no prompt_logprobs")
-        if len(prompt_logprobs) != len(full_ids):
-            raise RuntimeError(f"prompt_logprobs length {len(prompt_logprobs)} != token length {len(full_ids)}")
-        if prompt_logprobs[0] is not None:
-            raise RuntimeError("prompt_logprobs[0] must be None")
+        prompt_logprobs = _require_prompt_logprobs(output, full_ids)
         prompt_len = len(rollout["prompt_ids"])
         teacher_logprobs = [_logprob_at(prompt_logprobs[i], full_ids[i]) for i in range(prompt_len, len(full_ids))]
         if any(not math.isfinite(value) or value > 0.0 for value in teacher_logprobs):
             raise RuntimeError("teacher returned a non-finite or positive logprob")
         scored_rollout = dict(rollout)
         scored_rollout["teacher_logprobs"] = teacher_logprobs
+        scored.append(scored_rollout)
+    return scored
+
+
+def score_teacher_topk(
+    client: Any,
+    rollouts: Sequence[dict[str, Any]],
+    *,
+    teacher_top_k: int = 8,
+    teacher_temperature: float = 1.0,
+    add_tail_bucket: bool = True,
+) -> list[dict[str, Any]]:
+    """Teacher-forced top-k support on the student's token ids.
+
+    Requests ``prompt_logprobs=teacher_top_k``. vLLM reports the realized token
+    even when it falls outside top-k. Optional tail is ``log(1 - sum exp)``.
+    """
+    if teacher_top_k < 1:
+        raise ValueError("teacher_top_k must be >= 1")
+    full_batch, outputs = _teacher_outputs(
+        client, rollouts, prompt_logprobs=teacher_top_k, temperature=teacher_temperature
+    )
+
+    scored: list[dict[str, Any]] = []
+    for rollout, full_ids, output in zip(rollouts, full_batch, outputs):
+        prompt_logprobs = _require_prompt_logprobs(output, full_ids)
+        prompt_len = len(rollout["prompt_ids"])
+        token_ids: list[list[int]] = []
+        token_logprobs: list[list[float]] = []
+        tail: list[float] = []
+        for index in range(prompt_len, len(full_ids)):
+            realized = full_ids[index]
+            pairs = _position_candidates(prompt_logprobs[index])
+            if realized not in {token_id for token_id, _ in pairs}:
+                raise RuntimeError(f"token {realized} is absent from its prompt_logprobs position")
+            ids = [token_id for token_id, _ in pairs]
+            lps = [logprob for _, logprob in pairs]
+            if any(not math.isfinite(value) or value > 0.0 for value in lps):
+                raise RuntimeError("teacher returned a non-finite or positive logprob")
+            token_ids.append(ids)
+            token_logprobs.append(lps)
+            if add_tail_bucket:
+                tail.append(_tail_logprob(lps))
+        scored_rollout = dict(rollout)
+        scored_rollout["teacher_token_ids"] = token_ids
+        scored_rollout["teacher_logprobs"] = token_logprobs
+        if add_tail_bucket:
+            scored_rollout["teacher_tail_logprob"] = tail
         scored.append(scored_rollout)
     return scored

--- a/arctic_platform/rl/processors/__init__.py
+++ b/arctic_platform/rl/processors/__init__.py
@@ -72,6 +72,9 @@ from .packing import _align
 from .packing import pack_sequences
 from .packing import pad_packed_for_model
 from .packing import unpack_sequences
+from .packing import derive_varlen_model_kwargs
+from .packing import model_reads_varlen_kwargs
+from .packing import packing_boundaries_from_attention_mask
 
 # Pipeline registry and runner
 from .pipeline import LOSS_FNS
@@ -122,6 +125,9 @@ __all__ = [
     "pack_sequences",
     "unpack_sequences",
     "pad_packed_for_model",
+    "derive_varlen_model_kwargs",
+    "model_reads_varlen_kwargs",
+    "packing_boundaries_from_attention_mask",
     # microbatch
     "DEFAULT_MAX_TOKENS_PER_MB",
     "MicroBatchSpec",

--- a/arctic_platform/rl/processors/__init__.py
+++ b/arctic_platform/rl/processors/__init__.py
@@ -63,6 +63,9 @@ from .microbatch import _is_multi_modal_key
 from .microbatch import _reorder_list
 from .microbatch import split_padded_tensor_dict_into_mb_list
 
+# On-policy distillation (import registers "on_policy_distill").
+from .on_policy_distill import on_policy_distill_loss
+
 # Packing utilities
 from .packing import N_TOKENS_PER_PAGE
 from .packing import _align
@@ -112,6 +115,7 @@ __all__ = [
     "run_pipeline",
     "identity_post",
     "compute_entropy_and_logprobs_post",
+    "on_policy_distill_loss",
     # packing
     "N_TOKENS_PER_PAGE",
     "_align",

--- a/arctic_platform/rl/processors/on_policy_distill.py
+++ b/arctic_platform/rl/processors/on_policy_distill.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-logit on-policy distillation loss."""
+
+from __future__ import annotations
+
+import torch
+
+from .functional import agg_loss
+from .functional import kl_penalty
+from .pipeline import register_loss_fn
+
+
+@register_loss_fn("on_policy_distill")
+def on_policy_distill_loss(
+    model_outputs: dict,
+    batch: dict,
+    meta: dict,
+    config: dict,
+    device: str,
+) -> tuple[torch.Tensor, dict]:
+    """Reverse-KL estimate on completion tokens sampled by the student.
+
+    ``compute_entropy_and_logprobs`` supplies the student's causal token
+    log-probabilities. The fixed teacher values and masks travel with the batch,
+    and the teacher is always detached.
+    """
+    student_logprobs = model_outputs.get("logprobs")
+    if student_logprobs is None:
+        raise ValueError("on_policy_distill requires post=['compute_entropy_and_logprobs']")
+
+    teacher = batch["teacher_log_probs_shifted"].to(student_logprobs.device).detach()
+    loss_mask = batch["loss_mask"].to(student_logprobs.device).bool()
+    if teacher.shape != student_logprobs.shape or loss_mask.shape != student_logprobs.shape:
+        raise ValueError(
+            "student logprobs, teacher_log_probs_shifted, and loss_mask must have identical shapes"
+        )
+    if not loss_mask.any():
+        raise ValueError("on_policy_distill loss_mask is empty")
+
+    estimator = config.get("distill_estimator", "low_var_kl")
+    per_token_kl = kl_penalty(student_logprobs, teacher, method=estimator)
+    loss = float(config.get("kl_coef", 1.0)) * agg_loss(
+        per_token_kl,
+        loss_mask,
+        loss_agg_mode=config.get("loss_agg_mode", "token-mean"),
+        dp_size=config.get("dp_size", 1),
+        batch_num_tokens=config.get("batch_num_tokens"),
+        global_batch_size=config.get("global_batch_size"),
+    )
+
+    masked_kl = per_token_kl.detach()[loss_mask]
+    metrics = {
+        "distill_kl": float(masked_kl.mean().cpu()),
+        "distill_kl_sum": float(masked_kl.sum().cpu()),
+        "distill_kl_count": int(masked_kl.numel()),
+        "loss": float(loss.detach().cpu()),
+    }
+    old_logprobs = batch.get("old_log_probs_shifted")
+    if old_logprobs is not None:
+        old = old_logprobs.to(student_logprobs.device)
+        delta = (student_logprobs.detach() - old).abs()[loss_mask]
+        metrics.update(
+            {
+                "sampler_train_abs_delta_max": float(delta.max().cpu()),
+                "sampler_train_abs_delta_mean": float(delta.mean().cpu()),
+            }
+        )
+    return loss, metrics

--- a/arctic_platform/rl/processors/on_policy_distill.py
+++ b/arctic_platform/rl/processors/on_policy_distill.py
@@ -1,5 +1,17 @@
 # Copyright 2025 Snowflake Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Single-logit on-policy distillation loss."""
 
@@ -33,9 +45,7 @@ def on_policy_distill_loss(
     teacher = batch["teacher_log_probs_shifted"].to(student_logprobs.device).detach()
     loss_mask = batch["loss_mask"].to(student_logprobs.device).bool()
     if teacher.shape != student_logprobs.shape or loss_mask.shape != student_logprobs.shape:
-        raise ValueError(
-            "student logprobs, teacher_log_probs_shifted, and loss_mask must have identical shapes"
-        )
+        raise ValueError("student logprobs, teacher_log_probs_shifted, and loss_mask must have identical shapes")
     if not loss_mask.any():
         raise ValueError("on_policy_distill loss_mask is empty")
 

--- a/arctic_platform/rl/processors/on_policy_distill.py
+++ b/arctic_platform/rl/processors/on_policy_distill.py
@@ -13,15 +13,207 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Single-logit on-policy distillation loss."""
+"""Single-logit on-policy distillation loss.
+
+The student generates on-policy, a frozen teacher scores those exact same token
+ids, and the student minimises per-token reverse KL ``KL(pi_student || pi_teacher)``
+estimated from the sampled token alone.
+
+``functional.kl_penalty(method="low_var_kl")`` computes the same k3 estimator but
+clamps its *output* to ``[-10, 10]``. That zeroes the gradient for
+``|delta| ≳ 2.63`` — exactly where student and teacher disagree most. This module
+clamps only the *input* ``delta`` (to keep ``exp`` finite) and leaves the output
+cap opt-in via ``kl_clamp_max``.
+"""
 
 from __future__ import annotations
+
+from typing import Optional
 
 import torch
 
 from .functional import agg_loss
-from .functional import kl_penalty
 from .pipeline import register_loss_fn
+
+_DEFAULT_DELTA_CLAMP = 20.0
+
+_ESTIMATORS_K3 = frozenset({"low_var_kl", "k3"})
+_ESTIMATORS_K2 = frozenset({"mse", "k2"})
+_ESTIMATORS_ABS = frozenset({"abs"})
+_ESTIMATORS_VALUE_ONLY = frozenset({"kl", "k1"})
+_ESTIMATORS_TRAINABLE = _ESTIMATORS_K3 | _ESTIMATORS_K2 | _ESTIMATORS_ABS
+
+_DISTILL_CONFIG_KEYS = frozenset(
+    {
+        "distill_estimator",
+        "kl_coef",
+        "delta_clamp",
+        "kl_clamp_max",
+        "loss_agg_mode",
+        "dp_size",
+        "batch_num_tokens",
+        "global_batch_size",
+    }
+)
+
+
+def _packed_singleton_to_1d(tensor: torch.Tensor) -> torch.Tensor:
+    """``pack_sequences`` emits ``[1, T]``; canonicalise to ``[T]`` for the loss."""
+    if torch.is_tensor(tensor) and tensor.ndim == 2 and tensor.shape[0] == 1:
+        return tensor.squeeze(0)
+    return tensor
+
+
+def count_opd_loss_tokens(batch_data) -> tuple[int, int]:
+    """Local ``(tokens, sequences)`` from ``loss_mask`` on a rank shard or GAS list.
+
+    The DeepSpeed worker all-reduces these into ``batch_num_tokens`` / ``dp_size``
+    so each microbatch is ``sum(kl) / T_global * dp_size`` instead of a local
+    per-rollout mean.
+    """
+    if isinstance(batch_data, list):
+        tokens = seqs = 0
+        for micro_batch in batch_data:
+            mb_tokens, mb_seqs = count_opd_loss_tokens(micro_batch)
+            tokens += mb_tokens
+            seqs += mb_seqs
+        return tokens, seqs
+    if not isinstance(batch_data, dict):
+        return 0, 0
+    loss_mask = batch_data.get("loss_mask")
+    if not torch.is_tensor(loss_mask):
+        return 0, 0
+    tokens = int(loss_mask.count_nonzero().item())
+    if loss_mask.ndim >= 2 and loss_mask.shape[0] > 1:
+        seqs = int(loss_mask.reshape(loss_mask.shape[0], -1).any(dim=-1).sum().item())
+    elif torch.is_tensor(batch_data.get("cu_seqlens")) and batch_data["cu_seqlens"].numel() >= 2:
+        seqs = int(batch_data["cu_seqlens"].numel()) - 1
+    else:
+        seqs = 1 if tokens else 0
+    return tokens, seqs
+
+
+def _positive_int(value) -> Optional[int]:
+    if value is None:
+        return None
+    parsed = int(value)
+    return parsed if parsed > 0 else None
+
+
+def apply_opd_global_token_config(
+    processing: dict,
+    meta_data: dict,
+    *,
+    dp_size: int,
+    batch_num_tokens: int,
+    global_batch_size: int,
+) -> None:
+    """Write all-reduced token counts into OPD ``processing['config']`` and ``meta``."""
+    config = processing.setdefault("config", {})
+    if isinstance(config, dict):
+        config["dp_size"] = int(dp_size)
+        config["batch_num_tokens"] = int(batch_num_tokens)
+        config["global_batch_size"] = int(global_batch_size)
+    meta_data["dp_size"] = int(dp_size)
+    meta_data["batch_num_tokens"] = int(batch_num_tokens)
+    meta_data["global_num_tokens"] = int(batch_num_tokens)
+    meta_data["global_batch_size"] = int(global_batch_size)
+
+
+def _resolve_distill_norm(config: dict, meta: dict) -> tuple[int, Optional[int], Optional[int]]:
+    """``(dp_size, batch_num_tokens, global_batch_size)`` from config, then meta."""
+    meta = meta if isinstance(meta, dict) else {}
+    dp_size = int(config.get("dp_size") or meta.get("dp_size") or 1)
+    batch_num_tokens = _positive_int(config.get("batch_num_tokens"))
+    if batch_num_tokens is None:
+        batch_num_tokens = _positive_int(meta.get("batch_num_tokens"))
+    if batch_num_tokens is None:
+        batch_num_tokens = _positive_int(meta.get("global_num_tokens"))
+    global_batch_size = _positive_int(config.get("global_batch_size"))
+    if global_batch_size is None:
+        global_batch_size = _positive_int(meta.get("global_batch_size"))
+    return dp_size, batch_num_tokens, global_batch_size
+
+
+def _distill_kl_per_token(
+    student_logprobs: torch.Tensor,
+    teacher_logprobs: torch.Tensor,
+    *,
+    estimator: str,
+    delta_clamp: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-token reverse-KL objective, differentiable through ``student_logprobs``.
+
+    With ``delta = teacher - student`` (teacher detached), k3 is
+    ``exp(delta) - delta - 1``, whose gradient ``1 - exp(delta)`` pushes the
+    student toward the teacher. Returns ``(per_token_loss, unclamped delta)``.
+
+    ``k1`` is rejected: ``student - teacher`` has derivative ``+1``, so minimising
+    it drives every sampled logprob down regardless of the teacher.
+    """
+    if estimator in _ESTIMATORS_VALUE_ONLY:
+        raise ValueError(
+            f"distill_estimator='{estimator}' is a KL *value* estimator, not a trainable "
+            "objective: its gradient w.r.t. the student logprob is the constant +1, so "
+            "minimising it lowers every sampled logprob irrespective of the teacher. It is "
+            "reported as the 'distill_k1_sum' metric instead. Use 'low_var_kl' (k3, default), "
+            "'mse' (k2), or 'abs'."
+        )
+    if estimator not in _ESTIMATORS_TRAINABLE:
+        raise ValueError(
+            f"Unknown distill_estimator '{estimator}'. Expected one of "
+            f"{sorted(_ESTIMATORS_TRAINABLE)} (or 'k1'/'kl', which are value-only)."
+        )
+
+    delta = teacher_logprobs.float() - student_logprobs.float()
+    delta_clamped = torch.clamp(delta, min=-delta_clamp, max=delta_clamp)
+
+    if estimator in _ESTIMATORS_K3:
+        per_token = delta_clamped.exp() - delta_clamped - 1.0
+    elif estimator in _ESTIMATORS_K2:
+        per_token = 0.5 * delta_clamped.square()
+    else:
+        per_token = delta_clamped.abs()
+    return per_token, delta
+
+
+def _masked_sum(values: torch.Tensor, mask: torch.Tensor) -> float:
+    values = values.detach().float()
+    return float(torch.where(mask.bool(), values, torch.zeros_like(values)).sum().item())
+
+
+def _masked_max(values: torch.Tensor, mask: torch.Tensor) -> float:
+    mask_bool = mask.bool()
+    if not bool(mask_bool.any()):
+        return 0.0
+    values = values.detach().float()
+    return float(values[mask_bool].max().item())
+
+
+def _require_batch_tensor(batch: dict, key: str, *, produced_by: str) -> torch.Tensor:
+    value = batch.get(key)
+    if value is None:
+        raise ValueError(
+            f"loss_fn 'on_policy_distill' requires batch key '{key}' — {produced_by}. "
+            f"Present batch keys: {sorted(batch)}"
+        )
+    if not torch.is_tensor(value):
+        raise TypeError(f"batch['{key}'] must be a tensor, got {type(value).__name__}")
+    return value
+
+
+def _student_logprobs(model_outputs: dict, batch: dict) -> torch.Tensor:
+    logprobs = model_outputs.get("logprobs")
+    if logprobs is not None:
+        return logprobs
+    if "logits" not in model_outputs:
+        raise ValueError("on_policy_distill requires post=['compute_entropy_and_logprobs']")
+    logits = model_outputs["logits"]
+    input_ids = batch["input_ids"].to(logits.device)
+    if input_ids.ndim < logits.ndim:
+        input_ids = input_ids.view(logits.shape[:-1])
+    labels = torch.roll(input_ids, shifts=-1, dims=-1)
+    return torch.log_softmax(logits.float(), dim=-1).gather(-1, labels.unsqueeze(-1)).squeeze(-1)
 
 
 @register_loss_fn("on_policy_distill")
@@ -32,49 +224,132 @@ def on_policy_distill_loss(
     config: dict,
     device: str,
 ) -> tuple[torch.Tensor, dict]:
-    """Reverse-KL estimate on completion tokens sampled by the student.
+    """Single-logit on-policy distillation: reverse KL against a frozen teacher.
 
-    ``compute_entropy_and_logprobs`` supplies the student's causal token
-    log-probabilities. The fixed teacher values and masks travel with the batch,
-    and the teacher is always detached.
+    The config schema is strict — an unrecognised key raises rather than being
+    ignored, so a typo cannot silently fall back to a different objective.
     """
-    student_logprobs = model_outputs.get("logprobs")
-    if student_logprobs is None:
-        raise ValueError("on_policy_distill requires post=['compute_entropy_and_logprobs']")
+    unknown_keys = set(config) - _DISTILL_CONFIG_KEYS
+    if unknown_keys:
+        raise ValueError(
+            f"Unknown config keys for loss_fn 'on_policy_distill': {sorted(unknown_keys)} — this "
+            "contract fails loudly on unrecognized keys so a typo cannot silently change the "
+            f"objective. Known keys: {sorted(_DISTILL_CONFIG_KEYS)}"
+        )
 
-    teacher = batch["teacher_log_probs_shifted"].to(student_logprobs.device).detach()
-    loss_mask = batch["loss_mask"].to(student_logprobs.device).bool()
-    if teacher.shape != student_logprobs.shape or loss_mask.shape != student_logprobs.shape:
-        raise ValueError("student logprobs, teacher_log_probs_shifted, and loss_mask must have identical shapes")
+    logprobs = _student_logprobs(model_outputs, batch)
+    if not torch.isfinite(logprobs).all():
+        logprobs = torch.nan_to_num(logprobs, nan=0.0, posinf=0.0, neginf=0.0)
+
+    teacher_logprobs = _require_batch_tensor(
+        batch,
+        "teacher_log_probs_shifted",
+        produced_by="the teacher's per-token logprobs for the same token ids, roll(-1)-aligned",
+    ).to(logprobs.device)
+    loss_mask = _require_batch_tensor(
+        batch,
+        "loss_mask",
+        produced_by="True on the completion-predicting positions the student is trained on",
+    ).to(logprobs.device)
+
+    cu_seqlens = batch.get("cu_seqlens")
+    if cu_seqlens is None and isinstance(meta, dict):
+        cu_seqlens = meta.get("cu_seqlens")
+    if cu_seqlens is not None:
+        logprobs = _packed_singleton_to_1d(logprobs)
+        teacher_logprobs = _packed_singleton_to_1d(teacher_logprobs)
+        loss_mask = _packed_singleton_to_1d(loss_mask)
+
+    if teacher_logprobs.shape != logprobs.shape:
+        raise ValueError(
+            "student logprobs, teacher_log_probs_shifted, and loss_mask must have identical shapes; "
+            f"got teacher {tuple(teacher_logprobs.shape)} vs student {tuple(logprobs.shape)}"
+        )
+    if loss_mask.shape != logprobs.shape:
+        raise ValueError(
+            "student logprobs, teacher_log_probs_shifted, and loss_mask must have identical shapes; "
+            f"got loss_mask {tuple(loss_mask.shape)} vs student {tuple(logprobs.shape)}"
+        )
     if not loss_mask.any():
         raise ValueError("on_policy_distill loss_mask is empty")
 
     estimator = config.get("distill_estimator", "low_var_kl")
-    per_token_kl = kl_penalty(student_logprobs, teacher, method=estimator)
-    loss = float(config.get("kl_coef", 1.0)) * agg_loss(
+    delta_clamp = float(config.get("delta_clamp", _DEFAULT_DELTA_CLAMP))
+    kl_clamp_max: Optional[float] = config.get("kl_clamp_max")
+
+    per_token_kl, delta = _distill_kl_per_token(
+        logprobs,
+        teacher_logprobs.detach(),
+        estimator=estimator,
+        delta_clamp=delta_clamp,
+    )
+
+    kl_output_clamped = torch.zeros((), device=logprobs.device)
+    if kl_clamp_max is not None:
+        kl_output_clamped = (per_token_kl.detach() > float(kl_clamp_max)).to(per_token_kl.dtype)
+        per_token_kl = torch.clamp(per_token_kl, max=float(kl_clamp_max))
+
+    dp_size, batch_num_tokens, global_batch_size = _resolve_distill_norm(config, meta)
+    loss = agg_loss(
         per_token_kl,
         loss_mask,
         loss_agg_mode=config.get("loss_agg_mode", "token-mean"),
-        dp_size=config.get("dp_size", 1),
-        batch_num_tokens=config.get("batch_num_tokens"),
-        global_batch_size=config.get("global_batch_size"),
+        dp_size=dp_size,
+        batch_num_tokens=batch_num_tokens,
+        global_batch_size=global_batch_size,
     )
+    kl_coef = float(config.get("kl_coef", 1.0))
+    loss = kl_coef * loss
 
-    masked_kl = per_token_kl.detach()[loss_mask]
+    mask_count = float(loss_mask.count_nonzero().item())
+    masked_kl_mean = _masked_sum(per_token_kl, loss_mask) / max(mask_count, 1.0)
+    masked_k1_mean = _masked_sum(-delta, loss_mask) / max(mask_count, 1.0)
+    kl_sum = _masked_sum(per_token_kl, loss_mask)
     metrics = {
-        "distill_kl": float(masked_kl.mean().cpu()),
-        "distill_kl_sum": float(masked_kl.sum().cpu()),
-        "distill_kl_count": int(masked_kl.numel()),
         "loss": float(loss.detach().cpu()),
+        "loss.sum": kl_coef * kl_sum,
+        "loss.tokens": mask_count,
+        "distill_kl": masked_kl_mean,
+        "distill_kl.sum": kl_sum,
+        "distill_kl.tokens": mask_count,
+        "distill_k1": masked_k1_mean,
+        "distill_kl_sum": _masked_sum(per_token_kl, loss_mask),
+        "distill_kl_count": mask_count,
+        "distill_k1_sum": _masked_sum(-delta, loss_mask),
+        "distill_abs_delta_sum": _masked_sum(delta.abs(), loss_mask),
+        "teacher_logprob_sum": _masked_sum(teacher_logprobs, loss_mask),
+        "student_logprob_sum": _masked_sum(logprobs, loss_mask),
+        "distill_delta_clamped_count": _masked_sum((delta.abs() > delta_clamp).to(delta.dtype), loss_mask),
+        "distill_kl_output_clamped_count": (
+            _masked_sum(kl_output_clamped, loss_mask) if kl_clamp_max is not None else 0.0
+        ),
+        "loss_term_distill": float(loss.detach().item()),
+        "distill_kl_max": _masked_max(per_token_kl, loss_mask),
+        "distill_delta_max": _masked_max(delta, loss_mask),
+        "distill_delta_min": -_masked_max(-delta, loss_mask),
+        "distill_kl_coef": kl_coef,
+        "distill_delta_clamp": delta_clamp,
+        "distill_estimator_is_k3": float(estimator in _ESTIMATORS_K3),
+        "distill_dp_size": float(dp_size),
+        "distill_batch_num_tokens": float(batch_num_tokens if batch_num_tokens is not None else mask_count),
     }
-    old_logprobs = batch.get("old_log_probs_shifted")
-    if old_logprobs is not None:
-        old = old_logprobs.to(student_logprobs.device)
-        delta = (student_logprobs.detach() - old).abs()[loss_mask]
-        metrics.update(
-            {
-                "sampler_train_abs_delta_max": float(delta.max().cpu()),
-                "sampler_train_abs_delta_mean": float(delta.mean().cpu()),
-            }
-        )
+
+    sampler_logprobs = batch.get("old_log_probs_shifted")
+    if sampler_logprobs is not None:
+        sampler_logprobs = sampler_logprobs.to(logprobs.device)
+        if cu_seqlens is not None:
+            sampler_logprobs = _packed_singleton_to_1d(sampler_logprobs)
+        if sampler_logprobs.shape == logprobs.shape:
+            sampler_delta = sampler_logprobs.detach().float() - logprobs.detach().float()
+            sampler_delta_clamped = torch.clamp(sampler_delta, min=-delta_clamp, max=delta_clamp)
+            metrics["sampler_train_kl_sum"] = _masked_sum(
+                sampler_delta_clamped.exp() - sampler_delta_clamped - 1.0, loss_mask
+            )
+            metrics["sampler_train_abs_delta_sum"] = _masked_sum(sampler_delta.abs(), loss_mask)
+            metrics["sampler_train_abs_delta_max"] = _masked_max(sampler_delta.abs(), loss_mask)
+            abs_delta = sampler_delta.abs()[loss_mask.bool()]
+            metrics["sampler_train_abs_delta_mean"] = (
+                float(abs_delta.mean().item()) if abs_delta.numel() else 0.0
+            )
+
     return loss, metrics

--- a/arctic_platform/rl/processors/packing.py
+++ b/arctic_platform/rl/processors/packing.py
@@ -29,6 +29,81 @@ def _align(x: int, n: int) -> int:
     return ((x + n - 1) // n) * n
 
 
+def model_reads_varlen_kwargs(model) -> bool:
+    """Whether this model's attention needs explicit packing boundaries in kwargs.
+
+    Hybrid linear-attention stacks (Qwen3.5, Qwen3-Next) read ``cu_seq_lens_q``
+    and ``seq_idx`` out of ``**kwargs``. Unlike flash-attention they have no
+    ``position_ids`` fallback, and both keys are read with ``.get()`` — missing
+    them silently treats a packed ``[1, T]`` batch as one sequence.
+    """
+    config = getattr(model, "config", None)
+    for cfg in (config, getattr(config, "text_config", None)):
+        if cfg is None:
+            continue
+        layer_types = getattr(cfg, "layer_types", None) or ()
+        if any("linear_attention" in str(layer_type) for layer_type in layer_types):
+            return True
+    return False
+
+
+def derive_varlen_model_kwargs(packed_mb: dict[str, Any]) -> dict[str, Any]:
+    """Derive varlen attention kwargs from a packed microbatch's ``cu_seqlens``.
+
+    Returns an empty dict when the boundaries cannot be trusted (including
+    Ulysses SP, where global ``cu_seqlens`` would mislabel a local shard), so
+    callers can merge the result unconditionally.
+    """
+    cu_seqlens = packed_mb.get("cu_seqlens")
+    input_ids = packed_mb.get("input_ids")
+    if not (torch.is_tensor(cu_seqlens) and cu_seqlens.numel() >= 2):
+        return {}
+    if not (torch.is_tensor(input_ids) and input_ids.ndim == 2 and input_ids.shape[0] == 1):
+        return {}
+
+    device = input_ids.device
+    total_tokens = int(input_ids.shape[1])
+    cu = cu_seqlens.to(device=device, dtype=torch.int32)
+    if int(cu[-1].item()) > total_tokens:
+        # Ulysses SP pairs global sequence boundaries with a local shard.
+        return {}
+
+    lens = (cu[1:] - cu[:-1]).to(torch.long)
+    max_seqlen = int(lens.max().item()) if lens.numel() else 0
+    seq_idx = torch.repeat_interleave(torch.arange(lens.numel(), device=device, dtype=torch.int32), lens)
+    if seq_idx.numel() < total_tokens:
+        # Right-padded tail (page alignment): own segment id so causal conv
+        # cannot mix padding with real tokens.
+        seq_idx = torch.cat(
+            [
+                seq_idx,
+                torch.full(
+                    (total_tokens - seq_idx.numel(),),
+                    lens.numel(),
+                    device=device,
+                    dtype=torch.int32,
+                ),
+            ]
+        )
+    return {
+        "cu_seq_lens_q": cu,
+        "cu_seq_lens_k": cu,
+        "max_length_q": max_seqlen,
+        "max_length_k": max_seqlen,
+        "seq_idx": seq_idx.unsqueeze(0),
+    }
+
+
+def packing_boundaries_from_attention_mask(attention_mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """``cu_seqlens`` and reset-per-sequence ``position_ids`` from a padded ``[B, S]`` mask."""
+    lens = attention_mask.long().sum(dim=1)
+    cu_seqlens = F.pad(torch.cumsum(lens.to(torch.int32), dim=0), (1, 0), value=0)
+    position_ids = torch.cat(
+        [torch.arange(int(n), device=attention_mask.device) for n in lens.tolist()]
+    ).unsqueeze(0)
+    return cu_seqlens, position_ids
+
+
 def pack_sequences(data: dict[str, Any]) -> dict[str, Any]:
     """Pack padded [B, S] tensor dict into [1, T] with position_ids for flash-attn.
 
@@ -68,7 +143,6 @@ def pad_packed_for_model(packed: dict[str, Any]) -> tuple[dict[str, Any], int]:
     T = int(cu_seqlens[-1].item())
     padded_T = _align(T, N_TOKENS_PER_PAGE)
     pad_length = padded_T - T
-    max_seqlen = int((cu_seqlens[1:] - cu_seqlens[:-1]).max().item())
     model_kwargs = {}
     for key in ("input_ids", "position_ids"):
         value = packed[key]
@@ -76,12 +150,9 @@ def pad_packed_for_model(packed: dict[str, Any]) -> tuple[dict[str, Any], int]:
             pad_spec = [0, 0] * (value.ndim - 2) + [0, pad_length]
             value = F.pad(value, list(reversed(pad_spec)), value=0)
         model_kwargs[key] = value
-    model_kwargs["cu_seq_lens_q"] = cu_seqlens
-    model_kwargs["cu_seq_lens_k"] = cu_seqlens
-    model_kwargs["max_length_q"] = max_seqlen
-    model_kwargs["max_length_k"] = max_seqlen
     model_kwargs["attention_mask"] = dict(full_attention=None, sliding_attention=None)
     model_kwargs["use_cache"] = False
+    model_kwargs.update(derive_varlen_model_kwargs({**packed, "input_ids": model_kwargs["input_ids"]}))
     return model_kwargs, pad_length
 
 

--- a/arctic_platform/rl/processors/pipeline.py
+++ b/arctic_platform/rl/processors/pipeline.py
@@ -51,6 +51,7 @@ first use.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import torch
@@ -69,6 +70,9 @@ from arctic_platform.rl.utils.debug import pr0
 from arctic_platform.rl.utils.debug import see_memory_usage
 
 from .microbatch import DEFAULT_MAX_TOKENS_PER_MB
+from .packing import derive_varlen_model_kwargs
+from .packing import model_reads_varlen_kwargs
+from .packing import packing_boundaries_from_attention_mask
 
 try:
     from flash_attn.ops.triton.cross_entropy import cross_entropy_loss
@@ -219,6 +223,83 @@ def dump_dict_payload(payload: dict, tag: str):
 c = 0
 
 
+def _merge_varlen_model_kwargs(engine, batch: dict) -> dict:
+    """Forward packing boundaries to linear-attention models (Qwen3.5 GDN/conv1d)."""
+    model = getattr(engine, "module", engine)
+    if not model_reads_varlen_kwargs(model):
+        return batch
+    extra = derive_varlen_model_kwargs(batch)
+    if extra:
+        batch = {**batch, **extra}
+    return batch
+
+
+# Hugging Face Qwen3.5 GDN remaps ``cu_seq_lens_q`` → ``cu_seqlens=`` for
+# ``torch_chunk_gated_delta_rule``. Passing both raises TypeError.
+_ENGINE_FWD_SKIP = frozenset({"cu_seqlens"})
+
+
+def _engine_forward_kwargs(batch: dict, meta: dict) -> dict:
+    """Kwargs for ``engine()``: same merge as ``**batch, **meta``, minus loss-only keys."""
+    merged = {**batch, **meta}
+    return {k: v for k, v in merged.items() if k not in _ENGINE_FWD_SKIP}
+
+
+def _unwrap_engine_module(engine) -> Any:
+    module = getattr(engine, "module", engine)
+    return getattr(module, "module", module)
+
+
+def uses_chunked_fp32_lm_head(engine) -> bool:
+    """True when ``inject_prime_lm_head`` replaced the HF ``lm_head``."""
+    head = getattr(_unwrap_engine_module(engine), "lm_head", None)
+    return bool(getattr(head, "chunk_size", None) or getattr(head, "fp32_lm_head", False))
+
+
+def _maybe_add_chunked_lm_head_kwargs(engine, fwd_kwargs: dict) -> dict:
+    """FusedOutputLinear requires ``labels`` + per-token ``temperature``.
+
+    Only inject when the student actually has the chunked/fp32 head so a
+    vanilla HF forward is not asked to run causal LM CE from our roll labels.
+    """
+    if not uses_chunked_fp32_lm_head(engine):
+        return fwd_kwargs
+    input_ids = fwd_kwargs.get("input_ids")
+    if not torch.is_tensor(input_ids):
+        return fwd_kwargs
+    ids = input_ids.unsqueeze(0) if input_ids.ndim == 1 else input_ids
+    out = dict(fwd_kwargs)
+    out["input_ids"] = ids
+    position_ids = out.get("position_ids")
+    if torch.is_tensor(position_ids) and position_ids.ndim == 1:
+        out["position_ids"] = position_ids.unsqueeze(0)
+    if "labels" not in out or out["labels"] is None:
+        out["labels"] = torch.roll(ids, shifts=-1, dims=-1)
+    if "temperature" not in out or out["temperature"] is None:
+        out["temperature"] = torch.ones(ids.shape, dtype=torch.float32, device=ids.device)
+    return out
+
+
+def collect_model_outputs(outputs) -> dict[str, Any]:
+    """Accept HF ModelOutput objects or ``PrimeLmOutput`` dicts from the chunked head."""
+    model_outputs: dict[str, Any] = {}
+    if isinstance(outputs, Mapping):
+        for key in ("logits", "logprobs", "entropy", "loss"):
+            value = outputs.get(key)
+            if value is not None:
+                model_outputs[key] = value
+        return model_outputs
+    if hasattr(outputs, "logits") and outputs.logits is not None:
+        model_outputs["logits"] = outputs.logits
+    if hasattr(outputs, "logprobs") and outputs.logprobs is not None:
+        model_outputs["logprobs"] = outputs.logprobs
+    if hasattr(outputs, "entropy") and outputs.entropy is not None:
+        model_outputs["entropy"] = outputs.entropy
+    if hasattr(outputs, "loss") and outputs.loss is not None:
+        model_outputs["loss"] = outputs.loss
+    return model_outputs
+
+
 def run_pipeline(
     engine,
     args: tuple,
@@ -342,9 +423,13 @@ def run_pipeline(
 
     # XXX: could the zorro parts be folded back into the model? this will also change when we start packing on the client side
     zorro_train_enable = meta.get("zorro_train_enable", False)
+    already_packed = batch.get("cu_seqlens") is not None or (
+        isinstance(meta, dict) and meta.get("cu_seqlens") is not None
+    )
+    did_unpad = False
     # pr0(f"{zorro_train_enable=}")
 
-    if pack_with_unpad or zorro_train_enable:
+    if not already_packed and (pack_with_unpad or zorro_train_enable):
         batch = compute_packing_info_for_batch(batch)
 
     if zorro_train_enable:
@@ -361,10 +446,16 @@ def run_pipeline(
 
     # pr0(f"{pack_with_unpad=}")
 
-    if pack_with_unpad:
+    if pack_with_unpad and not already_packed:
         pad_token = meta["pad_token_id"]
         attention_mask_2d_bool = batch["attention_mask"].bool()
+        cu_seqlens, packed_position_ids = packing_boundaries_from_attention_mask(attention_mask_2d_bool)
         batch = padded_tensor_2d_dict_to_unpadded_tensor_1d_dict(batch, attention_mask_2d_bool)
+        batch["cu_seqlens"] = cu_seqlens.to(batch["input_ids"].device)
+        batch["position_ids"] = packed_position_ids.to(batch["input_ids"].device)
+        did_unpad = True
+
+    batch = _merge_varlen_model_kwargs(engine, batch)
 
     log_dp_shard_tokens(
         engine.global_rank,
@@ -378,29 +469,22 @@ def run_pipeline(
     tname = timers.start(f"pipe fwd {engine.global_rank}")
     with prof_fwd():
         # passing **meta to the model since optimizations like zorro living in the model need to receive flags like calculate_entropy from the client
+        fwd_kwargs = _maybe_add_chunked_lm_head_kwargs(engine, _engine_forward_kwargs(batch, meta))
         if backward is False:
             engine.eval()
             with torch.no_grad():
-                outputs = engine(*args, **batch, **meta)
+                outputs = engine(*args, **fwd_kwargs)
         else:
             engine.train()
             # backward=True or backward="loss_only": train mode, grads enabled
-            outputs = engine(*args, **batch, **meta)
+            outputs = engine(*args, **fwd_kwargs)
 
     timers.stop_and_print_elapsed(tname)
 
     see_memory_usage("after fwd", force=True)
     prof_fwd.report()
 
-    model_outputs: dict[str, Any] = {}
-    if hasattr(outputs, "logits"):
-        model_outputs["logits"] = outputs.logits
-    if hasattr(outputs, "logprobs"):
-        model_outputs["logprobs"] = outputs.logprobs
-    if hasattr(outputs, "entropy"):
-        model_outputs["entropy"] = outputs.entropy
-    if hasattr(outputs, "loss") and outputs.loss is not None:
-        model_outputs["loss"] = outputs.loss
+    model_outputs = collect_model_outputs(outputs)
 
     # --- post-forward ---
     prof_post_fwd = ProfilerContext(type=PROFILER_TYPE, name="POST-FWD")
@@ -479,7 +563,7 @@ def run_pipeline(
         )
         dump_dict_payload(pipeline_outputs["batch"], "zorro: post-fwd[after unpad_2_pad]")
 
-    if pack_with_unpad:
+    if did_unpad:
         dump_dict_payload(pipeline_outputs["batch"], "post-fwd[before unpad_2_pad]")
         pipeline_outputs["batch"] = unpadded_tensor_1d_dict_to_padded_tensor_2d_dict(
             pipeline_outputs["batch"], attention_mask_2d_bool, pad_token
@@ -515,6 +599,8 @@ def _run_pipeline_with_packing(
     Splits batch into microbatches, packs each to [1, T] for flash
     attention, runs the pipeline on each, then unpacks and concatenates.
     """
+    from arctic_platform.common.utils import combine_metric_microbatches
+
     from .microbatch import MicroBatchSpec
     from .microbatch import split_padded_tensor_dict_into_mb_list
     from .packing import pack_sequences
@@ -526,29 +612,24 @@ def _run_pipeline_with_packing(
     mb_list = split_padded_tensor_dict_into_mb_list(all_input, mb_spec)
     n_mbs = len(mb_list.mbs)
 
-    loss_cfg = (processing or {}).get("config") or {}
-    agg_level = loss_cfg.get("importance_sampling_level", "token")
-
     captured_losses: list[float] = []
-    captured_weights: list[int] = []
-    captured_metrics: dict[str, float] = {}
+    captured_metrics: list[dict] = []
     collected_batch: dict[str, list[torch.Tensor]] = {}
 
     for i, mb in enumerate(mb_list.mbs):
         packed = pack_sequences(mb)
         pack_meta = packed.pop("_pack_meta")
 
-        # 1D meta: packed tensors have shape [1, T] — squeeze for loss fns
-        mb_1d = {
-            k: v.squeeze(0) if torch.is_tensor(v) and v.ndim == 2 and v.shape[0] == 1 else v for k, v in packed.items()
-        }
-
-        # Model always receives packed [1, T] input_ids + position_ids
+        # Packed [1, T] plus sequence boundaries so Qwen3.5 GDN/conv1d reset
+        # recurrent state per rollout instead of leaking across the concat.
         mb_kwargs = {
             "input_ids": packed["input_ids"],
             "position_ids": packed["position_ids"],
             "use_cache": False,
+            "cu_seqlens": packed["cu_seqlens"],
+            **{k: packed[k] for k in packed if k not in ("input_ids", "position_ids", "cu_seqlens")},
         }
+        mb_kwargs.update(derive_varlen_model_kwargs(packed))
 
         if backward is True and hasattr(engine, "set_gradient_accumulation_boundary"):
             engine.set_gradient_accumulation_boundary(i == n_mbs - 1)
@@ -558,24 +639,18 @@ def _run_pipeline_with_packing(
             args,
             mb_kwargs,
             meta,
-            mb_1d,
             processing,
             device,
             backward=backward,
+            pack=False,
             return_tensors=True,
         )
 
         if "avg_loss" in result:
             captured_losses.append(result["avg_loss"])
-            loss_mask = mb_1d.get("loss_mask")
-            if agg_level == "sequence":
-                weight = int(mb["input_ids"].shape[0]) if mb["input_ids"].ndim >= 2 else 1
-            else:
-                weight = int(loss_mask.sum()) if loss_mask is not None else 1
-            captured_weights.append(weight)
-            for k, v in result.get("metrics", {}).items():
-                if isinstance(v, (int, float)):
-                    captured_metrics[k] = captured_metrics.get(k, 0.0) + v * weight
+        mb_metrics = result.get("metrics")
+        if mb_metrics:
+            captured_metrics.append(mb_metrics)
 
         for k, v in result.get("batch", {}).items():
             if torch.is_tensor(v):
@@ -595,10 +670,17 @@ def _run_pipeline_with_packing(
     batch_out = {k: _concat(v) for k, v in collected_batch.items()}
 
     if captured_losses:
-        total_weight = sum(captured_weights) or 1
-        avg_loss = sum(loss * weight for loss, weight in zip(captured_losses, captured_weights)) / total_weight
-        averaged_metrics = {k: v / total_weight for k, v in captured_metrics.items()}
-        result = {"avg_loss": avg_loss, "metrics": averaged_metrics}
+        # Each microbatch loss is already normalized by the GLOBAL token count
+        # (sum_pg_mb / T_global * dp_size), so the whole-batch value is their
+        # SUM -- exactly what a single unpacked forward would report. Metrics
+        # use the same paired-key convention as the GAS microbatch path
+        # (deepspeed_worker via combine_metric_microbatches): {name}.sum /
+        # {name}.tokens are summed and folded to a global token mean, other
+        # keys are averaged. A token-weighted mean here would bias
+        # kl/per_token to Sum(S*c)/Sum(c^2) instead of Sum(S)/Sum(c).
+        avg_loss = sum(captured_losses)
+        combined_metrics = combine_metric_microbatches(captured_metrics) if captured_metrics else {}
+        result = {"avg_loss": avg_loss, "metrics": combined_metrics}
         if batch_out:
             result["batch"] = detensorize(batch_out)
         return result

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ live in the [project README](../README.md).
 ```
 ┌──────────────────────────────────────────────┐
 │  Framework / script (CPU or GPU driver)      │
-│  SFT client  ·  RL client (verl / SkyRL)     │
+│  SFT · RL (verl / SkyRL) · OPD client        │
 └──────────────────────┬───────────────────────┘
                        │ HTTP or Ray
                        ▼
@@ -25,11 +25,13 @@ live in the [project README](../README.md).
 |-----|----------|
 | [**SFT**](sft.md) | Supervised fine-tuning — CPU client, wire batch, `sft` vs `sft_ce`, config |
 | [**RL**](rl.md) | Reinforcement learning — engines, client API, ZoRRo Train / Inference, integrations |
+| [**OPD**](opd.md) | On-policy distillation — `ArcticOPDClient`, single-logit reverse KL, vs TRL DistillationTrainer |
 | [**Common**](common.md) | Shared server infra — HTTP CLI, jobs/endpoints, DeepSpeed worker, metrics, env |
 
 ## Quick paths
 
 - **SFT smoke (colocated):** see [sft.md § Quick start](sft.md#quick-start)
+- **OPD vs TRL DistillationTrainer:** [opd.md § Stance vs TRL DistillationTrainer](opd.md#stance-vs-trl-distillationtrainer)
 - **RL starter recipe:** [`recipes/rl/verl/simple/`](../recipes/rl/verl/)
 - **SkyRL recipes:** [`recipes/rl/skyrl/`](../recipes/rl/skyrl/)
 - **verl plugin:** [`arctic_platform/integrations/verl/`](../arctic_platform/integrations/verl/)

--- a/docs/opd.md
+++ b/docs/opd.md
@@ -1,0 +1,139 @@
+# Arctic Platform on-policy distillation (OPD)
+
+`ArcticOPDClient` is a dual client: a student (DeepSpeed train + vLLM sample)
+and a frozen teacher (vLLM sample only). The **user script** owns the loop;
+Arctic owns model weights, `fwd_bwd`, the optimizer, and student weight sync.
+
+Docs index: [index.md](index.md) · Shared server: [common.md](common.md) · RL: [rl.md](rl.md)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  User process (run_on_policy_distill.py)                    │
+│  ArcticOPDClient                                            │
+│    generate → score_teacher → fwd_bwd → step → sync_weights │
+└──────────────────────────────┬──────────────────────────────┘
+                               │ HTTP or Ray
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Student server: DeepSpeed train + vLLM sample              │
+│  Teacher server: vLLM only (training_gpus=0, never synced)  │
+│  loss_fn = on_policy_distill (single-logit reverse KL)      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Stance vs TRL DistillationTrainer
+
+**Comparable at the algorithm-family level, not as APIs or losses.** Both do
+on-policy knowledge distillation in the sense of
+[Agarwal et al., 2023 (GKD)](https://huggingface.co/papers/2306.13649): the
+student generates completions, the teacher scores those same token ids, the
+student updates to match the teacher.
+
+They are **complementary, not interchangeable**. This tree does **not** wrap
+or subclass Hugging Face TRL's
+[`DistillationTrainer`](https://huggingface.co/docs/trl/en/distillation_trainer).
+
+The closer TRL system analog is
+[`AsyncDistillationTrainer`](https://huggingface.co/docs/trl/en/async_distillation_trainer)
+(remote HTTP teacher, student vLLM, weight sync, no local teacher). Even that
+trains the student locally with FSDP2 and uses a top-k generalized JSD, not
+Arctic's single-logit k3 reverse KL.
+
+Do not land distillation work on the GRPO `TrainingClientProtocol` draft
+([Arctic-Platform PR #84](https://github.com/Snowflake-AI-Research/Arctic-Platform/pull/84)).
+That adapter is GRPO-only and is out of scope here.
+
+A CPU-only Arctic training-client path for async distillation is a follow-up
+change; it is not part of this client.
+
+## vs TRL
+
+| | `ArcticOPDClient` | TRL `DistillationTrainer` | TRL `AsyncDistillationTrainer` |
+|---|---|---|---|
+| Role | Dual client over Arctic RL servers | Full HF Trainer | Async trainer like `AsyncGRPOTrainer` |
+| Owns the loop | No — [`run_on_policy_distill.py`](../arctic_platform/opd/examples/run_on_policy_distill.py) | Yes (`trainer.train()`) | Yes |
+| Where models live | Remote DeepSpeed + two vLLM jobs | Local student + local teacher (optional vLLM for gen) | Local student (FSDP2) + remote student vLLM + remote teacher vLLM |
+| Teacher signal | Logprob of the **sampled token only** (`prompt_logprobs: 0`), or top-k via `score_teacher_topk` | Full next-token distribution, chunked | Sparse **top-k** teacher distribution over HTTP |
+| Loss | Single-logit reverse KL, k3 / `low_var_kl` | Generalized JSD via `beta` | Same JSD, sparse support |
+| Optimizer / shard | DeepSpeed ZeRO-1 on the server | Accelerate / DeepSpeed / FSDP | FSDP2 only (no DeepSpeed ZeRO) |
+| Weight sync | `client.sync_weights()` student train → student sampler | In-process or vLLM NCCL | NCCL to student vLLM |
+
+Public Arctic surface is primitives, not a trainer:
+
+- `generate` / `generate_teacher`
+- `fwd_bwd` (`loss_fn: "on_policy_distill"`)
+- `fwd_no_grad` (training-engine forward without backward)
+- `step` / `sync_weights` / `save_checkpoint`
+
+TRL surface is `DistillationTrainer(model, teacher_model, train_dataset, ...).train()`.
+
+## Loss: why they are not the same
+
+Arctic ([`on_policy_distill.py`](../arctic_platform/rl/processors/on_policy_distill.py),
+[`scoring.py`](../arctic_platform/opd/scoring.py)):
+
+- Default teacher scoring uses `prompt_logprobs=0` (sampled token only).
+- `score_teacher_topk` requests `prompt_logprobs=k` plus an optional tail bucket.
+- The native train step uses only the sampled-token logprob.
+- Estimator: `exp(delta) - delta - 1` with
+  `delta = log π_T(y) - log π_S(y)` (k3 / `low_var_kl`).
+- This is a single-sample estimator of reverse KL `KL(π_S || π_T)`. It never
+  sees the rest of the vocabulary. No `beta`, no forward KL, no JSD mixture.
+
+TRL DistillationTrainer:
+
+- Generalized JSD: `β KL(T || M) + (1-β) KL(S || M)`, `M = (1-β)S + βT`.
+- `beta=0` → forward KL; `beta=1` → reverse KL; `beta=0.5` → JSD.
+- Sync path: full (chunked) next-token distribution.
+- Async path: `teacher_top_k` candidates; still a distributional divergence.
+
+Even at `beta=1.0` (TRL reverse KL), TRL is not Arctic's native loss: TRL uses
+a full or top-k distribution; `on_policy_distill` uses one token's logprob.
+
+Shared request shape: both teacher-force-score the student's token ids with
+`max_tokens=1` + `prompt_logprobs`. Both require a shared vocabulary and no
+retokenization.
+
+## Entry points
+
+```python
+from arctic_platform.opd import (
+    ArcticOPDClient,
+    ArcticOPDClientConfig,
+    create_arctic_opd_client,
+    score_teacher,
+    score_teacher_topk,
+    DEFAULT_PROCESSING,
+)
+```
+
+- Config: `arctic_platform.opd.config.ArcticOPDClientConfig`
+- Client: `arctic_platform.opd.client.ArcticOPDClient`
+- Teacher scoring: `arctic_platform.opd.scoring.score_teacher` / `score_teacher_topk`
+- Loss (server): `arctic_platform.rl.processors.on_policy_distill`
+
+## Quick start
+
+Dry-run alignment check (no jobs):
+
+```bash
+python -m arctic_platform.opd.examples.run_on_policy_distill --dry-run
+```
+
+Live student/teacher sampling plus train steps (see the example module
+docstring for 1-node and multi-node packs):
+
+```bash
+python -m arctic_platform.opd.examples.run_on_policy_distill --live \
+  --student-model Qwen/Qwen3.5-4B \
+  --teacher-model Qwen/Qwen3.6-27B \
+  --training-gpus 1 --sampling-gpus 1 --teacher-sampling-gpus 1
+```
+
+One training step is:
+
+1. `client.generate` — student vLLM completions + sampler logprobs
+2. `score_teacher` — teacher `prompt_logprobs` on the same token ids
+3. `client.fwd_bwd` — DeepSpeed forward + `on_policy_distill` + backward
+4. `client.step` — optimizer
+5. `client.sync_weights` — student train → student sampler only

--- a/docs/rl.md
+++ b/docs/rl.md
@@ -4,6 +4,8 @@ Reinforcement-learning backend: a thin client drives three GPU engines on a
 remote (or colocated) Arctic server. The RL framework keeps the training loop,
 rewards, and advantage estimation; Arctic owns the heavy compute.
 
+Docs index: [index.md](index.md) · Shared server: [common.md](common.md) · SFT: [sft.md](sft.md) · OPD: [opd.md](opd.md)
+
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  RL framework (verl / SkyRL / custom loop)                  │

--- a/docs/sft.md
+++ b/docs/sft.md
@@ -5,7 +5,7 @@ a remote DeepSpeed training server over HTTP (default) or Ray. The client owns
 the data loop; the server owns model weights, forward/backward, and the
 optimizer.
 
-Docs index: [index.md](index.md) · Shared server: [common.md](common.md) · RL: [rl.md](rl.md)
+Docs index: [index.md](index.md) · Shared server: [common.md](common.md) · RL: [rl.md](rl.md) · OPD: [opd.md](opd.md)
 
 ```
 ┌──────────────────────────────────────────────┐

--- a/tests/model/test_hf_vllm_weight_sync.py
+++ b/tests/model/test_hf_vllm_weight_sync.py
@@ -1,0 +1,225 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for HF Qwen3.5 → vLLM weight-sync conversion."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import (
+    expected_hf_names_for_text_sync,
+)
+from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import (
+    pack_qwen35_gdn_layer,
+)
+from arctic_platform.model.implementations.qwen35.hf_vllm_weight_sync import (
+    to_vllm_sync_weights,
+)
+
+
+def _qwen35_2b_like_layer(layer: int) -> list[tuple[str, torch.Tensor]]:
+    prefix = f"model.layers.{layer}"
+    return [
+        (f"{prefix}.input_layernorm.weight", torch.ones(2048)),
+        (f"{prefix}.linear_attn.in_proj_qkv.weight", torch.arange(6144 * 2048).reshape(6144, 2048).float()),
+        (f"{prefix}.linear_attn.in_proj_z.weight", torch.arange(2048 * 2048).reshape(2048, 2048).float() + 1),
+        (f"{prefix}.linear_attn.in_proj_b.weight", torch.arange(16 * 2048).reshape(16, 2048).float() + 2),
+        (f"{prefix}.linear_attn.in_proj_a.weight", torch.arange(16 * 2048).reshape(16, 2048).float() + 3),
+        (f"{prefix}.linear_attn.conv1d.weight", torch.arange(2048 * 4).reshape(2048, 4).float()),
+        (f"{prefix}.linear_attn.out_proj.weight", torch.ones(2048, 2048)),
+        (f"{prefix}.mlp.down_proj.weight", torch.ones(2048, 2048)),
+    ]
+
+
+def test_qwen35_packs_gdn_prefix_and_conv1d():
+    embed = torch.ones(100, 2048)
+    layer_weights = _qwen35_2b_like_layer(0)
+    by_hf = dict(layer_weights)
+    weights = [
+        ("model.embed_tokens.weight", embed),
+        *layer_weights,
+        ("model.visual.patch_embed.weight", torch.ones(8)),
+        ("mtp.layers.0.weight", torch.ones(4)),
+    ]
+    converted = dict(to_vllm_sync_weights(weights))
+
+    qkv = by_hf["model.layers.0.linear_attn.in_proj_qkv.weight"]
+    z = by_hf["model.layers.0.linear_attn.in_proj_z.weight"]
+    b = by_hf["model.layers.0.linear_attn.in_proj_b.weight"]
+    a = by_hf["model.layers.0.linear_attn.in_proj_a.weight"]
+    conv = by_hf["model.layers.0.linear_attn.conv1d.weight"]
+
+    qkvz = converted["language_model.model.layers.0.linear_attn.in_proj_qkvz.weight"]
+    ba = converted["language_model.model.layers.0.linear_attn.in_proj_ba.weight"]
+    conv_out = converted["language_model.model.layers.0.linear_attn.conv1d.weight"]
+
+    assert qkvz.shape == (8192, 2048)
+    assert torch.equal(qkvz[:6144], qkv)
+    assert torch.equal(qkvz[6144:], z)
+    assert ba.shape == (32, 2048)
+    assert torch.equal(ba[:16], b)
+    assert torch.equal(ba[16:], a)
+    assert conv_out.shape == (2048, 1, 4)
+    assert torch.equal(conv_out.squeeze(1), conv)
+
+    assert "language_model.model.embed_tokens.weight" in converted
+    assert "language_model.lm_head.weight" not in converted
+    assert "visual.patch_embed.weight" not in converted
+    assert "mtp.layers.0.weight" not in converted
+    assert "model.layers.0.linear_attn.in_proj_qkv.weight" not in converted
+
+
+def test_qwen35_vlm_language_model_prefix():
+    weights = [
+        ("model.language_model.embed_tokens.weight", torch.ones(4, 8)),
+        (
+            "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
+            torch.ones(6, 8),
+        ),
+        (
+            "model.language_model.layers.0.linear_attn.in_proj_z.weight",
+            torch.ones(2, 8),
+        ),
+        (
+            "model.language_model.layers.0.linear_attn.in_proj_b.weight",
+            torch.ones(1, 8),
+        ),
+        (
+            "model.language_model.layers.0.linear_attn.in_proj_a.weight",
+            torch.ones(1, 8),
+        ),
+        ("lm_head.weight", torch.ones(4, 8)),
+    ]
+    converted_list = to_vllm_sync_weights(weights)
+    converted = dict(converted_list)
+    assert "language_model.model.embed_tokens.weight" in converted
+    assert "language_model.model.layers.0.linear_attn.in_proj_qkvz.weight" in converted
+    assert converted["language_model.model.layers.0.linear_attn.in_proj_qkvz.weight"].shape == (8, 8)
+    assert "language_model.lm_head.weight" not in converted
+
+
+def test_qwen3_passthrough_without_unpacked_gdn():
+    weights = [
+        ("model.embed_tokens.weight", torch.ones(4, 8)),
+        ("model.layers.0.self_attn.q_proj.weight", torch.ones(8, 8)),
+        ("model.layers.0.mlp.down_proj.weight", torch.ones(8, 8)),
+        ("lm_head.weight", torch.ones(4, 8)),
+    ]
+    converted = to_vllm_sync_weights(weights)
+    assert [name for name, _ in converted] == [name for name, _ in weights]
+    for (_, src), (_, dst) in zip(weights, converted):
+        assert src is dst
+
+
+def test_pack_qwen35_gdn_layer_matches_vllm_cat_order():
+    prefix = "model.layers.1"
+    qkv = torch.arange(12).reshape(6, 2).float()
+    z = torch.arange(4).reshape(2, 2).float() + 100
+    b = torch.arange(2).reshape(1, 2).float() + 200
+    a = torch.arange(2).reshape(1, 2).float() + 300
+    layer_sd = {
+        f"{prefix}.linear_attn.in_proj_qkv.weight": qkv,
+        f"{prefix}.linear_attn.in_proj_z.weight": z,
+        f"{prefix}.linear_attn.in_proj_b.weight": b,
+        f"{prefix}.linear_attn.in_proj_a.weight": a,
+        f"{prefix}.linear_attn.out_proj.weight": torch.ones(2, 2),
+    }
+    pack_qwen35_gdn_layer(layer_sd, prefix)
+    assert f"{prefix}.linear_attn.in_proj_qkv.weight" not in layer_sd
+    assert torch.equal(
+        layer_sd[f"{prefix}.linear_attn.in_proj_qkvz.weight"],
+        torch.cat([qkv, z], dim=0),
+    )
+    assert torch.equal(
+        layer_sd[f"{prefix}.linear_attn.in_proj_ba.weight"],
+        torch.cat([b, a], dim=0),
+    )
+
+
+def test_expected_hf_names_drop_missing_visual_keep_shipped():
+    expected = {
+        "language_model.model.embed_tokens.weight",
+        "visual.patch_embed.weight",
+        "mtp.layers.0.weight",
+    }
+    sender = {"language_model.model.embed_tokens.weight"}
+    filtered = expected_hf_names_for_text_sync(expected, sender)
+    assert filtered == {"language_model.model.embed_tokens.weight"}
+
+    sender_with_vision = sender | {"visual.patch_embed.weight"}
+    filtered_vlm = expected_hf_names_for_text_sync(expected, sender_with_vision)
+    assert "visual.patch_embed.weight" in filtered_vlm
+    assert "mtp.layers.0.weight" not in filtered_vlm
+
+
+def test_text_only_extension_allows_missing_visual():
+    from arctic_platform.common.weight_sync_extension import TextOnlyWeightSyncExtension
+
+    ext = TextOnlyWeightSyncExtension()
+    expected = {
+        "language_model.model.embed_tokens.weight",
+        "visual.patch_embed.weight",
+        "mtp.layers.0.weight",
+    }
+
+    import arctic_inference.server.weight_sync.utils as ws_utils
+
+    orig = ws_utils.compute_expected_hf_param_names
+    ws_utils.compute_expected_hf_param_names = lambda model: set(expected)
+    try:
+        ext._validate_weight_sync_names(
+            object(),
+            ["language_model.model.embed_tokens.weight"],
+            context="test",
+        )
+    finally:
+        ws_utils.compute_expected_hf_param_names = orig
+
+
+def test_text_only_extension_still_rejects_unexpected_lm_name():
+    from arctic_platform.common.weight_sync_extension import TextOnlyWeightSyncExtension
+
+    ext = TextOnlyWeightSyncExtension()
+    import arctic_inference.server.weight_sync.utils as ws_utils
+
+    orig = ws_utils.compute_expected_hf_param_names
+    ws_utils.compute_expected_hf_param_names = lambda model: {
+        "language_model.model.embed_tokens.weight",
+        "visual.patch_embed.weight",
+    }
+    try:
+        with pytest.raises(RuntimeError, match="does NOT expect"):
+            ext._validate_weight_sync_names(
+                object(),
+                [
+                    "language_model.model.embed_tokens.weight",
+                    "language_model.lm_head.weight",
+                ],
+                context="test",
+            )
+    finally:
+        ws_utils.compute_expected_hf_param_names = orig
+
+
+def test_build_model_config_registers_enginecore_extension():
+    from arctic_platform.common.utils.server_models import build_model_config
+    from arctic_platform.common.weight_sync_extension import WORKER_EXTENSION_CLS
+
+    cfg = build_model_config("Qwen/Qwen3.5-2B", {})
+    assert cfg.extra_engine_kwargs["worker_extension_cls"] == WORKER_EXTENSION_CLS
+    kwargs = cfg.to_engine_kwargs()
+    assert kwargs["worker_extension_cls"] == WORKER_EXTENSION_CLS

--- a/tests/opd/test_example_loop.py
+++ b/tests/opd/test_example_loop.py
@@ -1,0 +1,422 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+
+from arctic_platform.opd.examples.run_on_policy_distill import _SYNC_ZERO_RUN
+from arctic_platform.opd.examples.run_on_policy_distill import _ds_config
+from arctic_platform.opd.examples.run_on_policy_distill import _student_gpu_memory_utilization
+from arctic_platform.opd.examples.run_on_policy_distill import build_parser
+from arctic_platform.opd.examples.run_on_policy_distill import build_step_record
+from arctic_platform.opd.examples.run_on_policy_distill import check_metrics
+from arctic_platform.opd.examples.run_on_policy_distill import check_sync_result
+from arctic_platform.opd.examples.run_on_policy_distill import iter_batches
+from arctic_platform.opd.examples.run_on_policy_distill import kl_per_token_len_adj
+from arctic_platform.opd.examples.run_on_policy_distill import load_prompt_records
+from arctic_platform.opd.examples.run_on_policy_distill import lr_at
+from arctic_platform.opd.examples.run_on_policy_distill import resolve_train_attn
+from arctic_platform.opd.examples.run_on_policy_distill import prompt_content_from_record
+from arctic_platform.opd.examples.run_on_policy_distill import student_sampling_params
+from arctic_platform.opd.examples.run_on_policy_distill import tokenize_and_filter
+from arctic_platform.opd.examples.run_on_policy_distill import tokenize_prompt
+from arctic_platform.opd.examples.run_on_policy_distill import vllm_fa2_engine_kwargs
+from arctic_platform.opd.examples.run_on_policy_distill import vllm_fp32_engine_kwargs
+from arctic_platform.opd.examples.run_on_policy_distill import vllm_supports_fp32_lm_head
+
+
+def test_linear_warmup_then_constant():
+    assert lr_at(0, 2e-5, 8) == 2e-5 * 1 / 8
+    assert lr_at(7, 2e-5, 8) == 2e-5
+    assert lr_at(20, 2e-5, 8) == 2e-5
+
+
+def test_cosine_after_warmup():
+    peak = 2e-5
+    assert lr_at(0, peak, 8, schedule="cosine", total_steps=152) == peak * 1 / 8
+    assert lr_at(7, peak, 8, schedule="cosine", total_steps=152) == peak
+    mid = lr_at(80, peak, 8, schedule="cosine", total_steps=152)
+    expected_frac = (80 - 8) / (152 - 8)
+    expected = peak * (0.1 + 0.9 * 0.5 * (1.0 + math.cos(math.pi * expected_frac)))
+    assert math.isclose(mid, expected)
+    last = lr_at(151, peak, 8, schedule="cosine", total_steps=152)
+    last_frac = (151 - 8) / (152 - 8)
+    last_expected = peak * (0.1 + 0.9 * 0.5 * (1.0 + math.cos(math.pi * last_frac)))
+    assert math.isclose(last, last_expected)
+    assert last > 0.1 * peak * 0.99
+
+
+def test_load_prompt_records_and_max_prompt_len(tmp_path: Path):
+    path = tmp_path / "prompts.jsonl"
+    path.write_text(
+        json.dumps({"prompt": "short"})
+        + "\n"
+        + json.dumps({"text": "also short"})
+        + "\n"
+        + json.dumps({"messages": [{"role": "user", "content": "chat"}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    records = load_prompt_records(str(path))
+    assert [prompt_content_from_record(row) for row in records] == [
+        "short",
+        "also short",
+        [{"role": "user", "content": "chat"}],
+    ]
+
+    class FakeTokenizer:
+        def apply_chat_template(self, messages, **kwargs):
+            content = messages[0]["content"]
+            return list(range(len(content)))
+
+    kept = tokenize_and_filter(FakeTokenizer(), records, max_prompt_len=5)
+    assert kept == [[0, 1, 2, 3, 4], [0, 1, 2, 3]]
+
+
+def test_tokenize_prompt_pins_non_thinking():
+    class CaptureTokenizer:
+        def __init__(self):
+            self.kwargs = None
+
+        def apply_chat_template(self, messages, **kwargs):
+            self.kwargs = kwargs
+            return [1, 2, 3]
+
+    tok = CaptureTokenizer()
+    assert tokenize_prompt(tok, "hello") == [1, 2, 3]
+    assert tok.kwargs["enable_thinking"] is False
+    assert tok.kwargs["add_generation_prompt"] is True
+    assert tok.kwargs["tokenize"] is True
+
+
+def test_tokenize_prompt_can_enable_thinking():
+    class CaptureTokenizer:
+        def __init__(self):
+            self.kwargs = None
+
+        def apply_chat_template(self, messages, **kwargs):
+            self.kwargs = kwargs
+            return [7, 8, 9]
+
+    tok = CaptureTokenizer()
+    assert tokenize_prompt(tok, "hello", enable_thinking=True) == [7, 8, 9]
+    assert tok.kwargs["enable_thinking"] is True
+    parser = build_parser()
+    assert parser.parse_args([]).enable_thinking is False
+    assert parser.parse_args(["--enable-thinking"]).enable_thinking is True
+
+
+def test_tokenize_prompt_drops_enable_thinking_if_unsupported():
+    class StrictTokenizer:
+        def apply_chat_template(self, messages, **kwargs):
+            if "enable_thinking" in kwargs:
+                raise TypeError("unexpected enable_thinking")
+            return [4, 5]
+
+    assert tokenize_prompt(StrictTokenizer(), "hello") == [4, 5]
+
+
+def test_resolve_train_attn_keeps_fa2():
+    assert resolve_train_attn("flash_attention_2") == "flash_attention_2"
+
+
+def test_parser_defaults_match_xyu_train_attn_and_graphs():
+    ns = build_parser().parse_args([])
+    assert ns.attn == "flash_attention_3"
+    assert ns.enforce_eager is False
+    assert ns.vllm_fp32_lm_head is True
+    assert ns.train_fp32_lm_head is True
+    off = build_parser().parse_args(["--no-vllm-fp32-lm-head", "--no-train-fp32-lm-head"])
+    assert off.vllm_fp32_lm_head is False
+    assert off.train_fp32_lm_head is False
+
+
+def test_student_sampling_params_match_xyu():
+    params = student_sampling_params(16384)
+    assert params["n"] == 1
+    assert params["temperature"] == 1.0
+    assert params["top_p"] == 1.0
+    assert params["max_tokens"] == 16384
+    assert params["logprobs"] == 0
+    assert params.get("top_k", -1) == -1
+    assert params.get("min_p", 0.0) == 0.0
+    assert isinstance(vllm_supports_fp32_lm_head(), bool)
+    fp32_engine = vllm_fp32_engine_kwargs()
+    assert fp32_engine in (
+        {},
+        {"fp32_lm_head": True},
+        {"hf_overrides": {"head_dtype": "float32"}},
+    )
+    fa2_engine = vllm_fa2_engine_kwargs()
+    assert fa2_engine in ({}, {"attention_config": {"flash_attn_version": 2}})
+
+
+def test_tokenize_prompt_unwraps_qwen35_mapping():
+    class MappingTokenizer:
+        def apply_chat_template(self, messages, **kwargs):
+            return {"input_ids": [10, 11, 12], "attention_mask": [1, 1, 1]}
+
+    assert tokenize_prompt(MappingTokenizer(), "hello") == [10, 11, 12]
+
+
+def test_tokenize_prompt_unwraps_nested_batch_input_ids():
+    class NestedTokenizer:
+        def apply_chat_template(self, messages, **kwargs):
+            return {"input_ids": [[10, 11]], "attention_mask": [[1, 1]]}
+
+    assert tokenize_prompt(NestedTokenizer(), "hello") == [10, 11]
+
+
+def test_iter_batches_shuffle_is_seed_deterministic():
+    ids = [[i] for i in range(10)]
+    a = iter_batches(ids, batch_size=3, steps=4, shuffle=True, seed=0)
+    b = iter_batches(ids, batch_size=3, steps=4, shuffle=True, seed=0)
+    c = iter_batches(ids, batch_size=3, steps=4, shuffle=True, seed=1)
+    assert a == b
+    assert a != c
+    assert a != iter_batches(ids, batch_size=3, steps=4, shuffle=False, seed=0)
+    unshuffled = iter_batches(ids, batch_size=3, steps=2, shuffle=False, seed=0)
+    assert unshuffled[0] == [[0], [1], [2]]
+    assert unshuffled[1] == [[3], [4], [5]]
+
+
+def test_ds_config_cosine_and_gas():
+    args = SimpleNamespace(
+        batch_size=8,
+        training_gpus=2,
+        lr=2e-5,
+        lr_schedule="cosine",
+        steps=152,
+        warmup_steps=8,
+    )
+    ds = _ds_config(args)
+    assert ds["train_batch_size"] == 8
+    assert ds["train_micro_batch_size_per_gpu"] == 1
+    assert ds["gradient_accumulation_steps"] == 4
+    assert ds["zero_optimization"]["stage"] == 1
+    assert "scheduler" not in ds
+    packed = _ds_config(
+        SimpleNamespace(
+            batch_size=8,
+            training_gpus=2,
+            lr=2e-5,
+            lr_schedule="cosine",
+            steps=152,
+            warmup_steps=8,
+            max_tokens_per_mb=46592,
+        )
+    )
+    assert packed["gradient_accumulation_steps"] == 1
+    assert packed["train_micro_batch_size_per_gpu"] == 4
+    assert packed["train_batch_size"] == 8
+
+
+def test_student_util_defaults_and_xyu_aliases():
+    colocated = SimpleNamespace(student_gpu_memory_utilization=None, colocate=True, gpu_memory_utilization=0.85)
+    disjoint = SimpleNamespace(student_gpu_memory_utilization=None, colocate=False, gpu_memory_utilization=0.85)
+    assert _student_gpu_memory_utilization(colocated) == 0.35
+    assert _student_gpu_memory_utilization(disjoint) == 0.85
+    args = build_parser().parse_args(
+        [
+            "--learning-rate",
+            "2e-5",
+            "--seq-len",
+            "32768",
+            "--max-new-tokens",
+            "1024",
+            "--train-gpus",
+            "2",
+            "--student-infer-gpus",
+            "2",
+            "--teacher-infer-gpus",
+            "4",
+            "--student-tp",
+            "1",
+            "--teacher-tp",
+            "2",
+            "--no-colocate",
+            "--wandb-run-name",
+            "opd3n_20260812_194823_lr2e-5-1node",
+        ]
+    )
+    assert args.lr == 2e-5
+    assert args.max_seq_len == 32768
+    assert args.max_tokens == 1024
+    assert args.training_gpus == 2
+    assert args.sampling_gpus == 2
+    assert args.teacher_sampling_gpus == 4
+    assert args.student_tp == 1
+    assert args.teacher_tp == 2
+    assert args.colocate is False
+    assert args.wandb_run_name == "opd3n_20260812_194823_lr2e-5-1node"
+    assert args.wandb_len_ref == 4096.0
+    assert args.wandb_len_exponent == 0.486
+    three_node = build_parser().parse_args(
+        [
+            "--training-gpus",
+            "8",
+            "--sampling-gpus",
+            "8",
+            "--teacher-sampling-gpus",
+            "8",
+            "--teacher-tp",
+            "2",
+            "--no-colocate",
+            "--student-ray-hostfile",
+            "/tmp/opd_student_hostfile",
+            "--teacher-ray-hostfile",
+            "/tmp/opd_teacher_hostfile",
+            "--teacher-server-cuda-visible-devices",
+            "",
+        ]
+    )
+    assert three_node.training_gpus == 8
+    assert three_node.sampling_gpus == 8
+    assert three_node.teacher_sampling_gpus == 8
+    assert three_node.student_ray_hostfile == "/tmp/opd_student_hostfile"
+    assert three_node.teacher_ray_hostfile == "/tmp/opd_teacher_hostfile"
+    assert three_node.teacher_server_cuda_visible_devices == ""
+
+
+def test_kl_len_adj_matches_xyu_446z0mnb():
+    # Last logged values from yak/opd-qwen35/446z0mnb.
+    per_token = 0.007215610657604029
+    tokens_per_rollout = 1663.8125
+    adj = kl_per_token_len_adj(per_token, tokens_per_rollout, 4096.0, 0.486)
+    assert math.isclose(adj, 0.004657178530134034, rel_tol=1e-9)
+
+
+def test_build_step_record_xyu_groups():
+    result = {
+        "forward_backward": {
+            "metrics": {
+                "loss": 0.1,
+                "distill_kl": 0.08,
+                "distill_k1": 0.09,
+                "distill_kl_count": 32,
+                "sampler_train_abs_delta_max": 0.2,
+                "sampler_train_abs_delta_mean": 0.01,
+            }
+        },
+        "step": {"metrics": {"grad_norm": [1.5, 1.5]}},
+        "n_rollouts": 16,
+        "tokens_scored": 26624,
+        "times": {
+            "gen_s": 10.0,
+            "score_s": 4.0,
+            "fwdbwd_s": 2.0,
+            "step_sync_s": 1.0,
+            "total_s": 17.0,
+        },
+    }
+    record = build_step_record(
+        step=3,
+        learning_rate=2e-5,
+        result=result,
+        tokens_cumulative=26624,
+        elapsed_s=99.0,
+        wandb_len_ref=4096.0,
+        wandb_len_exponent=0.486,
+    )
+    assert record["loss/avg"] == 0.1
+    assert record["kl/per_token"] == 0.08
+    assert record["kl/k1_per_token"] == 0.09
+    assert record["optim/lr"] == 2e-5
+    assert record["optim/grad_norm"] == 1.5
+    assert record["optim/update_successful"] == 1.0
+    assert record["tokens/scored"] == 26624
+    assert record["tokens/per_rollout"] == 1664.0
+    assert record["tokens/cumulative"] == 26624
+    assert record["time/gen_s"] == 10.0
+    assert record["time/score_s"] == 4.0
+    assert record["time/fwdbwd_s"] == 2.0
+    assert record["time/step_sync_s"] == 1.0
+    assert record["time/total_s"] == 17.0
+    assert record["sync/abs_delta_max"] == 0.2
+    assert record["kl/per_token_len_adj"] == kl_per_token_len_adj(0.08, 1664.0, 4096.0, 0.486)
+    assert record["loss"] == 0.1
+    assert record["grad_norm"] == 1.5
+
+
+def test_check_sync_result_flags_zero_params_loaded():
+    _SYNC_ZERO_RUN[0] = 0
+    warnings, summary = check_sync_result({"recv": {"params_loaded": 0, "workers": [{"params_loaded": 0}]}})
+    assert any("params_loaded=0" in w for w in warnings)
+    assert "params_loaded" in summary
+
+
+def test_check_sync_result_consecutive_zero_l2_is_a_stall():
+    _SYNC_ZERO_RUN[0] = 0
+    payload = {"model_l2_sq_before": 1.0, "model_l2_sq_after": 1.0, "params_loaded": 10}
+    for _ in range(4):
+        warnings, _ = check_sync_result(payload)
+        assert not any("consecutive" in w for w in warnings)
+    warnings, summary = check_sync_result(payload)
+    assert any("consecutive" in w for w in warnings)
+    assert "zero-delta run" in summary
+    _SYNC_ZERO_RUN[0] = 0
+
+
+def test_check_sync_result_onprem_status_ok_is_unverifiable():
+    _SYNC_ZERO_RUN[0] = 0
+    warnings, summary = check_sync_result({"status": "ok"})
+    assert warnings == []
+    assert "unverifiable" in summary
+
+
+def test_check_metrics_requires_parity_and_flags_large_gap():
+    missing = check_metrics({"distill_kl_coef": 1.0, "distill_estimator_is_k3": 1.0}, step=0)
+    assert any("parity gate did NOT run" in w for w in missing)
+
+    ok = check_metrics(
+        {
+            "distill_kl_coef": 1.0,
+            "distill_estimator_is_k3": 1.0,
+            "distill_kl_count": 8.0,
+            "sampler_train_kl_sum": 0.0,
+            "sampler_train_abs_delta_max": 0.0,
+        },
+        step=0,
+    )
+    assert ok == []
+
+    bad = check_metrics(
+        {
+            "distill_kl_coef": 1.0,
+            "distill_estimator_is_k3": 1.0,
+            "distill_kl_count": 4.0,
+            "sampler_train_kl_sum": 1.0,
+            "sampler_train_abs_delta_max": 1.0,
+        },
+        step=0,
+    )
+    assert any("RMS delta" in w for w in bad)
+
+    abs_only = check_metrics(
+        {
+            "distill_kl_coef": 1.0,
+            "distill_estimator_is_k3": 1.0,
+            "distill_kl_count": 8.0,
+            "sampler_train_kl_sum": 0.004,
+            "sampler_train_abs_delta_max": 0.34,
+        },
+        step=0,
+    )
+    assert any("abs_delta_max" in w for w in abs_only)
+    assert not any("RMS delta" in w for w in abs_only)

--- a/tests/opd/test_example_loop.py
+++ b/tests/opd/test_example_loop.py
@@ -302,6 +302,34 @@ def test_kl_len_adj_matches_xyu_446z0mnb():
     assert math.isclose(adj, 0.004657178530134034, rel_tol=1e-9)
 
 
+def _record_from_fwd_metrics(fwd_metrics: dict[str, float]) -> dict[str, Any]:
+    return build_step_record(
+        step=1,
+        learning_rate=1e-5,
+        result={
+            "forward_backward": {"metrics": fwd_metrics},
+            "step": {"metrics": {}},
+            "n_rollouts": 16,
+            "tokens_scored": 26624,
+            "times": {},
+        },
+        tokens_cumulative=26624,
+        elapsed_s=1.0,
+        wandb_len_ref=4096.0,
+        wandb_len_exponent=0.486,
+    )
+
+
+def test_paired_kl_sum_uses_token_count_not_per_rollout_average():
+    # distill_kl_count is a per-rollout average (scored/16), never a token count.
+    # Pairing a global sum with it would report a batch-size-times-too-large KL.
+    record = _record_from_fwd_metrics({"loss": 0.1, "distill_kl.sum": 3200.0, "distill_kl.tokens": 26624.0})
+    assert math.isclose(record["kl/per_token"], 3200.0 / 26624.0, rel_tol=1e-12)
+
+    starved = _record_from_fwd_metrics({"loss": 0.1, "distill_kl.sum": 3200.0, "distill_kl_count": 1664.0})
+    assert math.isnan(starved["kl/per_token"])
+
+
 def test_build_step_record_xyu_groups():
     result = {
         "forward_backward": {

--- a/tests/opd/test_fp32_lm_head.py
+++ b/tests/opd/test_fp32_lm_head.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from arctic_platform.common.deepspeed_worker import DeepSpeedWorker
+from arctic_platform.rl.processors.pipeline import _maybe_add_chunked_lm_head_kwargs
+from arctic_platform.rl.processors.pipeline import collect_model_outputs
+from arctic_platform.rl.processors.pipeline import uses_chunked_fp32_lm_head
+
+
+class _FakeChunkedHead(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.chunk_size = 2048
+        self.fp32_lm_head = True
+
+
+class _FakeModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lm_head = _FakeChunkedHead()
+
+
+def test_import_inject_prime_lm_head_avoids_models_package():
+    inject = DeepSpeedWorker._import_inject_prime_lm_head()
+    assert callable(inject)
+
+
+def test_collect_model_outputs_from_prime_dict():
+    logprobs = torch.zeros(1, 4)
+    out = collect_model_outputs({"logprobs": logprobs, "entropy": torch.ones(1, 4), "logits": None})
+    assert torch.equal(out["logprobs"], logprobs)
+    assert "logits" not in out
+
+
+def test_uses_chunked_fp32_lm_head_detects_injected_head():
+    engine = SimpleNamespace(module=_FakeModel())
+    assert uses_chunked_fp32_lm_head(engine)
+    assert not uses_chunked_fp32_lm_head(SimpleNamespace(module=nn.Linear(4, 4)))
+
+
+def test_pipeline_injects_labels_and_temperature_for_chunked_head():
+    engine = SimpleNamespace(module=_FakeModel())
+    ids = torch.arange(5, dtype=torch.long)
+    fwd = _maybe_add_chunked_lm_head_kwargs(engine, {"input_ids": ids})
+    assert fwd["input_ids"].shape == (1, 5)
+    assert torch.equal(fwd["labels"], torch.roll(fwd["input_ids"], -1, dims=-1))
+    assert torch.equal(fwd["temperature"], torch.ones(1, 5))
+
+
+def test_pipeline_does_not_inject_labels_for_vanilla_head():
+    engine = SimpleNamespace(module=nn.Linear(4, 4))
+    fwd = _maybe_add_chunked_lm_head_kwargs(engine, {"input_ids": torch.arange(5)})
+    assert "labels" not in fwd
+    assert "temperature" not in fwd

--- a/tests/opd/test_loss.py
+++ b/tests/opd/test_loss.py
@@ -15,20 +15,47 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 import torch
 
 from arctic_platform.rl.processors import LOSS_FNS
+from arctic_platform.rl.processors.on_policy_distill import _DEFAULT_DELTA_CLAMP
+from arctic_platform.rl.processors.on_policy_distill import _distill_kl_per_token
 from arctic_platform.rl.processors.on_policy_distill import on_policy_distill_loss
 
 
+def _make_call(
+    *,
+    student: torch.Tensor,
+    teacher: torch.Tensor,
+    loss_mask: torch.Tensor | None = None,
+    config: dict | None = None,
+    extra_batch: dict | None = None,
+):
+    if loss_mask is None:
+        loss_mask = torch.ones_like(student, dtype=torch.bool)
+    batch = {
+        "teacher_log_probs_shifted": teacher,
+        "loss_mask": loss_mask,
+    }
+    if extra_batch:
+        batch.update(extra_batch)
+    return {"logprobs": student}, batch, {}, dict(config or {})
+
+
+def _run(**kwargs):
+    model_outputs, batch, meta, config = _make_call(**kwargs)
+    return on_policy_distill_loss(model_outputs, batch, meta, config, "cpu")
+
+
 def _loss(student, teacher, mask):
-    return on_policy_distill_loss(
-        {"logprobs": student},
-        {"teacher_log_probs_shifted": teacher, "loss_mask": mask},
-        {},
-        {"distill_estimator": "low_var_kl", "loss_agg_mode": "token-mean"},
-        "cpu",
+    return _run(
+        student=student,
+        teacher=teacher,
+        loss_mask=mask,
+        config={"distill_estimator": "low_var_kl", "loss_agg_mode": "token-mean"},
     )
 
 
@@ -36,7 +63,18 @@ def test_equal_logprobs_have_zero_loss():
     logprobs = torch.tensor([[-1.0, -2.0]], requires_grad=True)
     loss, metrics = _loss(logprobs, logprobs.detach().clone(), torch.ones_like(logprobs, dtype=torch.bool))
     assert loss.item() == 0.0
-    assert metrics["distill_kl_count"] == 2
+    assert metrics["distill_kl_count"] == 2.0
+    assert metrics["distill_k1"] == 0.0
+    assert metrics["distill_kl_max"] == 0.0
+
+
+def test_k1_metric_is_masked_mean_logprob_gap():
+    student = torch.tensor([[-1.0, -2.0, -9.0]], requires_grad=True)
+    teacher = torch.tensor([[-1.5, -1.0, 3.0]])
+    mask = torch.tensor([[True, True, False]])
+    _, metrics = _loss(student, teacher, mask)
+    expected = ((-1.0 - -1.5) + (-2.0 - -1.0)) / 2
+    assert metrics["distill_k1"] == pytest.approx(expected)
 
 
 def test_loss_is_registered():
@@ -70,7 +108,7 @@ def test_kl_coefficient_scales_loss():
     teacher = torch.tensor([[-2.0]])
     mask = torch.tensor([[True]])
     base, _ = _loss(student, teacher, mask)
-    doubled, _ = on_policy_distill_loss(
+    doubled, metrics = on_policy_distill_loss(
         {"logprobs": student},
         {"teacher_log_probs_shifted": teacher, "loss_mask": mask},
         {},
@@ -78,6 +116,7 @@ def test_kl_coefficient_scales_loss():
         "cpu",
     )
     torch.testing.assert_close(doubled, 2 * base)
+    assert metrics["distill_kl_coef"] == 2.0
 
 
 def test_shape_mismatch_and_empty_mask_fail():
@@ -85,3 +124,281 @@ def test_shape_mismatch_and_empty_mask_fail():
         _loss(torch.zeros(1, 2), torch.zeros(1, 1), torch.ones(1, 2, dtype=torch.bool))
     with pytest.raises(ValueError, match="empty"):
         _loss(torch.zeros(1, 2), torch.zeros(1, 2), torch.zeros(1, 2, dtype=torch.bool))
+
+
+def test_k3_is_non_negative_over_a_wide_delta_range():
+    delta = torch.linspace(-15.0, 15.0, 601)
+    student = torch.zeros_like(delta)
+    per_token, _ = _distill_kl_per_token(
+        student, delta, estimator="low_var_kl", delta_clamp=_DEFAULT_DELTA_CLAMP
+    )
+    assert bool((per_token >= 0.0).all())
+
+
+def test_k3_matches_closed_form():
+    student = torch.tensor([[-2.0, -0.5]])
+    teacher = torch.tensor([[-1.0, -3.0]])
+    per_token, delta = _distill_kl_per_token(
+        student, teacher, estimator="low_var_kl", delta_clamp=_DEFAULT_DELTA_CLAMP
+    )
+    for got, d in zip(per_token.flatten().tolist(), delta.flatten().tolist()):
+        assert got == pytest.approx(math.exp(d) - d - 1.0, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    "teacher_lp, student_lp, expect_student_logprob_rises",
+    [
+        (-0.5, -2.0, True),
+        (-3.0, -1.0, False),
+    ],
+)
+def test_gradient_moves_student_toward_teacher(teacher_lp, student_lp, expect_student_logprob_rises):
+    student = torch.full((1, 3), student_lp, requires_grad=True)
+    teacher = torch.full((1, 3), teacher_lp)
+    loss, _ = _run(student=student, teacher=teacher)
+    loss.backward()
+    grad = student.grad
+    assert grad is not None
+    if expect_student_logprob_rises:
+        assert bool((grad < 0).all()), grad
+    else:
+        assert bool((grad > 0).all()), grad
+    delta = teacher_lp - student_lp
+    expected = (1.0 - math.exp(delta)) / student.numel()
+    assert grad.flatten()[0].item() == pytest.approx(expected, rel=1e-5)
+
+
+def test_output_clamp_is_off_by_default_so_gradients_survive_large_delta():
+    student = torch.full((1, 2), -8.0, requires_grad=True)
+    teacher = torch.full((1, 2), -1.0)
+    loss, metrics = _run(student=student, teacher=teacher)
+    assert loss.item() > 10.0, "default path must not cap the objective at 10"
+    loss.backward()
+    assert bool((student.grad.abs() > 1.0).all()), student.grad
+    assert metrics["distill_kl_output_clamped_count"] == 0.0
+
+
+def test_output_clamp_when_explicitly_requested():
+    student = torch.full((1, 2), -8.0, requires_grad=True)
+    teacher = torch.full((1, 2), -1.0)
+    loss, metrics = _run(student=student, teacher=teacher, config={"kl_clamp_max": 10.0})
+    assert loss.item() == pytest.approx(10.0, rel=1e-6)
+    assert metrics["distill_kl_output_clamped_count"] == 2.0
+    loss.backward()
+    assert bool((student.grad == 0).all())
+
+
+def test_k1_is_rejected_as_an_objective():
+    student = torch.full((1, 4), -2.0, requires_grad=True)
+    teacher = torch.full((1, 4), -1.0)
+    with pytest.raises(ValueError, match="value.*estimator, not a trainable objective"):
+        _run(student=student, teacher=teacher, config={"distill_estimator": "k1"})
+
+
+def test_unknown_estimator_is_rejected():
+    student = torch.full((1, 4), -2.0)
+    teacher = torch.full((1, 4), -1.0)
+    with pytest.raises(ValueError, match="Unknown distill_estimator"):
+        _run(student=student, teacher=teacher, config={"distill_estimator": "reverse_kl_full"})
+
+
+def test_unknown_config_key_is_rejected():
+    student = torch.full((1, 4), -2.0)
+    teacher = torch.full((1, 4), -1.0)
+    with pytest.raises(ValueError, match="Unknown config keys"):
+        _run(student=student, teacher=teacher, config={"kl_ceof": 0.5})
+
+
+@pytest.mark.parametrize("estimator", ["low_var_kl", "k3", "mse", "k2", "abs"])
+def test_trainable_estimators_have_correct_gradient_direction(estimator):
+    student = torch.full((1, 4), -3.0, requires_grad=True)
+    teacher = torch.full((1, 4), -1.0)
+    loss, _ = _run(student=student, teacher=teacher, config={"distill_estimator": estimator})
+    loss.backward()
+    assert bool((student.grad < 0).all()), (estimator, student.grad)
+
+
+def test_packed_layout_matches_padded_layout():
+    student_rows = [[-1.0, -2.0, -1.5], [-2.5, -0.5]]
+    teacher_rows = [[-1.5, -1.0, -2.0], [-1.0, -1.5]]
+    flat_student = torch.tensor([[v for row in student_rows for v in row]])
+    flat_teacher = torch.tensor([[v for row in teacher_rows for v in row]])
+    flat_mask = torch.ones_like(flat_student, dtype=torch.bool)
+    cu = torch.tensor([0, 3, 5], dtype=torch.int32)
+    packed_loss, packed_metrics = _run(
+        student=flat_student,
+        teacher=flat_teacher,
+        loss_mask=flat_mask,
+        extra_batch={"cu_seqlens": cu},
+    )
+    padded_loss, padded_metrics = _run(student=flat_student, teacher=flat_teacher)
+    assert packed_loss.item() == pytest.approx(padded_loss.item(), rel=1e-9)
+    assert packed_metrics["distill_kl_count"] == padded_metrics["distill_kl_count"] == 5.0
+
+
+def test_delta_clamp_keeps_loss_finite_on_absurd_input():
+    student = torch.full((1, 4), -400.0)
+    teacher = torch.full((1, 4), -0.001)
+    loss, metrics = _run(student=student, teacher=teacher)
+    assert torch.isfinite(loss), loss
+    assert metrics["distill_delta_clamped_count"] == 4.0
+
+
+def test_missing_teacher_logprobs_raises_a_useful_error():
+    student = torch.full((1, 4), -2.0)
+    with pytest.raises(ValueError, match="teacher_log_probs_shifted"):
+        on_policy_distill_loss(
+            {"logprobs": student},
+            {"loss_mask": torch.ones_like(student, dtype=torch.bool)},
+            {},
+            {},
+            "cpu",
+        )
+
+
+def test_k1_metric_is_signed_and_detects_bias_direction():
+    student = torch.full((1, 4), -3.0)
+    teacher = torch.full((1, 4), -1.0)
+    _, under = _run(student=student, teacher=teacher)
+    _, over = _run(student=teacher, teacher=student)
+    assert under["distill_k1_sum"] < 0.0
+    assert over["distill_k1_sum"] > 0.0
+    assert under["distill_kl_sum"] > 0.0 and over["distill_kl_sum"] > 0.0
+
+
+def test_sampler_train_kl_is_zero_when_sampler_matches_trainer():
+    student = torch.full((1, 4), -2.0)
+    teacher = torch.full((1, 4), -1.0)
+    _, metrics = _run(
+        student=student,
+        teacher=teacher,
+        extra_batch={"old_log_probs_shifted": student.clone()},
+    )
+    assert metrics["sampler_train_kl_sum"] == 0.0
+    assert metrics["sampler_train_abs_delta_max"] == 0.0
+
+
+def test_sampler_train_kl_is_positive_on_disagreement():
+    student = torch.full((1, 4), -2.0)
+    teacher = torch.full((1, 4), -1.0)
+    _, metrics = _run(
+        student=student,
+        teacher=teacher,
+        extra_batch={"old_log_probs_shifted": torch.full((1, 4), -2.5)},
+    )
+    assert metrics["sampler_train_kl_sum"] > 0.0
+    assert metrics["sampler_train_abs_delta_max"] == pytest.approx(0.5, rel=1e-6)
+
+
+def test_sampler_metrics_absent_when_sampler_logprobs_absent():
+    student = torch.full((1, 4), -2.0)
+    teacher = torch.full((1, 4), -1.0)
+    _, metrics = _run(student=student, teacher=teacher)
+    assert "sampler_train_kl_sum" not in metrics
+
+
+def test_all_metrics_are_plain_floats():
+    student = torch.full((1, 4), -2.0, requires_grad=True)
+    teacher = torch.full((1, 4), -1.0)
+    _, metrics = _run(student=student, teacher=teacher)
+    for key, value in metrics.items():
+        assert isinstance(value, float), (key, type(value))
+        assert math.isfinite(value), (key, value)
+
+
+def test_logits_fallback_when_no_logprobs_post_processor():
+    torch.manual_seed(0)
+    B, S, V = 1, 5, 7
+    logits = torch.randn(B, S, V, requires_grad=True)
+    input_ids = torch.randint(0, V, (B, S))
+    expected = (
+        torch.log_softmax(logits.float(), dim=-1)
+        .gather(-1, torch.roll(input_ids, -1, dims=-1).unsqueeze(-1))
+        .squeeze(-1)
+    )
+    loss, _ = on_policy_distill_loss(
+        {"logits": logits},
+        {
+            "input_ids": input_ids,
+            "teacher_log_probs_shifted": expected.detach(),
+            "loss_mask": torch.ones(B, S, dtype=torch.bool),
+        },
+        {},
+        {},
+        "cpu",
+    )
+    assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_count_opd_loss_tokens_dict_and_gas_list():
+    from arctic_platform.rl.processors.on_policy_distill import count_opd_loss_tokens
+
+    mask = torch.tensor([[1, 1, 0], [1, 0, 0]])
+    assert count_opd_loss_tokens({"loss_mask": mask}) == (3, 2)
+    assert count_opd_loss_tokens([{"loss_mask": mask}, {"loss_mask": mask}]) == (6, 4)
+    assert count_opd_loss_tokens({"input_ids": torch.zeros(1, 2)}) == (0, 0)
+
+
+def test_count_opd_loss_tokens_packed_cu_seqlens():
+    from arctic_platform.rl.processors.on_policy_distill import count_opd_loss_tokens
+
+    mask = torch.ones(1, 5, dtype=torch.long)
+    cu = torch.tensor([0, 3, 5], dtype=torch.int32)
+    assert count_opd_loss_tokens({"loss_mask": mask, "cu_seqlens": cu}) == (5, 2)
+
+
+def test_global_token_norm_downweights_short_microbatch():
+    student_short = torch.full((1, 1), -2.0, requires_grad=True)
+    teacher_short = torch.full((1, 1), -1.0)
+    student_long = torch.full((1, 9), -2.0, requires_grad=True)
+    teacher_long = torch.full((1, 9), -1.0)
+    cfg = {"distill_estimator": "low_var_kl", "loss_agg_mode": "token-mean", "dp_size": 8, "batch_num_tokens": 10}
+    loss_short, short_metrics = _run(
+        student=student_short, teacher=teacher_short, config=cfg, loss_mask=torch.ones(1, 1, dtype=torch.bool)
+    )
+    loss_long, long_metrics = _run(
+        student=student_long, teacher=teacher_long, config=cfg, loss_mask=torch.ones(1, 9, dtype=torch.bool)
+    )
+    local_short, _ = _run(student=student_short, teacher=teacher_short, loss_mask=torch.ones(1, 1, dtype=torch.bool))
+    assert local_short.item() == pytest.approx(loss_short.item() * 10 / 8, rel=1e-5)
+    assert loss_long.item() == pytest.approx(loss_short.item() * 9, rel=1e-5)
+    assert short_metrics["distill_dp_size"] == 8.0
+    assert short_metrics["distill_batch_num_tokens"] == 10.0
+    assert long_metrics["distill_batch_num_tokens"] == 10.0
+    assert "loss.sum" in short_metrics
+    assert "loss.tokens" in short_metrics
+    assert "distill_kl.sum" in short_metrics
+    assert "distill_kl.tokens" in short_metrics
+    assert short_metrics["distill_kl.tokens"] == 1.0
+    assert long_metrics["distill_kl.tokens"] == 9.0
+
+
+def test_meta_supplies_norm_when_config_omits_it():
+    student = torch.full((1, 2), -2.0, requires_grad=True)
+    teacher = torch.full((1, 2), -1.0)
+    model_outputs, batch, _, config = _make_call(student=student, teacher=teacher)
+    via_config, _ = on_policy_distill_loss(
+        model_outputs, batch, {}, {**config, "dp_size": 4, "batch_num_tokens": 20}, "cpu"
+    )
+    via_meta, _ = on_policy_distill_loss(
+        model_outputs, batch, {"dp_size": 4, "batch_num_tokens": 20}, config, "cpu"
+    )
+    assert via_meta.item() == pytest.approx(via_config.item(), rel=1e-9)
+
+
+def test_apply_opd_global_token_config_writes_config_and_meta():
+    from arctic_platform.rl.processors.on_policy_distill import apply_opd_global_token_config
+    from arctic_platform.rl.processors.on_policy_distill import count_opd_loss_tokens
+
+    mask = torch.tensor([[1, 1, 1, 0], [1, 0, 0, 0]])
+    tokens, seqs = count_opd_loss_tokens({"loss_mask": mask})
+    processing = {"config": {"distill_estimator": "low_var_kl"}}
+    meta: dict = {}
+    apply_opd_global_token_config(
+        processing, meta, dp_size=8, batch_num_tokens=tokens, global_batch_size=seqs
+    )
+    assert processing["config"]["dp_size"] == 8
+    assert processing["config"]["batch_num_tokens"] == 4
+    assert processing["config"]["global_batch_size"] == 2
+    assert meta["batch_num_tokens"] == 4
+    assert meta["dp_size"] == 8

--- a/tests/opd/test_loss.py
+++ b/tests/opd/test_loss.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from arctic_platform.rl.processors import LOSS_FNS
+from arctic_platform.rl.processors.on_policy_distill import on_policy_distill_loss
+
+
+def _loss(student, teacher, mask):
+    return on_policy_distill_loss(
+        {"logprobs": student},
+        {"teacher_log_probs_shifted": teacher, "loss_mask": mask},
+        {},
+        {"distill_estimator": "low_var_kl", "loss_agg_mode": "token-mean"},
+        "cpu",
+    )
+
+
+def test_equal_logprobs_have_zero_loss():
+    logprobs = torch.tensor([[-1.0, -2.0]], requires_grad=True)
+    loss, metrics = _loss(logprobs, logprobs.detach().clone(), torch.ones_like(logprobs, dtype=torch.bool))
+    assert loss.item() == 0.0
+    assert metrics["distill_kl_count"] == 2
+
+
+def test_loss_is_registered():
+    assert LOSS_FNS["on_policy_distill"] is on_policy_distill_loss
+
+
+def test_masked_values_do_not_change_loss():
+    student = torch.tensor([[-1.0, -2.0, -400.0]], requires_grad=True)
+    teacher = torch.tensor([[-1.1, -1.8, 99.0]])
+    mask = torch.tensor([[True, True, False]])
+    loss_a, _ = _loss(student, teacher, mask)
+    teacher[-1, -1] = -999.0
+    student_b = student.detach().clone()
+    student_b[-1, -1] = 123.0
+    student_b.requires_grad_(True)
+    loss_b, _ = _loss(student_b, teacher, mask)
+    torch.testing.assert_close(loss_a, loss_b)
+
+
+def test_teacher_is_detached_and_student_receives_gradient():
+    student = torch.tensor([[-1.0]], requires_grad=True)
+    teacher = torch.tensor([[-2.0]], requires_grad=True)
+    loss, _ = _loss(student, teacher, torch.tensor([[True]]))
+    loss.backward()
+    assert student.grad is not None
+    assert teacher.grad is None
+
+
+def test_kl_coefficient_scales_loss():
+    student = torch.tensor([[-1.0]], requires_grad=True)
+    teacher = torch.tensor([[-2.0]])
+    mask = torch.tensor([[True]])
+    base, _ = _loss(student, teacher, mask)
+    doubled, _ = on_policy_distill_loss(
+        {"logprobs": student},
+        {"teacher_log_probs_shifted": teacher, "loss_mask": mask},
+        {},
+        {"distill_estimator": "low_var_kl", "kl_coef": 2.0},
+        "cpu",
+    )
+    torch.testing.assert_close(doubled, 2 * base)
+
+
+def test_shape_mismatch_and_empty_mask_fail():
+    with pytest.raises(ValueError, match="identical shapes"):
+        _loss(torch.zeros(1, 2), torch.zeros(1, 1), torch.ones(1, 2, dtype=torch.bool))
+    with pytest.raises(ValueError, match="empty"):
+        _loss(torch.zeros(1, 2), torch.zeros(1, 2), torch.zeros(1, 2, dtype=torch.bool))

--- a/tests/opd/test_loss.py
+++ b/tests/opd/test_loss.py
@@ -1,3 +1,18 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import pytest

--- a/tests/opd/test_opd_client_ops.py
+++ b/tests/opd/test_opd_client_ops.py
@@ -15,6 +15,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from arctic_platform.client import CortexConfig
@@ -207,7 +209,33 @@ def test_partial_reconnect_ids_rejected():
         )
 
 
-def test_local_launch_requires_disjoint_student_and_teacher_devices():
+def test_local_launch_allows_overlapping_devices_with_disjoint_hostfiles(tmp_path: Path):
+    student_hf = tmp_path / "student.hosts"
+    teacher_hf = tmp_path / "teacher.hosts"
+    student_hf.write_text("10.0.0.1 slots=8\n10.0.0.2 slots=8\n", encoding="utf-8")
+    teacher_hf.write_text("10.0.0.3 slots=8\n", encoding="utf-8")
+    cfg = ArcticOPDClientConfig(
+        student_model="student",
+        teacher_model="teacher",
+        training_gpus=8,
+        sampling_gpus=8,
+        teacher_sampling_gpus=8,
+        teacher_server_cuda_visible_devices="",
+        student_ray_hostfile=str(student_hf),
+        teacher_ray_hostfile=str(teacher_hf),
+        backend=OnPremConfig(
+            launch_local_server=True,
+            server_cuda_visible_devices="0,1,2,3,4,5,6,7",
+        ),
+    )
+    student_env = cfg.student_transport_config().backend.server_extra_env
+    teacher_env = cfg.teacher_transport_config().backend.server_extra_env
+    assert student_env["ARL_RAY_HOSTFILE"] == str(student_hf)
+    assert teacher_env["ARL_RAY_HOSTFILE"] == str(teacher_hf)
+    assert cfg.teacher_transport_config().backend.server_cuda_visible_devices == ""
+
+
+def test_local_launch_overlapping_devices_still_rejected_without_hostfiles():
     with pytest.raises(ValueError, match="must be disjoint"):
         ArcticOPDClientConfig(
             student_model="student",

--- a/tests/opd/test_opd_client_ops.py
+++ b/tests/opd/test_opd_client_ops.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import pytest
+
+from arctic_platform.client import CortexConfig
+from arctic_platform.client import JobHandles
+from arctic_platform.client import OnPremConfig
+from arctic_platform.client import Request
+from arctic_platform.client import SyncArcticRLClient
+from arctic_platform.client import client as rl_client_module
+from arctic_platform.opd import ArcticOPDClient
+from arctic_platform.opd import ArcticOPDClientConfig
+from arctic_platform.opd import DEFAULT_PROCESSING
+from arctic_platform.opd.client import _fwd_bwd_body
+
+
+class FakeTransport:
+    def __init__(self, config, server_state=None):
+        self.config = config
+        self.server_state = server_state
+        self.jobs = JobHandles()
+        self.calls: list[Request] = []
+        self.stopped = False
+
+    def initialize(self):
+        if self.config.training_gpus:
+            self.jobs = JobHandles(training=11, sampling=12)
+        else:
+            self.jobs = JobHandles(sampling=21)
+        return self.jobs
+
+    def call(self, request):
+        self.calls.append(request)
+        return {"results": [{"ok": True}], "metrics": {}}
+
+    def shutdown(self):
+        self.stopped = True
+
+
+def config(**updates):
+    base = ArcticOPDClientConfig(
+        student_model="student",
+        teacher_model="teacher",
+        training_gpus=2,
+        sampling_gpus=2,
+        teacher_sampling_gpus=4,
+        backend=CortexConfig(base_url="http://example"),
+    )
+    return base.model_copy(update=updates)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    transports = []
+
+    def make_transport(cfg, server_state=None):
+        transport = FakeTransport(cfg, server_state=server_state)
+        transports.append(transport)
+        return transport
+
+    monkeypatch.setattr(rl_client_module, "make_transport", make_transport)
+    return ArcticOPDClient(config()), transports
+
+
+def test_composes_two_sync_rl_clients(client):
+    opd, transports = client
+    assert isinstance(opd.student, SyncArcticRLClient)
+    assert isinstance(opd.teacher, SyncArcticRLClient)
+    assert opd.student.config.training_gpus == 2
+    assert opd.student.config.sampling_gpus == 2
+    assert opd.teacher.config.training_gpus == 0
+    assert opd.teacher.config.sampling_gpus == 4
+    assert opd.teacher.config.model_name == "teacher"
+    assert opd.student.transport is transports[0]
+    assert opd.teacher.transport is transports[1]
+
+
+def test_routes_student_and_teacher_generate(client):
+    opd, transports = client
+    assert opd.generate([[1, 2]]) == [{"ok": True}]
+    assert transports[0].calls[-1].op == "generate"
+    assert transports[0].calls[-1].job_id == 12
+    assert opd.generate_teacher([[1, 2, 3]]) == [{"ok": True}]
+    assert transports[1].calls[-1].op == "generate"
+    assert transports[1].calls[-1].job_id == 21
+
+
+def test_fwd_bwd_defaults_distill_processing(client):
+    opd, transports = client
+    opd.fwd_bwd({"input_ids": [1]})
+    request = transports[0].calls[-1]
+    assert request.job_id == 11
+    assert request.binary is True
+    assert request.body["processing"] == DEFAULT_PROCESSING
+    assert request.body["kwargs"] == {"input_ids": [1]}
+    assert request.body["context"] == {"input_ids": [1]}
+
+
+def test_onprem_fwd_bwd_uses_structured_batch_envelope():
+    cfg = ArcticOPDClientConfig(
+        student_model="student",
+        teacher_model="teacher",
+        training_gpus=1,
+        sampling_gpus=1,
+        teacher_sampling_gpus=1,
+    )
+    body = _fwd_bwd_body(cfg, {"input_ids": [1], "loss_mask": [True]}, None)
+    assert body == {
+        "batch": {"input_ids": [1], "loss_mask": [True]},
+        "meta": {"zorro_train_enable": False},
+        "processing": DEFAULT_PROCESSING,
+    }
+
+
+def test_cortex_sync_is_hf_and_never_targets_teacher(client):
+    opd, transports = client
+    opd.sync_weights()
+    # Cortex has no wake-inference: sync then reset cache, student only.
+    assert [request.op for request in transports[0].calls] == ["operation", "operation"]
+    sync_request = transports[0].calls[-2]
+    assert sync_request.body["payload"]["source_sub_job_id"] == 11
+    assert sync_request.body["payload"]["target_sub_job_ids"] == [12]
+    assert sync_request.body["payload"]["weight_format"] == "hf"
+    assert 21 not in sync_request.body["payload"]["target_sub_job_ids"]
+    assert transports[1].calls == []
+
+
+def test_onprem_sync_weights_delegates_to_student(monkeypatch):
+    transports = []
+
+    def make_transport(cfg, server_state=None):
+        transport = FakeTransport(cfg, server_state=server_state)
+        transports.append(transport)
+        return transport
+
+    monkeypatch.setattr(rl_client_module, "make_transport", make_transport)
+    opd = ArcticOPDClient(
+        ArcticOPDClientConfig(
+            student_model="student",
+            teacher_model="teacher",
+            training_gpus=1,
+            sampling_gpus=1,
+            teacher_sampling_gpus=1,
+        )
+    )
+    opd.sync_weights()
+    assert [request.op for request in transports[0].calls] == [
+        "wake-inference",
+        "operation",
+        "wake-inference",
+        "operation",
+    ]
+    sync_request = transports[0].calls[-3]
+    assert sync_request.body["operation_type"] == "weight-sync"
+    assert sync_request.body["payload"]["source_sub_job_id"] == 11
+    assert sync_request.body["payload"]["target_sub_job_ids"] == [12]
+    assert transports[1].calls == []
+
+
+def test_reconnect_config_contains_all_three_ids(client):
+    opd, _ = client
+    reconnect = opd.reconnect_config()
+    assert (reconnect.training_job_id, reconnect.sampling_job_id, reconnect.teacher_job_id) == (11, 12, 21)
+
+
+def test_teacher_init_failure_cleans_up_student(monkeypatch):
+    student = FakeTransport(config().student_transport_config())
+    calls = 0
+
+    def make_transport(_cfg, server_state=None):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return student
+        raise RuntimeError("teacher failed")
+
+    monkeypatch.setattr(rl_client_module, "make_transport", make_transport)
+    with pytest.raises(RuntimeError, match="teacher failed"):
+        ArcticOPDClient(config())
+    assert student.stopped
+
+
+def test_partial_reconnect_ids_rejected():
+    with pytest.raises(ValueError, match="requires training_job_id"):
+        ArcticOPDClientConfig(
+            student_model="student",
+            teacher_model="teacher",
+            training_gpus=1,
+            sampling_gpus=1,
+            teacher_sampling_gpus=1,
+            training_job_id=1,
+        )
+
+
+def test_local_launch_requires_disjoint_student_and_teacher_devices():
+    with pytest.raises(ValueError, match="must be disjoint"):
+        ArcticOPDClientConfig(
+            student_model="student",
+            teacher_model="teacher",
+            training_gpus=1,
+            sampling_gpus=1,
+            teacher_sampling_gpus=1,
+            teacher_server_cuda_visible_devices="0,1",
+            backend=OnPremConfig(
+                launch_local_server=True,
+                server_cuda_visible_devices="0,1",
+            ),
+        )
+
+
+def test_local_launch_isolates_student_and_teacher_ray_ports():
+    cfg = ArcticOPDClientConfig(
+        student_model="student",
+        teacher_model="teacher",
+        training_gpus=1,
+        sampling_gpus=1,
+        teacher_sampling_gpus=1,
+        teacher_port=18101,
+        teacher_server_cuda_visible_devices="1",
+        backend=OnPremConfig(
+            launch_local_server=True,
+            port=18100,
+            server_cuda_visible_devices="0",
+        ),
+    )
+    student_env = cfg.student_transport_config().backend.server_extra_env
+    teacher_env = cfg.teacher_transport_config().backend.server_extra_env
+    for key in (
+        "RAY_PORT",
+        "RAY_DASHBOARD_PORT",
+        "MASTER_PORT",
+        "ARL_WEIGHT_SYNC_PORT",
+        "ARL_RAY_MIN_WORKER_PORT",
+        "ARL_RAY_MAX_WORKER_PORT",
+    ):
+        assert student_env[key] != teacher_env[key], key
+        assert int(student_env["ARL_RAY_MAX_WORKER_PORT"]) < int(teacher_env["ARL_RAY_MIN_WORKER_PORT"]) or int(
+            teacher_env["ARL_RAY_MAX_WORKER_PORT"]
+        ) < int(student_env["ARL_RAY_MIN_WORKER_PORT"])

--- a/tests/opd/test_opd_client_ops.py
+++ b/tests/opd/test_opd_client_ops.py
@@ -1,3 +1,18 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import pytest
@@ -8,9 +23,9 @@ from arctic_platform.client import OnPremConfig
 from arctic_platform.client import Request
 from arctic_platform.client import SyncArcticRLClient
 from arctic_platform.client import client as rl_client_module
+from arctic_platform.opd import DEFAULT_PROCESSING
 from arctic_platform.opd import ArcticOPDClient
 from arctic_platform.opd import ArcticOPDClientConfig
-from arctic_platform.opd import DEFAULT_PROCESSING
 from arctic_platform.opd.client import _fwd_bwd_body
 
 

--- a/tests/opd/test_opd_client_ops.py
+++ b/tests/opd/test_opd_client_ops.py
@@ -113,6 +113,15 @@ def test_fwd_bwd_defaults_distill_processing(client):
     assert request.body["context"] == {"input_ids": [1]}
 
 
+def test_fwd_no_grad_uses_same_envelope(client):
+    opd, transports = client
+    opd.fwd_no_grad({"input_ids": [1]})
+    request = transports[0].calls[-1]
+    assert request.op == "forward"
+    assert request.job_id == 11
+    assert request.body["processing"] == DEFAULT_PROCESSING
+
+
 def test_onprem_fwd_bwd_uses_structured_batch_envelope():
     cfg = ArcticOPDClientConfig(
         student_model="student",

--- a/tests/opd/test_ray_hostfile.py
+++ b/tests/opd/test_ray_hostfile.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from arctic_platform.common.ray_cluster import _peer_hosts
+from arctic_platform.common.ray_cluster import hostfile_hosts
+from arctic_platform.common.ray_cluster import hostfile_path
+
+
+def test_hostfile_path_and_peers_honor_arl_ray_hostfile(tmp_path: Path, monkeypatch):
+    path = tmp_path / "hosts"
+    path.write_text("10.0.0.1 slots=8\n10.0.0.2 slots=8\n# skip\n\n", encoding="utf-8")
+    monkeypatch.setenv("ARL_RAY_HOSTFILE", str(path))
+    assert hostfile_path() == str(path)
+    assert hostfile_hosts() == ["10.0.0.1", "10.0.0.2"]
+    monkeypatch.setattr("arctic_platform.common.ray_cluster.primary_ip", lambda: "10.0.0.1")
+    assert _peer_hosts() == ["10.0.0.2"]

--- a/tests/opd/test_scoring.py
+++ b/tests/opd/test_scoring.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from arctic_platform.opd.scoring import score_teacher
+
+
+class Teacher:
+    def generate_teacher(self, prompts, sampling_params):
+        assert prompts == [[1, 2, 3, 4]]
+        assert sampling_params["prompt_logprobs"] == 0
+        return [
+            {
+                "prompt_logprobs": [
+                    None,
+                    {2: -0.1},
+                    {"3": {"logprob": -0.2}},
+                    {4: -0.3},
+                ]
+            }
+        ]
+
+
+def test_teacher_scores_exact_completion_token_ids():
+    scored = score_teacher(
+        Teacher(),
+        [{"prompt_ids": [1, 2], "completion_ids": [3, 4], "sampler_logprobs": [-0.4, -0.5]}],
+    )
+    assert scored[0]["teacher_logprobs"] == [-0.2, -0.3]
+
+
+def test_teacher_alignment_mismatch_fails():
+    class BadTeacher:
+        def generate_teacher(self, prompts, sampling_params):
+            return [{"prompt_logprobs": [None]}]
+
+    with pytest.raises(RuntimeError, match="length"):
+        score_teacher(BadTeacher(), [{"prompt_ids": [1], "completion_ids": [2]}])

--- a/tests/opd/test_scoring.py
+++ b/tests/opd/test_scoring.py
@@ -1,3 +1,18 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import pytest

--- a/tests/opd/test_scoring.py
+++ b/tests/opd/test_scoring.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import pytest
 
 from arctic_platform.opd.scoring import score_teacher
+from arctic_platform.opd.scoring import score_teacher_topk
 
 
 class Teacher:
@@ -42,6 +43,45 @@ def test_teacher_scores_exact_completion_token_ids():
         [{"prompt_ids": [1, 2], "completion_ids": [3, 4], "sampler_logprobs": [-0.4, -0.5]}],
     )
     assert scored[0]["teacher_logprobs"] == [-0.2, -0.3]
+
+
+def test_teacher_topk_keeps_support_and_tail():
+    class TopKTeacher:
+        def generate_teacher(self, prompts, sampling_params):
+            assert sampling_params["prompt_logprobs"] == 2
+            return [
+                {
+                    "prompt_logprobs": [
+                        None,
+                        {2: -0.1},
+                        {3: -0.2, 9: -1.0},
+                        {4: -0.3, 8: -2.0},
+                    ]
+                }
+            ]
+
+    scored = score_teacher_topk(
+        TopKTeacher(),
+        [{"prompt_ids": [1, 2], "completion_ids": [3, 4]}],
+        teacher_top_k=2,
+    )
+    row = scored[0]
+    assert row["teacher_token_ids"] == [[3, 9], [4, 8]]
+    assert row["teacher_logprobs"] == [[-0.2, -1.0], [-0.3, -2.0]]
+    assert len(row["teacher_tail_logprob"]) == 2
+
+
+def test_teacher_topk_requires_realized_token():
+    class MissingRealized:
+        def generate_teacher(self, prompts, sampling_params):
+            return [{"prompt_logprobs": [None, {9: -0.1}]}]
+
+    with pytest.raises(RuntimeError, match="absent"):
+        score_teacher_topk(
+            MissingRealized(),
+            [{"prompt_ids": [1], "completion_ids": [2]}],
+            teacher_top_k=1,
+        )
 
 
 def test_teacher_alignment_mismatch_fails():

--- a/tests/opd/test_vision_freeze.py
+++ b/tests/opd/test_vision_freeze.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from arctic_platform.model.implementations.qwen35.vlm import freeze_unused_vision_tower
+
+
+class _TinyVision(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4)
+
+
+class _Inner(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.visual = _TinyVision()
+        self.language_model = nn.Linear(4, 4)
+
+
+class _TinyVLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = _Inner()
+        self.config = type("C", (), {"model_type": "qwen3_5"})()
+
+
+def test_freeze_unused_vision_tower_disables_visual_grads():
+    model = _TinyVLM()
+    assert all(p.requires_grad for p in model.model.visual.parameters())
+    frozen = freeze_unused_vision_tower(model, rank=0)
+    assert frozen == sum(1 for _ in model.model.visual.parameters())
+    assert all(not p.requires_grad for p in model.model.visual.parameters())
+    assert all(p.requires_grad for p in model.model.language_model.parameters())
+
+
+def test_freeze_unused_vision_tower_is_noop_without_visual():
+    model = nn.Linear(3, 3)
+    model.config = type("C", (), {"model_type": "llama"})()
+    assert freeze_unused_vision_tower(model, rank=0) == 0
+    assert all(p.requires_grad for p in model.parameters())

--- a/tests/rl/test_packing.py
+++ b/tests/rl/test_packing.py
@@ -81,3 +81,141 @@ class TestPackSequences(TestCasePlus):
         self.assertEqual(pad_length, padded_len - total_tokens)
         self.assertEqual(model_kwargs["max_length_q"], max(real_token_counts))
         self.assertTrue(torch.equal(model_kwargs["cu_seq_lens_q"], packed["cu_seqlens"]))
+        self.assertEqual(model_kwargs["seq_idx"].shape, (1, padded_len))
+        self.assertEqual(model_kwargs["seq_idx"][0, :total_tokens].tolist(), [0] * 6 + [1] * 4 + [2] * 2)
+        # Right-padded tail gets its own segment id so conv1d cannot leak into pad.
+        if pad_length:
+            self.assertTrue(torch.all(model_kwargs["seq_idx"][0, total_tokens:] == 3))
+
+
+class TestVarlenKwargs(TestCasePlus):
+    def test_model_reads_varlen_from_layer_types(self):
+        from types import SimpleNamespace
+
+        from arctic_platform.rl.processors.packing import model_reads_varlen_kwargs
+
+        hybrid = SimpleNamespace(config=SimpleNamespace(layer_types=["full_attention", "linear_attention"]))
+        dense = SimpleNamespace(config=SimpleNamespace(layer_types=["full_attention"]))
+        text_cfg = SimpleNamespace(
+            config=SimpleNamespace(text_config=SimpleNamespace(layer_types=["linear_attention"]), layer_types=None)
+        )
+        self.assertTrue(model_reads_varlen_kwargs(hybrid))
+        self.assertFalse(model_reads_varlen_kwargs(dense))
+        self.assertTrue(model_reads_varlen_kwargs(text_cfg))
+
+    def test_ulysses_sp_returns_empty_kwargs(self):
+        from arctic_platform.rl.processors.packing import derive_varlen_model_kwargs
+
+        packed = {
+            "input_ids": torch.ones(1, 4, dtype=torch.long),
+            "cu_seqlens": torch.tensor([0, 8], dtype=torch.int32),
+        }
+        self.assertEqual(derive_varlen_model_kwargs(packed), {})
+
+    def test_packing_boundaries_reset_position_ids(self):
+        from arctic_platform.rl.processors.packing import packing_boundaries_from_attention_mask
+
+        mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]])
+        cu, pos = packing_boundaries_from_attention_mask(mask)
+        self.assertEqual(cu.tolist(), [0, 3, 5])
+        self.assertEqual(pos.tolist(), [[0, 1, 2, 0, 1]])
+
+
+class TestEngineForwardKwargs(TestCasePlus):
+    def test_strips_cu_seqlens_from_batch_and_keeps_varlen(self):
+        from arctic_platform.rl.processors.pipeline import _engine_forward_kwargs
+
+        cu = torch.tensor([0, 4, 8], dtype=torch.int32)
+        seq_idx = torch.tensor([[0, 0, 0, 0, 1, 1, 1, 1]], dtype=torch.int32)
+        batch = {
+            "input_ids": torch.ones(1, 8, dtype=torch.long),
+            "cu_seqlens": cu,
+            "cu_seq_lens_q": cu,
+            "seq_idx": seq_idx,
+        }
+        fwd = _engine_forward_kwargs(batch, {})
+        self.assertNotIn("cu_seqlens", fwd)
+        self.assertTrue(torch.equal(fwd["cu_seq_lens_q"], cu))
+        self.assertTrue(torch.equal(fwd["seq_idx"], seq_idx))
+        self.assertTrue(torch.equal(fwd["input_ids"], batch["input_ids"]))
+
+    def test_strips_cu_seqlens_from_meta(self):
+        from arctic_platform.rl.processors.pipeline import _engine_forward_kwargs
+
+        cu = torch.tensor([0, 3], dtype=torch.int32)
+        batch = {"input_ids": torch.ones(1, 3, dtype=torch.long)}
+        meta = {"cu_seqlens": cu, "pad_token_id": 0}
+        fwd = _engine_forward_kwargs(batch, meta)
+        self.assertNotIn("cu_seqlens", fwd)
+        self.assertEqual(fwd["pad_token_id"], 0)
+        self.assertTrue(torch.equal(fwd["input_ids"], batch["input_ids"]))
+
+    def test_collect_model_outputs_accepts_prime_dict(self):
+        from arctic_platform.rl.processors.pipeline import collect_model_outputs
+
+        logprobs = torch.zeros(1, 4)
+        out = collect_model_outputs({"logprobs": logprobs, "entropy": torch.ones(1, 4), "logits": None})
+        self.assertTrue(torch.equal(out["logprobs"], logprobs))
+        self.assertTrue(torch.equal(out["entropy"], torch.ones(1, 4)))
+        self.assertNotIn("logits", out)
+
+    def test_chunked_lm_head_kwargs_stay_off_for_vanilla_linear(self):
+        from arctic_platform.rl.processors.pipeline import _maybe_add_chunked_lm_head_kwargs
+
+        class Engine:
+            module = torch.nn.Linear(4, 4)
+
+        batch = {"input_ids": torch.arange(6)}
+        fwd = _maybe_add_chunked_lm_head_kwargs(Engine(), batch)
+        self.assertNotIn("labels", fwd)
+        self.assertNotIn("temperature", fwd)
+
+
+class TestPackedMetricAggregation(TestCasePlus):
+    """The ``--max-tokens-per-mb`` path must combine per-microbatch metrics with
+    the same paired-key convention as the GAS worker (``combine_metric_microbatches``):
+    ``{name}.sum`` / ``{name}.tokens`` are SUMMED so the server folds
+    ``Σsum / Σtokens``; other keys are averaged; ``avg_loss`` is summed. A
+    token-weighted mean (the previous behaviour) biased ``kl/per_token`` to
+    ``Σ(S·c) / Σc²`` and mean-averaged the parity ``*_max`` gate inputs.
+    """
+
+    def test_paired_keys_summed_not_weight_averaged(self):
+        from unittest import mock
+
+        from arctic_platform.rl.processors import pipeline
+
+        # 3 rollouts of real length [6, 4, 2]; capacity 6 -> exactly 2 microbatches.
+        attn = torch.zeros(3, seq_len, dtype=torch.long)
+        for row, count in enumerate(real_token_counts):
+            attn[row, :count] = 1
+        input_ids = torch.randint(1, 100, (3, seq_len)) * attn
+        batch = {"input_ids": input_ids, "attention_mask": attn, "loss_mask": attn.clone()}
+
+        per_mb = {
+            "avg_loss": 2.0,
+            "metrics": {"distill_kl.sum": 4.0, "distill_kl.tokens": 2.0, "distill_kl_max": 3.0},
+            "batch": {},
+        }
+
+        with mock.patch.object(pipeline, "run_pipeline", return_value=per_mb) as m:
+            out = pipeline._run_pipeline_with_packing(
+                object(),
+                (),
+                batch,
+                {},
+                {},
+                "cpu",
+                backward=False,
+                max_tokens_per_mb=6,
+            )
+
+        n = m.call_count
+        self.assertGreaterEqual(n, 2, "capacity 6 over lengths [6,4,2] should split into >=2 microbatches")
+        # Paired accumulators grow with microbatch count (summed), not collapsed to one mb's value.
+        self.assertAlmostEqual(out["metrics"]["distill_kl.sum"], 4.0 * n)
+        self.assertAlmostEqual(out["metrics"]["distill_kl.tokens"], 2.0 * n)
+        # Non-paired keys (e.g. the parity ``*_max`` gate inputs) are averaged.
+        self.assertAlmostEqual(out["metrics"]["distill_kl_max"], 3.0)
+        # Globally-normalized per-mb losses sum to the whole-batch loss.
+        self.assertAlmostEqual(out["avg_loss"], 2.0 * n)


### PR DESCRIPTION
## Summary
- Add `ArcticOPDClient`, a composition of two `SyncArcticRLClient`s: student train+sample and a sampling-only frozen teacher.
- Isolate concurrent local servers (disjoint Ray/DeepSpeed ports, `--no-ray-auto-attach`, per-server CUDA) so student and teacher do not share one sampling pool.
- Register `on_policy_distill` reverse-KL loss, accept token-id prompts for exact teacher scoring, and pass `weight_format=hf` on Cortex student weight sync.
- Document the client in `docs/opd.md` and add `score_teacher_topk` / `fwd_no_grad` for a later TRL-style async distillation training client (#106).

Follow-up (not in this PR): #106 adds the CPU-only `ArcticOPDTrainingClient` for `AsyncDistillationTrainer`.

## Test plan

### CPU
- [x] `pytest tests/opd` (19 passed): loss, teacher scoring, composed client ops (student/teacher generate, fwd_bwd, step, student-only weight sync)

### Live GPU (on-prem, FA2 trainer, composed client)
Same recipe unless noted: 80 steps, warmup 20, lr `1e-6`, max seq 512, gen 32, 8 rollouts, student train+sample on GPU 0, teacher sample on GPU 1.

```bash
python -m arctic_platform.opd.examples.run_on_policy_distill \
  --live \
  --student-model Qwen/Qwen3-0.6B \
  --teacher-model Qwen/Qwen3-1.7B \
  --steps 80 --warmup-steps 20 --lr 1e-6 \
  --max-seq-len 512 --max-tokens 32 \
  --training-gpus 1 --sampling-gpus 1 --teacher-sampling-gpus 1 \
  --server-cuda-visible-devices 0 \
  --teacher-server-cuda-visible-devices 1 \
  --attn flash_attention_2
```

- [x] Qwen3-0.6B student / Qwen3-1.7B teacher, 80-step FA2: exit 0; log prints `composed student=SyncArcticRLClient(...) teacher=SyncArcticRLClient(...)`; mean distill KL ~0.64, last-10 ~0.49 (matches pre-composition FA2 80-step within noise)
- [x] Qwen3-1.7B student / Qwen3-4B teacher, 80-step FA2: exit 0; mean distill KL ~0.72, last-10 ~0.62
- [x] Confirm student weight sync does not target the teacher, and the two local servers use disjoint Ray ports / CUDA devices

### CI
- [x] Formatting, unit-tests, and semgrep green on this PR