### PR TITLE
trl: encode the client-side loss through stock grpo (no server-registered surrogate)

### DIFF
--- a/arctic_platform/integrations/trl/__init__.py
+++ b/arctic_platform/integrations/trl/__init__.py
@@ -17,10 +17,9 @@
 
 from typing import TYPE_CHECKING
 
-from arctic_platform.integrations.trl.client import ArcticOptimizer
-from arctic_platform.integrations.trl.client import ArcticTrainingClient
-
 if TYPE_CHECKING:
+    from arctic_platform.integrations.trl.client import ArcticOptimizer
+    from arctic_platform.integrations.trl.client import ArcticTrainingClient
     from arctic_platform.integrations.trl.rollout import ArcticRolloutWorker
     from arctic_platform.integrations.trl.weights import ArcticWeightTransfer
     from arctic_platform.rl.processors.weighted_logprob import weighted_logprob_sum
@@ -35,7 +34,13 @@ __all__ = [
 
 
 def __getattr__(name: str):
-    # Lazy: rollout/weights need async_grpo; loss needs the server.
+    # Lazy: client needs trl, rollout/weights need async_grpo; loss needs the server.
+    # Importing client eagerly made the whole package -- loss included -- unimportable
+    # without trl, which silently skipped the CPU loss tests.
+    if name in ("ArcticOptimizer", "ArcticTrainingClient"):
+        from arctic_platform.integrations.trl import client
+
+        return getattr(client, name)
     if name == "ArcticRolloutWorker":
         from arctic_platform.integrations.trl.rollout import ArcticRolloutWorker
 

--- a/arctic_platform/integrations/trl/client.py
+++ b/arctic_platform/integrations/trl/client.py
@@ -24,6 +24,9 @@ from typing import Any
 import torch
 from trl.experimental.api import ForwardBackwardOutput
 
+from arctic_platform.integrations.trl.loss import _CLIENT_LOSS_ENCODINGS
+from arctic_platform.integrations.trl.loss import _surrogate_payload
+
 
 def _meta_dict(
     *,
@@ -67,6 +70,11 @@ class ArcticTrainingClient:
             (perf + parity with verl/SkyRL). When ``False`` (default), keep the
             two-pass client-side surrogate path.
         server_loss_fn: Server GRPO loss name/dotted-path used when ``server_side_loss``.
+        client_loss_encoding: How the two-pass path expresses ``dL/dlogprobs`` to the
+            server. ``"weighted_logprob_sum"`` (default) names this package's own
+            surrogate, which the server must have registered. ``"grpo"`` encodes the
+            same quantity in the stock GRPO loss instead, so the path runs on a server
+            that ships nothing from this package -- see :func:`_surrogate_payload`.
     """
 
     def __init__(
@@ -83,6 +91,7 @@ class ArcticTrainingClient:
         logits_compute_in_fp32: bool = False,
         server_side_loss: bool = False,
         server_loss_fn: str = "arctic_platform.integrations.trl.loss.trl_grpo",
+        client_loss_encoding: str = "weighted_logprob_sum",
         zorro_train_enable: bool = False,
         response_len: int | None = None,
         zorro_load_balancer: bool = False,
@@ -99,6 +108,11 @@ class ArcticTrainingClient:
         self.logits_compute_in_fp32 = logits_compute_in_fp32
         self.server_side_loss = server_side_loss
         self.server_loss_fn = server_loss_fn
+        if client_loss_encoding not in _CLIENT_LOSS_ENCODINGS:
+            raise ValueError(
+                f"client_loss_encoding must be one of {sorted(_CLIENT_LOSS_ENCODINGS)}, got {client_loss_encoding!r}"
+            )
+        self.client_loss_encoding = client_loss_encoding
         self.zorro_train_enable = zorro_train_enable
         # Padded response width (== configured max_completion_length == server ds_worker_config.response_len).
         # Zorro emits verl-style structured [B, max_prompt_len + response_len] batches, so this must be set.
@@ -188,14 +202,20 @@ class ArcticTrainingClient:
         def send_backward(grad_loss: torch.Tensor) -> None:
             # Scale, unshift to [1, T], unpack to [B, S].
             weights = _unpack_to_padded(_unshift_from_trl(grad_log_probs * grad_loss), seq_lens)
+            back_batch, back_loss_fn, loss_config = _surrogate_payload(
+                self.client_loss_encoding, batch, weights, out["logprobs"], self.loss_fn
+            )
+            processing = {
+                "post": ["apply_temperature", "compute_entropy_and_logprobs"],
+                "loss_fn": back_loss_fn,
+            }
+            if loss_config:
+                processing["config"] = loss_config
             self.client.fwd_bwd(
                 {
-                    "batch": {**batch, "logprob_weights_shifted": weights},
+                    "batch": back_batch,
                     "meta": self._meta(calculate_entropy=False),
-                    "processing": {
-                        "post": ["apply_temperature", "compute_entropy_and_logprobs"],
-                        "loss_fn": self.loss_fn,
-                    },
+                    "processing": processing,
                 }
             )
 

--- a/arctic_platform/integrations/trl/loss.py
+++ b/arctic_platform/integrations/trl/loss.py
@@ -65,3 +65,48 @@ def trl_grpo(
     loss = masked / batch_num_tokens * dp_size / grad_accum
 
     return loss, {"loss": loss.detach()}
+
+
+_CLIENT_LOSS_ENCODINGS = ("weighted_logprob_sum", "grpo")
+
+
+def _surrogate_payload(
+    encoding: str,
+    batch: dict,
+    weights: torch.Tensor,
+    old_log_probs: torch.Tensor,
+    loss_fn: str,
+) -> tuple[dict, str, dict]:
+    """Express ``w = dL/dlogprobs`` as a batch the server can differentiate.
+
+    Both encodings ask for the same thing -- a loss whose gradient wrt log-probs is
+    exactly ``w`` -- and differ only in which registered loss carries it.
+
+    ``weighted_logprob_sum`` states it directly, but the server has to have this
+    package installed. ``grpo`` gets there with a loss every RL server already
+    ships: its gradient wrt log-probs is ``-advantages * ratio``, so pinning
+    ``old_log_probs_shifted`` to the log-probs the forward pass just returned makes
+    the ratio 1 and leaves ``-advantages``.
+
+    Scale follows from ``token-mean``, which is ``masked_sum / batch_num_tokens *
+    dp_size``. Setting both to 1 collapses it to a plain masked sum, so ``grpo``
+    reduces to exactly what ``weighted_logprob_sum`` computes -- including how it
+    behaves under data parallelism, which is inherited here rather than redefined.
+
+    Clipping cannot engage: at ratio 1, ``min(r*A, clip(r)*A)`` is ``A`` for any
+    epsilon. The server recomputes log-probs in bf16, so the ratio lands at 1 only
+    to within forward nondeterminism, which perturbs the gradient by ~1e-5
+    relative -- far inside the clip band, but not bit-exact.
+    """
+    if encoding == "grpo":
+        return (
+            {
+                **batch,
+                "old_log_probs_shifted": old_log_probs,
+                "advantages": -weights,
+                "loss_mask": batch["attention_mask"].to(weights.dtype),
+            },
+            "grpo",
+            {"batch_num_tokens": 1, "dp_size": 1},
+        )
+    return {**batch, "logprob_weights_shifted": weights}, loss_fn, {}

--- a/arctic_platform/integrations/trl/loss.py
+++ b/arctic_platform/integrations/trl/loss.py
@@ -89,9 +89,16 @@ def _surrogate_payload(
     the ratio 1 and leaves ``-advantages``.
 
     Scale follows from ``token-mean``, which is ``masked_sum / batch_num_tokens *
-    dp_size``. Setting both to 1 collapses it to a plain masked sum, so ``grpo``
-    reduces to exactly what ``weighted_logprob_sum`` computes -- including how it
-    behaves under data parallelism, which is inherited here rather than redefined.
+    dp_size``. Setting both to 1 collapses it to a plain masked sum, leaving the
+    gradient unnormalized exactly as ``weighted_logprob_sum`` leaves it -- so the
+    two encodings behave identically under data parallelism, inheriting that
+    behaviour rather than redefining it.
+
+    What matches is the gradient, not the number. ``weighted_logprob_sum`` reports
+    ``sum(w * logprobs)`` while this reports ``sum(w)``, because at ratio 1 the
+    per-token GRPO term is ``-advantages``. Both differentiate to ``w``, which is
+    all the backward pass consumes; the client reports its own loss to TRL and
+    discards the server's, so the difference is confined to server-side metrics.
 
     Clipping cannot engage: at ratio 1, ``min(r*A, clip(r)*A)`` is ``A`` for any
     epsilon. The server recomputes log-probs in bf16, so the ratio lands at 1 only

--- a/tests/integrations/trl/test_client_loss_encoding.py
+++ b/tests/integrations/trl/test_client_loss_encoding.py
@@ -32,6 +32,7 @@ import torch
 
 from arctic_platform.integrations.trl.loss import _surrogate_payload
 from arctic_platform.rl.processors.grpo import grpo_loss
+from arctic_platform.rl.processors.weighted_logprob import weighted_logprob_sum
 
 B, S = 2, 6
 
@@ -110,6 +111,49 @@ class TestGrpoEncoding:
         payload, _, config = _surrogate_payload("grpo", batch, weights, log_probs, "unused")
 
         assert torch.allclose(_server_gradient(payload, config, log_probs), weights, atol=1e-12)
+
+
+class TestEquivalenceWithTheDefaultEncoding:
+    def test_both_encodings_produce_the_same_gradient(self):
+        """The two paths must be interchangeable in the only way that matters."""
+        torch.manual_seed(2)
+        batch = _batch()
+        log_probs = torch.randn(B, S, dtype=torch.float64)
+        weights = torch.randn(B, S, dtype=torch.float64)
+        weights[:, -1] = 0.0  # as _unpack_to_padded leaves padded positions
+
+        grpo_payload, _, config = _surrogate_payload("grpo", batch, weights, log_probs, "x")
+        wls_payload, _, _ = _surrogate_payload("weighted_logprob_sum", batch, weights, log_probs, "x")
+
+        leaf = log_probs.clone().requires_grad_(True)
+        wls_loss, _ = weighted_logprob_sum({"logprobs": leaf}, wls_payload, {}, {}, "cpu")
+        (wls_grad,) = torch.autograd.grad(wls_loss, leaf)
+
+        assert torch.allclose(_server_gradient(grpo_payload, config, log_probs), wls_grad, atol=1e-12)
+
+    def test_the_reported_loss_value_differs_and_that_is_fine(self):
+        """Only the gradient is shared; the scalars are not the same number.
+
+        At ratio 1 the per-token GRPO term is ``-advantages``, so grpo reports
+        ``sum(w)`` where the default reports ``sum(w * logprobs)``. The client
+        reports its own loss to TRL and drops the server's, so this shows up only
+        in server-side metrics -- but it would be a real surprise when comparing
+        runs across encodings, so it is pinned rather than left implicit.
+        """
+        torch.manual_seed(3)
+        batch = _batch()
+        log_probs = torch.randn(B, S, dtype=torch.float64)
+        weights = torch.randn(B, S, dtype=torch.float64)
+
+        grpo_payload, _, config = _surrogate_payload("grpo", batch, weights, log_probs, "x")
+        wls_payload, _, _ = _surrogate_payload("weighted_logprob_sum", batch, weights, log_probs, "x")
+
+        grpo_value, _ = grpo_loss({"logprobs": log_probs}, grpo_payload, config, "cpu")
+        wls_value, _ = weighted_logprob_sum({"logprobs": log_probs}, wls_payload, {}, {}, "cpu")
+
+        assert float(grpo_value) == pytest.approx(float(weights.sum()))
+        assert float(wls_value) == pytest.approx(float((weights * log_probs).sum()))
+        assert float(grpo_value) != pytest.approx(float(wls_value))
 
 
 class TestDefaultEncoding:

--- a/tests/integrations/trl/test_client_loss_encoding.py
+++ b/tests/integrations/trl/test_client_loss_encoding.py
@@ -156,6 +156,73 @@ class TestEquivalenceWithTheDefaultEncoding:
         assert float(grpo_value) != pytest.approx(float(wls_value))
 
 
+class TestPayloadAlignment:
+    """Whether the tensors line up once the real client builds them.
+
+    The encoding tests above feed ``_surrogate_payload`` tensors that are aligned
+    by construction. In the client they are not: ``weights`` round-trips through
+    TRL's packed layout via ``_unshift_from_trl`` and ``_unpack_to_padded``, while
+    ``old_log_probs_shifted`` is the server's reply untouched. If those two frames
+    disagree by even one position the gradient is silently wrong -- no error, just
+    a worse model -- so it is worth pinning against the real call path.
+    """
+
+    LENS = (5, 4)
+
+    class _MockClient:
+        def __init__(self, lens):
+            self.payload = None
+            b, s = len(lens), max(lens)
+            # Distinctive per-position values, so a misalignment cannot look plausible.
+            self.logprobs = torch.zeros(b, s, dtype=torch.float32)
+            for row, n in enumerate(lens):
+                for col in range(n):
+                    self.logprobs[row, col] = -(10 * (row + 1) + col)
+
+        def fwd_no_grad(self, payload):
+            del payload
+            return {"batch": {"logprobs": self.logprobs.clone(), "entropy": torch.zeros_like(self.logprobs)}}
+
+        def fwd_bwd(self, payload):
+            self.payload = payload
+            return {}
+
+    def _run(self, encoding: str):
+        client_mod = pytest.importorskip("arctic_platform.integrations.trl.client")
+        mock = self._MockClient(self.LENS)
+        client = client_mod.ArcticTrainingClient(client=mock, client_loss_encoding=encoding)
+        total = sum(self.LENS)
+
+        out = client.forward_backward(
+            model=None,
+            input_ids=torch.arange(1, total + 1).unsqueeze(0),
+            position_ids=torch.cat([torch.arange(n) for n in self.LENS]).unsqueeze(0),
+            completion_mask=torch.ones(1, total, dtype=torch.long),
+            # dL/dlogprobs == logprobs, so the weights coming back out are the
+            # log-probs themselves after the full round trip.
+            loss_fn=lambda leaf: (leaf**2).sum() / 2,
+        )
+        out.loss.backward()
+        return mock
+
+    def test_advantages_are_paired_with_the_logprobs_they_came_from(self):
+        mock = self._run("grpo")
+        batch = mock.payload["batch"]
+
+        assert torch.equal(batch["old_log_probs_shifted"], mock.logprobs)
+        carried = batch["advantages"] != 0
+        assert carried.any()
+        assert torch.allclose(batch["advantages"][carried], -mock.logprobs[carried])
+
+    def test_both_encodings_weight_exactly_the_same_positions(self):
+        """grpo must not silently supervise more or fewer tokens than the default."""
+        grpo_batch = self._run("grpo").payload["batch"]
+        default_batch = self._run("weighted_logprob_sum").payload["batch"]
+
+        assert torch.equal(grpo_batch["advantages"] != 0, default_batch["logprob_weights_shifted"] != 0)
+        assert torch.allclose(grpo_batch["advantages"], -default_batch["logprob_weights_shifted"])
+
+
 class TestDefaultEncoding:
     def test_default_is_unchanged(self):
         """The existing path must keep naming its own loss and its own key."""

--- a/tests/integrations/trl/test_client_loss_encoding.py
+++ b/tests/integrations/trl/test_client_loss_encoding.py
@@ -1,0 +1,134 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for how the two-pass path encodes ``w = dL/dlogprobs`` for the server.
+
+The client-side path is only correct if the server, differentiating whatever we
+send, lands on exactly ``w``. The `weighted_logprob_sum` encoding says so
+literally, so there is little to check. The `grpo` encoding says it indirectly --
+through advantages, a pinned behavioural policy and a normalization that has to
+collapse -- so these tests differentiate the real ``grpo`` loss and compare.
+
+That is the property worth pinning: not the payload's shape, but that its
+gradient is the weights we asked for.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from arctic_platform.integrations.trl.loss import _surrogate_payload
+from arctic_platform.rl.processors.grpo import grpo_loss
+
+B, S = 2, 6
+
+
+def _batch() -> dict:
+    return {
+        "input_ids": torch.randint(0, 50, (B, S)),
+        "attention_mask": torch.ones(B, S, dtype=torch.long),
+        "position_ids": torch.arange(S).expand(B, S).contiguous(),
+    }
+
+
+def _server_gradient(payload: dict, config: dict, log_probs: torch.Tensor) -> torch.Tensor:
+    """d(grpo)/d(logprobs) as the server would compute it, at the returned log-probs.
+
+    The server recomputes log-probs; in the noiseless case they equal what the
+    forward pass returned, which is the point at which the ratio is 1.
+    """
+    leaf = log_probs.clone().requires_grad_(True)
+    loss, _ = grpo_loss({"logprobs": leaf}, payload, config, "cpu")
+    (grad,) = torch.autograd.grad(loss, leaf)
+    return grad
+
+
+class TestGrpoEncoding:
+    def test_server_gradient_is_the_requested_weights(self):
+        """The whole contract: differentiate what we send, get back w."""
+        torch.manual_seed(0)
+        batch = _batch()
+        log_probs = torch.randn(B, S, dtype=torch.float64)
+        weights = torch.randn(B, S, dtype=torch.float64)
+
+        payload, loss_fn, config = _surrogate_payload("grpo", batch, weights, log_probs, "unused")
+
+        assert loss_fn == "grpo"
+        assert torch.allclose(_server_gradient(payload, config, log_probs), weights, atol=1e-12)
+
+    def test_it_holds_when_some_weights_are_zero(self):
+        """Masked-out positions must contribute no gradient, not a small one."""
+        torch.manual_seed(1)
+        batch = _batch()
+        log_probs = torch.randn(B, S, dtype=torch.float64)
+        weights = torch.randn(B, S, dtype=torch.float64)
+        weights[0, :3] = 0.0
+        weights[1, -1] = 0.0
+
+        payload, _, config = _surrogate_payload("grpo", batch, weights, log_probs, "unused")
+        grad = _server_gradient(payload, config, log_probs)
+
+        assert torch.allclose(grad, weights, atol=1e-12)
+        assert float(grad[0, :3].abs().max()) == 0.0
+
+    def test_normalization_collapses_to_a_plain_sum(self):
+        """token-mean is masked_sum / batch_num_tokens * dp_size.
+
+        Both must be 1 or the gradient picks up a scale factor, which is the one
+        way this encoding can be wrong while still looking plausible.
+        """
+        _, _, config = _surrogate_payload("grpo", _batch(), torch.zeros(B, S), torch.zeros(B, S), "unused")
+
+        assert config == {"batch_num_tokens": 1, "dp_size": 1}
+
+    def test_the_behavioural_policy_is_pinned_to_the_returned_logprobs(self):
+        """Ratio 1 is what removes clipping and leaves -advantages."""
+        log_probs = torch.randn(B, S, dtype=torch.float64)
+        payload, _, _ = _surrogate_payload("grpo", _batch(), torch.randn(B, S, dtype=torch.float64), log_probs, "x")
+
+        assert torch.equal(payload["old_log_probs_shifted"], log_probs)
+
+    def test_a_large_weight_still_maps_exactly(self):
+        """Advantages are -w unscaled, so nothing clips however big w gets."""
+        batch = _batch()
+        log_probs = torch.zeros(B, S, dtype=torch.float64)
+        weights = torch.full((B, S), 37.5, dtype=torch.float64)
+
+        payload, _, config = _surrogate_payload("grpo", batch, weights, log_probs, "unused")
+
+        assert torch.allclose(_server_gradient(payload, config, log_probs), weights, atol=1e-12)
+
+
+class TestDefaultEncoding:
+    def test_default_is_unchanged(self):
+        """The existing path must keep naming its own loss and its own key."""
+        weights = torch.randn(B, S)
+        payload, loss_fn, config = _surrogate_payload(
+            "weighted_logprob_sum", _batch(), weights, torch.randn(B, S), "pkg.weighted_logprob_sum"
+        )
+
+        assert loss_fn == "pkg.weighted_logprob_sum"
+        assert config == {}
+        assert torch.equal(payload["logprob_weights_shifted"], weights)
+        assert "advantages" not in payload
+
+    def test_an_unknown_encoding_is_rejected_at_construction(self):
+        # The client module needs trl itself; the encoding above does not, which is
+        # why it lives in loss.py and is testable without it.
+        client_mod = pytest.importorskip("arctic_platform.integrations.trl.client")
+
+        with pytest.raises(ValueError, match="client_loss_encoding"):
+            client_mod.ArcticTrainingClient(client=object(), client_loss_encoding="nope")

--- a/tests/integrations/trl/test_client_loss_encoding.py
+++ b/tests/integrations/trl/test_client_loss_encoding.py
@@ -222,6 +222,44 @@ class TestPayloadAlignment:
         assert torch.equal(grpo_batch["advantages"] != 0, default_batch["logprob_weights_shifted"] != 0)
         assert torch.allclose(grpo_batch["advantages"], -default_batch["logprob_weights_shifted"])
 
+    def test_both_encodings_hand_the_server_the_same_gradient(self):
+        """Switching encodings must change nothing the server acts on.
+
+        The tests above compare payload tensors, and the equivalence test above
+        differentiates the two losses on tensors that were aligned by
+        construction. Neither would catch a divergence introduced inside
+        ``forward_backward`` itself. This runs the real client path under both
+        encodings and then differentiates the real server losses on whatever it
+        produced, which is the form of the claim a caller on the default
+        encoding actually depends on.
+        """
+        grpo_run = self._run("grpo")
+        default_run = self._run("weighted_logprob_sum")
+        assert torch.equal(grpo_run.logprobs, default_run.logprobs), "fixtures diverged; comparison is meaningless"
+
+        def _f64(batch: dict) -> dict:
+            # float32 leaves ~4e-6 of slack at these magnitudes, which is wider
+            # than a real disagreement would have to be to matter.
+            return {k: v.double() if torch.is_tensor(v) and v.is_floating_point() else v for k, v in batch.items()}
+
+        grpo_leaf = grpo_run.logprobs.double().requires_grad_(True)
+        grpo_value, _ = grpo_loss(
+            {"logprobs": grpo_leaf},
+            _f64(grpo_run.payload["batch"]),
+            grpo_run.payload["processing"].get("config", {}),
+            "cpu",
+        )
+        (grpo_grad,) = torch.autograd.grad(grpo_value, grpo_leaf)
+
+        default_leaf = default_run.logprobs.double().requires_grad_(True)
+        default_value, _ = weighted_logprob_sum(
+            {"logprobs": default_leaf}, _f64(default_run.payload["batch"]), {}, {}, "cpu"
+        )
+        (default_grad,) = torch.autograd.grad(default_value, default_leaf)
+
+        assert grpo_grad.abs().max() > 0, "a zero gradient would pass the comparison for the wrong reason"
+        assert torch.allclose(grpo_grad, default_grad, atol=1e-12)
+
 
 class TestDefaultEncoding:
     def test_default_is_unchanged(self):


### PR DESCRIPTION
Builds on #84. Lets the TRL client compute its loss locally and still train over Cortex, without registering a new server-side loss function or rebuilding the image.

## The idea

The client differentiates its own objective to get `w = dL/dlogprobs`, then ships that through the **stock** `grpo` loss by setting `old_log_probs_shifted = logprobs` and `advantages = -w` with `batch_num_tokens=1`. The ratio is then identically 1, and grpo's gradient with respect to the log-probs collapses to exactly `w`. The server never learns which loss the client used.

## This does not replace `weighted_logprob_sum`

`client_loss_encoding` defaults to `"weighted_logprob_sum"`, so #84's path is unchanged and `"grpo"` is opt-in. This is a fallback for servers that do not register the direct loss, not an alternative to it.

Where both are available, prefer the direct encoding: it sends one `[batch, seq]` tensor rather than three, reports a loss value that moves instead of the constant `sum(w)`, and does not lean on incidental properties of a clipped objective that a server-side change could alter silently.

Today the fallback is needed only on Cortex, whose registry is `arctic_training.arctic_rl.processors` in ArcticTraining-dss — not this repo — and holds `causal_cross_entropy`, `grpo` and `grpo_echo_v1` only.

An earlier version of this description said the alternative "needs a Jenkins image rebuild" and framed it as waiting on Cortex to depend on Arctic-Platform. Both were wrong, and read as if this competed with #84. Registering `weighted_logprob_sum` in ArcticTraining is a small addition to a registry that already exists, and doing so retires this encoding. That is the better fix; treat this as a stopgap with a short shelf life.

## What is verified

**The gradient is right, on a real cluster.** Against Qwen3-8B on QA6, the surrogate reproduces the gradient of a direct server-side `grpo` call to a relative difference below `1e-3`, measured through the returned `grad_norm`.

**The tensors line up.** This was the risk I cared most about, because a shift or transpose in the round trip is silent — no error, just a worse model — and a gradient check at a point cannot catch an error consistent across both paths. `weights` round-trips through TRL's packed layout via `_unshift_from_trl` and `_unpack_to_padded`, while `old_log_probs_shifted` is the server's reply untouched, so the two frames have independent provenance.

`TestPayloadAlignment` drives the real `forward_backward` against a mock client with a loss whose derivative is the identity, so the weights coming back out are the log-probs themselves. Every supervised position satisfies `advantages == -old_log_probs_shifted` to `0.0` error, and both encodings weight *exactly* the same positions — grpo does not silently supervise more or fewer tokens than the default.

**It trains, and our gradient is what drives it.** Overfitting a single fixed batch through the real path — client-side NLL, #95's `CortexTransport`, this PR's `_surrogate_payload`, a real optimizer step, and a fresh forward re-measuring each step:

| | start | end | |
|---|---|---|---|
| descent | 6.301 | 5.6e-05 | down on 19/19 steps |
| control, advantages negated | 1.3e-05 | 29.3 | up, after Adam momentum reverses at step ~8 |

![client-side loss convergence over Cortex](https://github.com/Snowflake-AI-Research/Arctic-Platform/raw/karthik/pr100-assets/pr100/convergence.png)

The control separates "our gradient drives this" from "something moved". Flipping the one sign the encoding depends on reverses the direction, and the turn lands where β₁=0.9 predicts.

<details>
<summary>Per-step records from both runs</summary>

```
DESCENT  (job 74806ebc-2ac5-46fc-8a7f-f23dd5f6bb5c, lr=1e-05, 27 supervised tokens)

step    client NLL   server avg_loss   mean logprob
   0      6.301409      -0.037037037      -0.664602
   1      4.812599      -0.037037037      -0.507579
   2      2.759532      -0.037037037      -0.291044
   3      2.140888      -0.037037037      -0.225797
   4      0.655851      -0.037037037      -0.069172
   5      0.407752      -0.037037037      -0.043005
   6      0.333765      -0.037037037      -0.035202
   7      0.224964      -0.037037037      -0.023727
   8      0.186377      -0.037037037      -0.019657
   9      0.156420      -0.037037037      -0.016497
  10      0.100299      -0.037037037      -0.010578
  11      0.058551      -0.037037037      -0.006175
  12      0.029190      -0.037037037      -0.003079
  13      0.004112      -0.037037037      -0.000434
  14      0.001076      -0.037037037      -0.000113
  15      0.000418      -0.037037037      -0.000044
  16      0.000201      -0.037037037      -0.000021
  17      0.000127      -0.037037037      -0.000013
  18      0.000083      -0.037037037      -0.000009
  19      0.000056      -0.037037037      -0.000006

CONTROL - advantages negated  (job 74806ebc-2ac5-46fc-8a7f-f23dd5f6bb5c, lr=1e-05, 27 supervised tokens)

step    client NLL   server avg_loss   mean logprob
   0      0.000013       0.037037037      -0.000001
   1      0.000013       0.037037037      -0.000001
   2      0.000013       0.037037037      -0.000001
   3      0.000009       0.037037037      -0.000001
   4      0.000010       0.037037037      -0.000001
   5      0.000009       0.037037037      -0.000001
   6      0.000009       0.037037037      -0.000001
   7      0.000009       0.037037037      -0.000001
   8      0.000014       0.037037037      -0.000001
   9      0.000015       0.037037037      -0.000002
  10      0.000018       0.037037037      -0.000002
  11      0.000033       0.037037037      -0.000004
  12      0.000044       0.037037037      -0.000005
  13      0.000191       0.037037037      -0.000020
  14      0.042644       0.037037037      -0.004498
  15      1.931545       0.037037037      -0.203718
  16      3.267599       0.037037037      -0.344630
  17      3.317190       0.037037037      -0.349860
  18      6.730339       0.037037037      -0.709840
  19      7.638395       0.037037037      -0.805612
  20     10.684365       0.037037037      -1.126867
  21     14.444805       0.037037037      -1.523476
  22     20.465557       0.037037037      -2.158477
  23     22.777063       0.037037037      -2.402268
  24     29.332265       0.037037037      -3.093637
```

`server avg_loss` holding constant is expected: `old_log_probs` is refreshed to the current policy each step, so the ratio is identically 1 and the surrogate's value depends only on the advantages. It is the gradient that does the work, and drift in that constant would have meant the encoding was not being read as intended.

</details>

**It runs inside the real TRL trainer, against Cortex.** `send_backward` had never executed with real TRL tensors; it now has, for 150 optimizer steps across two runs of the gsm8k recipe (`recipes/rl/trl/gsm8k`) with the backend swapped from on-prem to Cortex. Real vLLM rollouts, real `accuracy_reward`, real weight sync.

![gsm8k over Cortex](https://github.com/Snowflake-AI-Research/Arctic-Platform/raw/karthik/pr100-assets/pr100/gsm8k/gsm8k_convergence.png)

The load-bearing number is the right panel. The importance ratio stayed within **0.9993–1.0025** across all 120 steps, which is an end-to-end check on the log-prob frame through packing, unpacking and shifting — an off-by-one anywhere would push it far from 1.

The reward went from 0.497 (first 30 steps) to 0.633 (last 30), `t ≈ 2.3`. I would call that suggestive, not a convergence result: the steps are not independent samples (32 prompts recycled for 120 steps, autocorrelated), and 13% of steps had `reward_std = 0`, meaning every rollout in the group scored alike and the step contributed no gradient at all. A real claim needs the recipe's scale — 7,473 prompts on 8 GPUs, not 32 prompts on 1.

**The two PRs compose.** #95 and this branch merge with no conflicts, and the union of both test suites is green (77 passed).

## The blocker this surfaced

Getting the recipe to Cortex at all required an adapter, for reasons independent of this PR. Every call in `arctic_platform/integrations/trl/client.py` sends the on-prem `{batch, meta, processing}` envelope and asks for the post-processors `apply_temperature` and `compute_entropy_and_logprobs`. Grep `dss/` for those two and you get nothing — a Cortex zone registers only `compute_logprobs`. The first failure is the zone rejecting the envelope outright: `dispatch requires 2D input_ids`.

The [adapter](https://github.com/Snowflake-AI-Research/Arctic-Platform/tree/karthik/pr100-assets/pr100/gsm8k/cortex_trl_adapter.py) translates the envelope and substitutes `compute_logprobs`, which is only sound because the recipe runs at `temperature=1.0` where `apply_temperature` is a no-op; anything else is refused rather than silently mis-scaled. Entropy comes back as zeros, so any entropy metric is meaningless and an entropy bonus would silently do nothing.

That is a shim for a demonstration, not a fix. The real fix is either teaching Cortex zones those post-processors or teaching the integration to speak both dialects, and it probably wants its own issue.

Two smaller ones, both worth knowing: the Cortex image ships FA3 but not FA2 (the recipe asks for FA2 and the job dies at model load), and `offload_optimizer: {"device": "none"}` is still enough for DeepSpeed to instantiate CPUAdam, which then asserts because the params are on GPU.

## Not verified

- **Convergence at the recipe's scale.** See above — 1 GPU and 32 prompts is not 8 GPUs and 7,473.
- **The on-prem backend.** The encoding has only ever run against Cortex.
- **`temperature != 1.0`**, and entropy anywhere.
- **`loss_mask`.** `_surrogate_payload` derives it from `attention_mask`. When a batch also carries `labels` that is one position too generous per row and grpo's preflight rejects it, so both harnesses override it with `labels != -100`. TRL's own batches carry no `labels`, so the default is correct on the path this PR targets.

## Note on the equivalence

The `grpo` encoding and `weighted_logprob_sum` produce **identical gradients**, not identical loss values — the reported scalars differ (`sum(w)` versus `sum(w * logprobs)`). An earlier draft of this description overstated that as full equivalence. `test_client_loss_encoding.py` pins both facts.

Raw artifacts, the gsm8k runner and the adapter live on [`karthik/pr100-assets`](https://github.com/Snowflake-AI-Research/Arctic-Platform/tree/karthik/pr100-assets/pr100), kept off this branch so the diff stays code-only. Safe to delete once this merges.
