### PR TITLE
Cortex envelope adapter for the TRL integration

### DIFF
--- a/arctic_platform/integrations/trl/cortex.py
+++ b/arctic_platform/integrations/trl/cortex.py
@@ -1,0 +1,154 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Make this integration's client calls legible to a Cortex zone.
+
+The TRL integration was written against the on-prem server and speaks its
+dialect: batches go out as ``{"batch", "meta", "processing"}`` and every call
+asks for the post-processors ``apply_temperature`` and
+``compute_entropy_and_logprobs``. A Cortex zone understands neither. It wants
+``{"kwargs", "processing"}``, and the only post-processor it registers is
+``compute_logprobs`` -- the other two names do not appear anywhere in
+ArcticTraining-dss or dss-platform.
+
+Without translation the recipe fails before it ever reaches the loss: the zone's
+``dp_shard_batch`` rejects the outer envelope with ``dispatch requires 2D
+input_ids to plan token-budget microbatches``.
+
+:class:`CortexTRLAdapter` sits between :class:`ArcticTrainingClient` /
+:class:`ArcticRolloutWorker` and the real client, and translates.
+
+This is a translation layer, not the end state. The two candidates for a real
+fix are registering those post-processors in ArcticTraining-dss, or teaching
+this integration to emit both dialects directly. Either retires this file. It
+exists because the alternative is that the Cortex path cannot run at all.
+
+Two gaps it cannot close, both raised or documented rather than hidden:
+
+* ``apply_temperature`` is a no-op only at ``temperature == 1.0``. Anything else
+  is refused in the constructor rather than silently mis-scaled.
+* ``compute_entropy_and_logprobs`` returns entropy and ``compute_logprobs`` does
+  not, so entropy comes back as zeros. Any entropy metric is therefore
+  meaningless and an entropy bonus would silently do nothing. GRPO as configured
+  for this path uses neither, which is the only reason this is survivable.
+
+Whether the two post-processors agree on the *frame* of the returned log-probs
+is not something this file can assert -- it is a property of the two server
+implementations. The check is the reported importance ratio: on policy it must
+sit at ~1, and an off-by-one frame blows it up.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+_ON_PREM_POST_PROCESSORS = ("apply_temperature", "compute_entropy_and_logprobs")
+
+
+def next_token_labels(batch: dict) -> torch.Tensor:
+    """Next-token targets, with ``-100`` on padding and on each row's last token.
+
+    The zone's ``compute_logprobs`` scores position ``t`` against ``labels[t]``.
+    A row's final real token has no successor, so it is not a target -- which is
+    also why ``loss_mask`` has to be derived from the labels rather than the
+    attention mask. It is one position tighter, and grpo's preflight rejects a
+    mask that supervises a position whose label is ``-100``.
+    """
+    ids = batch["input_ids"]
+    mask = batch["attention_mask"]
+    labels = torch.full_like(ids, -100)
+    labels[:, :-1] = ids[:, 1:]
+    valid = mask.bool()
+    has_next = torch.zeros_like(valid)
+    has_next[:, :-1] = valid[:, 1:]
+    labels[~(valid & has_next)] = -100
+    return labels
+
+
+class CortexTRLAdapter:
+    """Translate on-prem-shaped TRL client calls into Cortex-shaped ones.
+
+    Wrap the client and hand the *wrapper* to both
+    :class:`ArcticTrainingClient` and :class:`ArcticRolloutWorker`. Passing the
+    unwrapped client to either one reintroduces the dialect mismatch for that
+    call path only, which fails at the zone rather than locally.
+
+    Args:
+        client: an :class:`~arctic_platform.client.ArcticRLClient` on a Cortex
+            backend.
+        temperature: must be ``1.0``; see the module docstring.
+    """
+
+    def __init__(self, client: Any, *, temperature: float = 1.0):
+        if abs(temperature - 1.0) > 1e-9:
+            raise ValueError(
+                f"temperature={temperature} needs the apply_temperature post-processor, which no "
+                "Cortex zone registers. Only 1.0 is safe here, where it is a no-op."
+            )
+        self._client = client
+        self.temperature = temperature
+
+    def __getattr__(self, name: str) -> Any:
+        # generate, step, sync_weights, jobs, shutdown, ... all pass through.
+        # Only the two calls that carry a batch envelope need translating.
+        return getattr(self._client, name)
+
+    def _to_cortex(self, payload: dict) -> tuple[dict, dict]:
+        batch = dict(payload["batch"])
+        processing = dict(payload.get("processing") or {})
+        batch.setdefault("labels", next_token_labels(batch))
+
+        unknown = [p for p in (processing.get("post") or []) if p not in _ON_PREM_POST_PROCESSORS]
+        if unknown:
+            # Refuse rather than drop: a post-processor we do not recognise may
+            # be load-bearing, and silently discarding it would corrupt the run
+            # in a way that looks like a modelling problem.
+            raise ValueError(
+                f"cannot translate post-processors {unknown} for the Cortex path; "
+                f"only {list(_ON_PREM_POST_PROCESSORS)} are known to be expressible here"
+            )
+
+        cortex: dict[str, Any] = {"post": ["compute_logprobs"], "loss_fn": processing.get("loss_fn")}
+        if processing.get("config"):
+            cortex["config"] = processing["config"]
+        return batch, cortex
+
+    def fwd_no_grad(self, payload: dict) -> dict:
+        batch, processing = self._to_cortex(payload)
+        result = self._client.fwd_no_grad({"kwargs": batch, "processing": processing})
+        if "logprobs" not in result:
+            raise RuntimeError(f"cortex forward returned no logprobs (keys={sorted(result)})")
+        logprobs = torch.as_tensor(result["logprobs"])
+        entropy = result.get("entropy")
+        return {
+            "batch": {
+                "logprobs": logprobs,
+                # The zone computes no entropy. Zeros keep the caller's shape
+                # contract; see the module docstring for why that is survivable
+                # here and what it silently disables.
+                "entropy": torch.as_tensor(entropy) if entropy is not None else torch.zeros_like(logprobs),
+            }
+        }
+
+    def fwd_bwd(self, payload: dict) -> dict:
+        batch, processing = self._to_cortex(payload)
+        if "loss_mask" in batch:
+            # The caller derives loss_mask from attention_mask, which is one
+            # position too generous once labels exist. grpo's preflight requires
+            # loss_mask == 0 wherever the label is -100.
+            batch["loss_mask"] = (batch["labels"] != -100).to(batch["loss_mask"].dtype)
+        return self._client.fwd_bwd({"kwargs": batch, "processing": processing})

