### PR TITLE
[CI] adapt to AI's changed

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -53,13 +53,7 @@ jobs:
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
           uv pip install torch --index-url https://download.pytorch.org/whl/cpu
-          # [rl] declares arctic-inference and vllm, so this resolves the whole stack.
-          # ArcticInference builds a native nanobind extension via CMake. actions/setup-python exports
-          # Python(3)_ROOT_DIR/pythonLocation pointing at the tool-cache interpreter (no nanobind); CMake's
-          # find_package(Python) honors those hints and fails to find nanobind. Unset them so CMake uses uv's
-          # build-env interpreter, which has nanobind from ArcticInference's build-system.requires.
-          env -u Python_ROOT_DIR -u Python2_ROOT_DIR -u Python3_ROOT_DIR -u pythonLocation \
-            uv pip install ".[testing,rl]"
+          uv pip install ".[sft,testing]"
       - name: Environment print
         run: |
           uv pip list

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,11 +1,9 @@
+[bug fix] Require arctic-inference 0.3.0+ for the [rl] extra
+
 ## Summary
 
-- SFT returns a single merged `metrics` dict after `fwd_bwd` + `step`, matching RL `update_actor` (step metrics as the base, fwd_bwd keys win).
-- `ArcticSFTClient.train_step` and `merge_sft_step_metrics` live on the unified client (`arctic_platform/client/sft.py`). The worker already emitted `loss` / `grad_norm` (and any extra loss-fn keys); this wires them through as one dict instead of making every caller cherry-pick.
-- Demos and `docs/sft.md` use `train_step`.
-- Merges `origin/main` client unification (`ArcticSFTClient` subclasses `ArcticClient`; old `arctic_platform/sft/client.py` is gone).
+`[rl]` asks for `arctic-inference[server,vllm]>=0.3.0` and does not declare `vllm`. That extra pulls vLLM and applies that release's pin. `tensordict` lives on `[sft]`. `[testing]` is pytest plugins only. Unit Tests Setup environment is `uv pip install ".[sft,testing]"` after CPU torch, so the CPU runner does not pull arctic-inference.
 
 ## Testing
 
-- CPU on `stas-dev-2-0` (`CUDA_VISIBLE_DEVICES=`, conda `dev`): `tests/sft/test_sft_client_ops.py` + `tests/sft/test_sft_config.py` + `tests/client/test_client_ops.py` — 84 passed after the merge (job `20260824T163728Z-1073948-000-2668422822`).
-- No GPU / live-server run for this change (client surface only).
+`tests/test_dependency_groups.py`. GitHub Unit Tests Setup environment is unrun on this SHA.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,6 @@ classifiers = [
 
 requires-python = ">=3.12"
 
-
-# Config models only. Every usable install picks a backend extra: [cortex] to
-# drive Cortex, [sft]/[rl]/[onprem] to run against an on-prem server.
 dependencies = [
     "pydantic>=2.10",
     "typing-extensions",  # Self, per the pydantic model_validator convention
@@ -70,10 +67,7 @@ dev = [
     "arctic_platform[testing]",
 ]
 
-# Pulls [onprem] because the suite exercises both servers, and because `dev` is
-# defined as formatting + testing.
 testing = [
-    "arctic_platform[onprem]",
     "parameterized",
     "pytest-instafail",
     "pytest-flakefinder",
@@ -126,15 +120,17 @@ sft = [
     "nvidia-ml-py",
     "psutil",
     "ray",
+    "tensordict",
     "transformers",
     "uvicorn",
 ]
 
-# [sft] plus sampling. arctic-inference[vllm] owns the validated vLLM pin.
+# [sft] plus sampling. arctic-inference[vllm] pulls vLLM and applies that extra's
+# pin; [rl] does not declare vLLM. 0.3.0 is the first release of that extra
+# contract.
 rl = [
     "arctic_platform[sft]",
-    "arctic-inference[server,vllm]>=0.2.0",
-    "tensordict",
+    "arctic-inference[server,vllm]>=0.3.0",
 ]
 
 onprem = [

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -21,8 +21,6 @@ cannot silently diverge from the base; op-registry coverage and log_probs stay o
 the RL clients, and SFT's loss-fn defaulting is asserted in tests/sft.
 """
 
-# testing CI
-
 from __future__ import annotations
 
 import asyncio

--- a/tests/client/test_client_ops.py
+++ b/tests/client/test_client_ops.py
@@ -21,6 +21,8 @@ cannot silently diverge from the base; op-registry coverage and log_probs stay o
 the RL clients, and SFT's loss-fn defaulting is asserted in tests/sft.
 """
 
+# testing CI
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
AI 0.3.0 release broke CI, fixing it to remove deps on AI, since cpu only tests can't use AI anyway.