### PR TITLE
add GDN perf deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,12 @@ formatting = [
     "autoflake",
 ]
 
+# qwen3.5 and other models that use GDN attention layers need this for much better perf
+gdn = [
+    "flash-linear-attention",
+    "causal-conv1d",
+]
+
 # Shared DSSST1 tensor wire format.
 wire = [
     "numpy",


### PR DESCRIPTION
models relying on GDN layers need `flash-linear-attention` and `causal-conv1d` to run fast