--- a/tests/integrations/trl/test_cortex_adapter.py
+++ b/tests/integrations/trl/test_cortex_adapter.py
@@ -1,0 +1,215 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What the Cortex adapter must translate, and what it must refuse.
+
+A zone rejects a mistranslated envelope, so translation bugs are loud. The two
+that would *not* be loud are a mis-framed ``labels`` tensor and a ``loss_mask``
+one position too wide: both produce a running job that optimises the wrong
+thing. Those get the most attention here.
+"""
+
+import pytest
+import torch
+
+cortex = pytest.importorskip("arctic_platform.integrations.trl.cortex")
+
+CortexTRLAdapter = cortex.CortexTRLAdapter
+next_token_labels = cortex.next_token_labels
+
+
+class _RecordingClient:
+    """Captures what the adapter sends, and answers plausibly."""
+
+    def __init__(self, *, logprobs=None, entropy=None, omit_logprobs=False):
+        self.fwd_no_grad_payload = None
+        self.fwd_bwd_payload = None
+        self._logprobs = logprobs
+        self._entropy = entropy
+        self._omit_logprobs = omit_logprobs
+        self.generate_calls = 0
+
+    def fwd_no_grad(self, payload):
+        self.fwd_no_grad_payload = payload
+        if self._omit_logprobs:
+            return {"job_id": "j"}
+        rows = payload["kwargs"]["input_ids"]
+        lp = self._logprobs if self._logprobs is not None else torch.zeros_like(rows, dtype=torch.float32)
+        out = {"logprobs": lp}
+        if self._entropy is not None:
+            out["entropy"] = self._entropy
+        return out
+
+    def fwd_bwd(self, payload):
+        self.fwd_bwd_payload = payload
+        return {"avg_loss": 0.5}
+
+    def generate(self, *a, **k):
+        self.generate_calls += 1
+        return "generated"
+
+
+def _payload(lens=(4, 3), width=5, *, processing=None, extra=None):
+    """An on-prem-dialect payload with right-padded rows of the given lengths."""
+    b = len(lens)
+    input_ids = torch.zeros(b, width, dtype=torch.long)
+    attention_mask = torch.zeros(b, width, dtype=torch.long)
+    for row, n in enumerate(lens):
+        input_ids[row, :n] = torch.arange(1, n + 1) + 100 * row
+        attention_mask[row, :n] = 1
+    batch = {"input_ids": input_ids, "attention_mask": attention_mask}
+    if extra:
+        batch.update(extra)
+    return {
+        "batch": batch,
+        "meta": {"temperature": 1.0},
+        "processing": (
+            processing if processing is not None else {"post": ["apply_temperature", "compute_entropy_and_logprobs"]}
+        ),
+    }
+
+
+class TestLabelFraming:
+    """The quiet failure mode: labels off by one supervise the wrong tokens."""
+
+    def test_labels_are_the_next_token(self):
+        p = _payload(lens=(4,), width=5)
+        labels = next_token_labels(p["batch"])
+        ids = p["batch"]["input_ids"]
+        # Positions 0..2 predict tokens 1..3.
+        assert torch.equal(labels[0, :3], ids[0, 1:4])
+
+    def test_last_real_token_is_not_a_target(self):
+        # Row of length 4 in a width-5 tensor: index 3 is the last real token and
+        # has no successor, so it must not be supervised.
+        labels = next_token_labels(_payload(lens=(4,), width=5)["batch"])
+        assert labels[0, 3] == -100
+
+    def test_padding_is_not_a_target(self):
+        labels = next_token_labels(_payload(lens=(4,), width=6)["batch"])
+        assert torch.all(labels[0, 4:] == -100)
+
+    def test_a_full_width_row_still_drops_its_final_position(self):
+        # No padding to hide behind: the last column must still be excluded.
+        labels = next_token_labels(_payload(lens=(5,), width=5)["batch"])
+        assert labels[0, -1] == -100
+        assert torch.all(labels[0, :-1] != -100)
+
+    def test_supervised_count_is_one_less_than_the_row_length(self):
+        labels = next_token_labels(_payload(lens=(4, 3), width=5)["batch"])
+        assert int((labels[0] != -100).sum()) == 3
+        assert int((labels[1] != -100).sum()) == 2
+
+    def test_caller_supplied_labels_are_not_overwritten(self):
+        mine = torch.full((1, 5), 7, dtype=torch.long)
+        client = _RecordingClient()
+        CortexTRLAdapter(client).fwd_no_grad(_payload(lens=(4,), width=5, extra={"labels": mine}))
+        assert torch.equal(client.fwd_no_grad_payload["kwargs"]["labels"], mine)
+
+
+class TestEnvelopeTranslation:
+    def test_batch_is_rehomed_under_kwargs(self):
+        client = _RecordingClient()
+        CortexTRLAdapter(client).fwd_no_grad(_payload())
+        sent = client.fwd_no_grad_payload
+        assert set(sent) == {"kwargs", "processing"}
+        assert "batch" not in sent and "meta" not in sent
+
+    def test_on_prem_post_processors_are_replaced(self):
+        client = _RecordingClient()
+        CortexTRLAdapter(client).fwd_no_grad(_payload())
+        assert client.fwd_no_grad_payload["processing"]["post"] == ["compute_logprobs"]
+
+    def test_loss_fn_and_config_survive(self):
+        client = _RecordingClient()
+        CortexTRLAdapter(client).fwd_bwd(
+            _payload(processing={"post": [], "loss_fn": "grpo", "config": {"dp_size": 1}})
+        )
+        processing = client.fwd_bwd_payload["processing"]
+        assert processing["loss_fn"] == "grpo"
+        assert processing["config"] == {"dp_size": 1}
+
+    def test_absent_config_is_not_invented(self):
+        client = _RecordingClient()
+        CortexTRLAdapter(client).fwd_bwd(_payload(processing={"post": [], "loss_fn": "grpo"}))
+        assert "config" not in client.fwd_bwd_payload["processing"]
+
+    def test_an_unrecognised_post_processor_is_refused(self):
+        # Dropping it would leave a run that looks healthy and optimises
+        # something other than what was asked for.
+        client = _RecordingClient()
+        with pytest.raises(ValueError, match="cannot translate post-processors"):
+            CortexTRLAdapter(client).fwd_no_grad(_payload(processing={"post": ["something_new"]}))
+        assert client.fwd_no_grad_payload is None
+
+    def test_unrelated_methods_pass_through(self):
+        client = _RecordingClient()
+        assert CortexTRLAdapter(client).generate() == "generated"
+        assert client.generate_calls == 1
+
+
+class TestLossMaskTightening:
+    """The other quiet failure: a mask one position wider than the labels."""
+
+    def test_loss_mask_is_narrowed_to_the_labels(self):
+        client = _RecordingClient()
+        lens, width = (4, 3), 5
+        attention = _payload(lens=lens, width=width)["batch"]["attention_mask"]
+        CortexTRLAdapter(client).fwd_bwd(
+            _payload(lens=lens, width=width, extra={"loss_mask": attention.to(torch.float32)})
+        )
+        sent = client.fwd_bwd_payload["kwargs"]
+        assert torch.equal(sent["loss_mask"] != 0, sent["labels"] != -100)
+        # Strictly tighter than what the caller passed: one position per row.
+        assert int(attention.sum()) - int(sent["loss_mask"].sum()) == len(lens)
+
+    def test_loss_mask_dtype_is_preserved(self):
+        client = _RecordingClient()
+        attention = _payload()["batch"]["attention_mask"]
+        CortexTRLAdapter(client).fwd_bwd(_payload(extra={"loss_mask": attention.to(torch.float64)}))
+        assert client.fwd_bwd_payload["kwargs"]["loss_mask"].dtype is torch.float64
+
+    def test_no_loss_mask_is_not_fabricated(self):
+        client = _RecordingClient()
+        CortexTRLAdapter(client).fwd_bwd(_payload())
+        assert "loss_mask" not in client.fwd_bwd_payload["kwargs"]
+
+
+class TestTheLimitsAreEnforcedNotHidden:
+    def test_a_temperature_other_than_one_is_refused_up_front(self):
+        # Fail at construction, not on the first request: the zone has no
+        # apply_temperature, so any other value is silently mis-scaled logits.
+        with pytest.raises(ValueError, match="apply_temperature"):
+            CortexTRLAdapter(_RecordingClient(), temperature=0.7)
+
+    def test_temperature_one_is_accepted(self):
+        assert CortexTRLAdapter(_RecordingClient(), temperature=1.0).temperature == 1.0
+
+    def test_entropy_is_zeros_when_the_zone_returns_none(self):
+        client = _RecordingClient()
+        out = CortexTRLAdapter(client).fwd_no_grad(_payload())
+        entropy = out["batch"]["entropy"]
+        assert entropy.shape == out["batch"]["logprobs"].shape
+        assert torch.all(entropy == 0)
+
+    def test_a_zone_supplied_entropy_is_passed_through(self):
+        # So this stops being a fabricated zero the moment a zone computes it.
+        real = torch.full((2, 5), 0.25)
+        out = CortexTRLAdapter(_RecordingClient(entropy=real)).fwd_no_grad(_payload())
+        assert torch.equal(out["batch"]["entropy"], real)
+
+    def test_a_forward_without_logprobs_is_an_error(self):
+        with pytest.raises(RuntimeError, match="no logprobs"):
+            CortexTRLAdapter(_RecordingClient(omit_logprobs=True)).fwd_no_grad(_payload())


### PR DESCRIPTION
Stacked on #84. Small: one module, one test file.

## Why

The TRL integration speaks the on-prem server's dialect. It sends `{batch, meta, processing}` and asks for the post-processors `apply_temperature` and `compute_entropy_and_logprobs`. A Cortex zone wants `{kwargs, processing}` and registers only `compute_logprobs` — the other two names appear nowhere in ArcticTraining-dss or dss-platform.

So on Cortex the recipe dies before it reaches the loss at all:

```
dispatch requires 2D input_ids to plan token-budget microbatches
```

from the zone's `dp_shard_batch`, which is being handed the outer envelope instead of a batch.

`CortexTRLAdapter` sits between `ArcticTrainingClient` / `ArcticRolloutWorker` and the real client and translates. Only `fwd_no_grad` and `fwd_bwd` carry a batch envelope; everything else passes through untouched.

## Why now, and why it isn't hiding in a scratch file anymore

This translation is what every end-to-end result on the Cortex path has quietly depended on, including the three-seed GSM8K convergence run. It lived in my scratch directory, which meant that run could not be reproduced from the PRs — anyone starting from #84 + #95 would hit the `dispatch requires 2D input_ids` wall. That's the gap this closes. It is load-bearing infrastructure, so it belongs in the tree where it can be reviewed and tested.

Worth being clear that this is a translation layer, not the end state. Two things retire it: registering `apply_temperature` and `compute_entropy_and_logprobs` in ArcticTraining-dss, or teaching the integration to emit both dialects directly. I'd rather have the second, but either beats a shim, and neither is a reason to keep the Cortex path unrunnable in the meantime.

## The two gaps it can't close

Both are enforced or documented rather than papered over:

| gap | what the adapter does |
|---|---|
| `apply_temperature` doesn't exist on the zone | refuses any `temperature != 1.0` in the constructor, where it's a no-op. Mis-scaled logits would otherwise be invisible. |
| `compute_logprobs` returns no entropy | returns zeros to keep the caller's shape contract. **Any entropy metric on this path is meaningless and an entropy bonus is a silent no-op.** GRPO as configured uses neither, which is the only reason it's survivable. |

If a zone ever does return entropy, it's passed straight through — there's a test pinning that, so the zeros stop the moment they're no longer necessary.

One thing this file cannot assert: whether `compute_logprobs` and `compute_entropy_and_logprobs` agree on the *frame* of the log-probs they return. That's a property of two server implementations, not of the translation. The observable check is the importance ratio, which must sit at ~1 on policy; an off-by-one frame blows it up. It did sit at ~1 across the seed runs.

## Tests

20 tests. Most of the surface fails loudly if mistranslated — the zone rejects a bad envelope — so the tests concentrate on the two failures that would be *quiet*, because both produce a running job that optimises the wrong thing:

- **an off-by-one label frame.** `compute_logprobs` scores position `t` against `labels[t]`, so labels are next-token and a row's final real token is not a target.
- **a `loss_mask` one position wider than the labels.** Callers derive it from `attention_mask`, which is one position too generous once labels exist; grpo's preflight requires `loss_mask == 0` wherever the label is `-100`.

Both were checked by mutation rather than assumed: reverting either fix turns exactly its test red, and dropping the unknown-post-processor guard turns its test red too.

## What I did not verify here

These are unit tests against a recording client, so they pin the translation and nothing about the zone. The end-to-end evidence is separate: `fwd_no_grad` over `CortexTransport` on the current default QA6 image, gradient agreement to 5.2e-05 against the direct grpo path, and the seed runs. A default-image recipe-scale run is in flight and I'll post it when it lands.

Made with [Cursor](https://cursor.com)